### PR TITLE
Fixes #179

### DIFF
--- a/dist/src/main/dist/conf/agent-log4j.xml
+++ b/dist/src/main/dist/conf/agent-log4j.xml
@@ -9,9 +9,10 @@
         </layout>
     </appender>
 
-    <appender name="file" class="org.apache.log4j.FileAppender">
+    <appender name="file" class="org.apache.log4j.RollingFileAppender">
         <param name="File" value="logs/agent.log"/>
         <param name="Threshold" value="DEBUG"/>
+        <param name="MaxBackupIndex" value="10"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-5p %d [%t] %c: %m%n"/>
         </layout>

--- a/dist/src/main/dist/conf/cloudinfo-log4j.xml
+++ b/dist/src/main/dist/conf/cloudinfo-log4j.xml
@@ -9,9 +9,10 @@
         </layout>
     </appender>
 
-    <appender name="file" class="org.apache.log4j.FileAppender">
+    <appender name="file" class="org.apache.log4j.RollingFileAppender">
         <param name="File" value="logs/cloudinfo.log"/>
-        <param name="Threshold" value="INFO"/>
+        <param name="Threshold" value="DEBUG"/>
+        <param name="MaxBackupIndex" value="10"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-5p %d [%t] %c: %m%n"/>
         </layout>

--- a/dist/src/main/dist/conf/communicator-log4j.xml
+++ b/dist/src/main/dist/conf/communicator-log4j.xml
@@ -9,9 +9,10 @@
         </layout>
     </appender>
 
-    <appender name="file" class="org.apache.log4j.FileAppender">
+    <appender name="file" class="org.apache.log4j.RollingFileAppender">
         <param name="File" value="logs/communicator.log"/>
-        <param name="Threshold" value="INFO"/>
+        <param name="Threshold" value="DEBUG"/>
+        <param name="MaxBackupIndex" value="10"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-5p %d [%t] %c: %m%n"/>
         </layout>

--- a/dist/src/main/dist/conf/coordinator-log4j.xml
+++ b/dist/src/main/dist/conf/coordinator-log4j.xml
@@ -9,9 +9,10 @@
         </layout>
     </appender>
 
-    <appender name="file" class="org.apache.log4j.FileAppender">
+    <appender name="file" class="org.apache.log4j.RollingFileAppender">
         <param name="File" value="logs/coordinator.log"/>
-        <param name="Threshold" value="INFO"/>
+        <param name="Threshold" value="DEBUG"/>
+        <param name="MaxBackupIndex" value="10"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-5p %d [%t] %c: %m%n"/>
         </layout>

--- a/dist/src/main/dist/conf/provisioner-log4j.xml
+++ b/dist/src/main/dist/conf/provisioner-log4j.xml
@@ -9,9 +9,10 @@
         </layout>
     </appender>
 
-    <appender name="file" class="org.apache.log4j.FileAppender">
+    <appender name="file" class="org.apache.log4j.RollingFileAppender">
         <param name="File" value="logs/provisioner.log"/>
         <param name="Threshold" value="DEBUG"/>
+        <param name="MaxBackupIndex" value="10"/>
         <layout class="org.apache.log4j.PatternLayout">
             <param name="ConversionPattern" value="%-5p %d [%t] %c: %m%n"/>
         </layout>


### PR DESCRIPTION
Log files don't keep growning anymore because of rollingfile appender with a max of 10 files and 10mb per log file.
So 100mb of logfiles at the most
