### PR TITLE
JCache tests compile again.

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/icache/CacheLoaderTest.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/icache/CacheLoaderTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.stabilizer.tests.utils.ThreadSpawner;
 
 import javax.cache.Cache;
 import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableConfiguration;
 import javax.cache.integration.CompletionListenerFuture;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,7 +67,7 @@ public class CacheLoaderTest {
     private HazelcastCacheManager cacheManager;
     private String basename;
 
-    private CacheConfig config;
+    private MutableConfiguration config;
     private Cache<Object,Object> cache;
     private Set keySet = new HashSet();
 
@@ -84,8 +85,7 @@ public class CacheLoaderTest {
             cacheManager = new HazelcastClientCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
         }
 
-        config = new CacheConfig();
-        config.setName(basename);
+        config = new MutableConfiguration();
         config.setReadThrough(true);
 
         RecordingCacheLoader recordingCacheLoader = new RecordingCacheLoader();
@@ -95,7 +95,6 @@ public class CacheLoaderTest {
 
         cacheManager.createCache(basename, config);
         cache = cacheManager.getCache(basename);
-        config = cache.getConfiguration(CacheConfig.class);
     }
 
     @Warmup(global = false)

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/icache/ReadWriteICacheTest.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/icache/ReadWriteICacheTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.stabilizer.tests.utils.ThreadSpawner;
 
 import javax.cache.Cache;
 import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableConfiguration;
 import java.io.Serializable;
 import java.util.Random;
 
@@ -68,7 +69,7 @@ public class ReadWriteICacheTest {
     private HazelcastCacheManager cacheManager;
     private String basename;
 
-    private CacheConfig config;
+    private MutableConfiguration config;
     private Cache<Object,Object> cache;
 
     @Setup
@@ -85,8 +86,7 @@ public class ReadWriteICacheTest {
             cacheManager = new HazelcastClientCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
         }
 
-        config = new CacheConfig();
-        config.setName(basename);
+        config = new MutableConfiguration();
         config.setReadThrough(true);
         config.setWriteThrough(true);
 
@@ -102,7 +102,6 @@ public class ReadWriteICacheTest {
 
         cacheManager.createCache(basename, config);
         cache = cacheManager.getCache(basename);
-        config = cache.getConfiguration(CacheConfig.class);
     }
 
     @Run


### PR DESCRIPTION
There has been a change in our implementation of JCache. CacheConfig no longer extends MutableConfiguration.
