### PR TITLE
Probes can now be injected to fields instead of passing via Setup method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- we want to remain java 1.6 compatible -->
         <java.version>1.6</java.version>
         <junit.version>4.11</junit.version>
-        <hazelcast.version>3.4-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>3.3.1-SNAPSHOT</hazelcast.version>
         <jopt.version>4.4</jopt.version>
         <log4j.version>1.2.17</log4j.version>
         <jclouds.version>1.8.0</jclouds.version>

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/annotations/Name.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/annotations/Name.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 public @interface Name {
     String value();
 }


### PR DESCRIPTION
I have also changed Hazelcast version to 3.3.1 as Stabilizer has JCache tests and 3.4-SNAPSHOT doesn't have JCache stuff in yet. 
