### PR TITLE
simple addressing added.

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/BlockTrafficMessage.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/BlockTrafficMessage.java
@@ -5,10 +5,6 @@ import com.hazelcast.stabilizer.agent.remoting.AgentRemoteService;
 
 import java.io.Serializable;
 
-/**
- *
- *
- */
 @MessageSpec("blockHzTraffic")
 public class BlockTrafficMessage extends RunnableMessage {
     private static final String ports = "5700:5800";

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessageAddress.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessageAddress.java
@@ -40,13 +40,13 @@ public class MessageAddress implements Serializable {
     public String toString() {
         StringBuilder builder = new StringBuilder("MessageAddress{");
         if (agentAddress != null) {
-            builder.append("agentAddress='").append(agentAddress);
+            builder.append("agentAddress='").append(agentAddress).append("'");
         }
         if (workerAddress != null) {
-            builder.append("workerAddress='").append(workerAddress);
+            builder.append(",workerAddress='").append(workerAddress).append("'");
         }
         if (testAddress != null) {
-            builder.append("testAddress='").append(testAddress);
+            builder.append(",testAddress='").append(testAddress).append("'");
         }
         builder.append("}");
         return builder.toString();

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessageAddressParser.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessageAddressParser.java
@@ -35,11 +35,7 @@ public class MessageAddressParser {
         DONE
     }
 
-    public MessageAddress parse(final String originInput) {
-        return parseRexexp(originInput);
-    }
-
-    private MessageAddress parseRexexp(String input) {
+    public MessageAddress parse(String input) {
         if (input == null) {
             throw new IllegalArgumentException("Input string cannot be null");
         }


### PR DESCRIPTION
instead of --message-address <full_address> is now possible to use:
--oldest-member
--random-agent
--random-worker

Also --message-type is now optional. Therefore message can be sent using this syntax:
communicator --random-worker spinCore

Fixing #185 and #186 
