### PR TITLE
workaround for #107 - run.sh has now exectuable bit set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,15 +140,7 @@ CLOUD_CREDENTIAL=~/ec2.credential
 
 The ec2.identity file should contain your access key and the ec2.credential your secret key.
 
-After you have made the modifications, you need to set the executable flag on the run.sh in the workdir directory:
-
-```
-chmod +x run.sh
-```
-
-This is needed because the maven archetype is not able to deal with the executable flag.
-
-And finally you can run the test:
+And finally you can run the test from the workdir directory:
 
 ```
 ./run.sh

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -52,6 +52,25 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>process-classes</id>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <target>
+                                <chmod file="\${basedir}/workdir/*.sh" perm="755"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>


### PR DESCRIPTION
it seems to be affected by this bug: MRESOURCES-132

The Antrun-based workaround is not nice; Maven Assembly Plugin might be another option.
