### PR TITLE
OperationSelector implemented

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/OperationSelector.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/OperationSelector.java
@@ -1,0 +1,87 @@
+package com.hazelcast.stabilizer.worker;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Facility to select different operations based on probabilities. Each operations is
+ * represented as an enum item and is registered with its probability (0-1) via the {@link #addOperation(Enum, double)} method.
+ *
+ * Calling {@link #select()} method will select an operation according configured probabilities. It can return null
+ * if sum of configured probabilities if lower than 1. You can change this behaviour by {@link #empty(Enum)} method.
+ *
+ * @param <T>
+ */
+public class OperationSelector<T extends Enum<T>> {
+    private final Random r;
+    private final Map<T, Double> ops;
+    private T emptyOperation;
+    private double remaining;
+
+    public OperationSelector() {
+        r = new Random();
+        ops = new ConcurrentHashMap<T, Double>();
+        remaining = 1;
+    }
+
+    /**
+     * Register new operation for selection.
+     *
+     * @param operation operation to be selected
+     * @param probability probability of this operation. It must be a non-negative number between 0 - 1.
+     * @return this instance to allow method-chaining
+     */
+    public OperationSelector<T> addOperation(T operation, double probability) {
+        if (ops.put(operation, probability) != null) {
+            throw new IllegalStateException("Operations " + operation + " has been already added to this selector.");
+        }
+        remaining -= probability;
+        if (remaining < -0.1) {
+            return onProbabilityExceeded();
+        }
+        return this;
+    }
+
+    /**
+     * Register an operation to be returned when no operation registered via {@link #addOperation(Enum, double)} has been
+     * selected.
+     *
+     * @param operation
+     * @return
+     */
+    public OperationSelector<T> empty(T operation) {
+        this.emptyOperation = operation;
+        return this;
+    }
+
+    /**
+     * Select an operation according to probabilities
+     *
+     * @return selected operation or null if no operation has been selected
+     */
+    public T select() {
+        double chance = r.nextDouble();
+        for (Map.Entry<T, Double> entry : ops.entrySet()) {
+            Double probability = entry.getValue();
+            if ((chance -= probability) < 0) {
+                return entry.getKey();
+            }
+        }
+        return emptyOperation;
+    }
+
+    private OperationSelector<T> onProbabilityExceeded() {
+        StringBuilder builder = new StringBuilder("Sum of probabilities of all operations can't be greater than 0. " +
+                "Current operations and probabalities: ").append('\n');
+        double total = 0;
+        for (Map.Entry<T, Double> entry : ops.entrySet()) {
+            Double probability = entry.getValue();
+            builder.append("Operation: ").append(entry.getKey()).append(", Probability: ").append(probability);
+            total += probability;
+        }
+        builder.append("\nThis means current sum of probabilities is ").append(total);
+        throw new IllegalStateException(builder.toString());
+    }
+
+}

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/OperationSelectorTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/OperationSelectorTest.java
@@ -1,0 +1,95 @@
+package com.hazelcast.stabilizer.worker;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class OperationSelectorTest {
+    private static final int ITERATIONS = 1000000;
+    private static final double TOLERANCE = 0.05;
+
+    private OperationSelector<MyOps> selector;
+
+    @Before
+    public void setUp() {
+        selector = new OperationSelector<MyOps>();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddOperations_sumOfProbabilitiesCannotExceed1() {
+        selector.addOperation(MyOps.OP1, 0.8)
+                .addOperation(MyOps.OP2, 0.8);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddOperations_operationCannotBeAddedTwice() {
+        selector.addOperation(MyOps.OP1, 0.1)
+                .addOperation(MyOps.OP1, 0.1);
+    }
+
+    @Test
+    public void testSelect_emptyOperations() {
+        double op1Prob = 0.1;
+        double op2Prob = 0.1;
+
+        selector.addOperation(MyOps.OP1, op1Prob)
+                .addOperation(MyOps.OP2, op2Prob)
+                .empty(MyOps.EMPTY);
+
+        Map<MyOps, Integer> opsStats = exerciseSelector(selector);
+        Integer op1Count = opsStats.get(MyOps.OP1);
+        Integer op2Count = opsStats.get(MyOps.OP2);
+        Integer emptyCount = opsStats.get(MyOps.EMPTY);
+        assertCountIsWithinTolerance(MyOps.OP1, op1Count, op1Prob);
+        assertCountIsWithinTolerance(MyOps.OP2, op2Count, op2Prob);
+        assertCountIsWithinTolerance(MyOps.EMPTY, emptyCount, 1 - (op1Prob + op2Prob));
+    }
+
+    @Test
+    public void testSelect_distributionIsAccordingToProbabilities() {
+        double op1Prob = 0.5;
+        double op2Prob = 0.3;
+        double op3Prob = 0.2;
+
+        selector.addOperation(MyOps.OP1, op1Prob)
+                .addOperation(MyOps.OP2, op2Prob)
+                .addOperation(MyOps.OP3, op3Prob);
+        Map<MyOps, Integer> opsStats = exerciseSelector(selector);
+
+        Integer op1Count = opsStats.get(MyOps.OP1);
+        Integer op2Count = opsStats.get(MyOps.OP2);
+        Integer op3Count = opsStats.get(MyOps.OP3);
+        assertCountIsWithinTolerance(MyOps.OP1, op1Count, op1Prob);
+        assertCountIsWithinTolerance(MyOps.OP2, op2Count, op2Prob);
+        assertCountIsWithinTolerance(MyOps.OP3, op3Count, op3Prob);
+    }
+
+    private void assertCountIsWithinTolerance(MyOps op, int count, double probability) {
+        double lowerBound = (ITERATIONS * probability - ITERATIONS * TOLERANCE);
+        double upperBound = (ITERATIONS * probability + ITERATIONS * TOLERANCE);
+
+        assertTrue("Operations " + op + " was selected " + count + " times, however lower bound is " + lowerBound,
+                count > lowerBound);
+        assertTrue("Operations " + op + " was selected " + count + " times, however upper bound is " + upperBound,
+                count < upperBound);
+    }
+
+    private Map<MyOps, Integer> exerciseSelector(OperationSelector<MyOps> selector) {
+        Map<MyOps, Integer> opsStats = new HashMap<MyOps, Integer>();
+        for (int i = 0 ; i < ITERATIONS; i++) {
+            MyOps myOps = selector.select();
+            Integer counter = opsStats.get(myOps);
+            counter = (counter == null ? 1 : ++counter);
+            opsStats.put(myOps, counter);
+        }
+        return opsStats;
+    }
+
+    private static enum MyOps {
+        OP1, OP2, OP3, EMPTY
+    }
+}


### PR DESCRIPTION
OperationSelector implemented. Fixing #383 

It's now possible to register operations to be selected with various probabilities without worrying about algorithm behind it.
A worker can just use the selector without knowing about probabilities at all.
