### PR TITLE
HdrHistogram written by Gil Tene can now be used to measure latency inst...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <jsr107.api.version>1.0.0</jsr107.api.version>
+        <hdr-histogram.version>2.0.1</hdr-histogram.version>
     </properties>
 
     <modules>

--- a/probes/pom.xml
+++ b/probes/pom.xml
@@ -14,6 +14,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>${hdr-histogram.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/probes/src/main/java/com/hazelcast/stabilizer/probes/probes/Probes.java
+++ b/probes/src/main/java/com/hazelcast/stabilizer/probes/probes/Probes.java
@@ -1,5 +1,6 @@
 package com.hazelcast.stabilizer.probes.probes;
 
+import com.hazelcast.stabilizer.probes.probes.impl.HdrLatencyDistributionProbe;
 import com.hazelcast.stabilizer.probes.probes.impl.MaxLatencyProbe;
 import com.hazelcast.stabilizer.probes.probes.impl.ConcurrentIntervalProbe;
 import com.hazelcast.stabilizer.probes.probes.impl.ConcurrentSimpleProbe;
@@ -38,12 +39,18 @@ public class Probes {
                 return (T) newMaxLatencyProbe();
             } else if ("disabled".equals(config)) {
                 return (T) disabledProbe();
+            } else if ("hdr".equals(config)) {
+                return (T) hdrProbe();
             } else {
                 throw new IllegalArgumentException("Unknown probe " + config + " for probe type " + type.getName() + ".");
             }
         } else {
             throw new IllegalArgumentException("Unknown probe " + config + " for probe type " + type.getName() + ".");
         }
+    }
+
+    private static IntervalProbe hdrProbe() {
+        return Probes.wrapAsThreadLocal(new HdrLatencyDistributionProbe());
     }
 
     public static <T extends IntervalProbe> IntervalProbe newMaxLatencyProbe() {

--- a/probes/src/main/java/com/hazelcast/stabilizer/probes/probes/impl/HdrLatencyDistributionProbe.java
+++ b/probes/src/main/java/com/hazelcast/stabilizer/probes/probes/impl/HdrLatencyDistributionProbe.java
@@ -1,0 +1,42 @@
+package com.hazelcast.stabilizer.probes.probes.impl;
+
+import com.hazelcast.stabilizer.probes.probes.IntervalProbe;
+import org.HdrHistogram.Histogram;
+
+public class HdrLatencyDistributionProbe implements IntervalProbe<HdrLatencyProbeResult, HdrLatencyDistributionProbe> {
+    public static final long MAXIMUM_LATENCY = 60 * 1000 * 1000; // 1 minute
+    private final Histogram histogram = new Histogram(MAXIMUM_LATENCY, 4);
+
+    private long started;
+
+
+    @Override
+    public void started() {
+        started = System.nanoTime();
+    }
+
+    @Override
+    public void done() {
+        histogram.recordValue((System.nanoTime() - started) / 1000);
+    }
+
+    @Override
+    public void startProbing(long time) {
+
+    }
+
+    @Override
+    public void stopProbing(long time) {
+
+    }
+
+    @Override
+    public HdrLatencyProbeResult getResult() {
+        return new HdrLatencyProbeResult(histogram);
+    }
+
+    @Override
+    public HdrLatencyDistributionProbe createNew(Long arg) {
+        return new HdrLatencyDistributionProbe();
+    }
+}

--- a/probes/src/main/java/com/hazelcast/stabilizer/probes/probes/impl/HdrLatencyProbeResult.java
+++ b/probes/src/main/java/com/hazelcast/stabilizer/probes/probes/impl/HdrLatencyProbeResult.java
@@ -1,0 +1,77 @@
+package com.hazelcast.stabilizer.probes.probes.impl;
+
+import com.hazelcast.stabilizer.probes.probes.Result;
+import org.HdrHistogram.Histogram;
+import sun.misc.BASE64Encoder;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+
+public class HdrLatencyProbeResult implements Result<HdrLatencyProbeResult> {
+    private final Histogram histogram;
+
+    public HdrLatencyProbeResult(Histogram histogram) {
+        this.histogram = histogram;
+    }
+
+    @Override
+    public HdrLatencyProbeResult combine(HdrLatencyProbeResult other) {
+        if (other == null) {
+            return this;
+        }
+        Histogram histogramCopy = new Histogram(histogram);
+        histogramCopy.add(other.histogram);
+        return new HdrLatencyProbeResult(histogramCopy);
+    }
+
+    @Override
+    public String toHumanString() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream stream = new PrintStream(outputStream);
+        histogram.outputPercentileDistribution(stream, 1.0);
+        stream.flush();
+        return new String(outputStream.toByteArray());
+    }
+
+    @Override
+    public void writeTo(XMLStreamWriter writer) {
+        int size = histogram.getNeededByteBufferCapacity();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+        int bytesWritten = histogram.encodeIntoCompressedByteBuffer(byteBuffer);
+        byteBuffer.rewind();
+        byteBuffer.limit(bytesWritten);
+        BASE64Encoder encoder = new BASE64Encoder();
+        String encodedData = encoder.encode(byteBuffer);
+        try {
+            writer.writeStartElement("data");
+            writer.writeCData(encodedData);
+            writer.writeEndElement();
+        } catch (XMLStreamException e) {
+            new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HdrLatencyProbeResult that = (HdrLatencyProbeResult) o;
+
+        if (histogram != null ? !histogram.equals(that.histogram) : that.histogram != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return histogram != null ? histogram.hashCode() : 0;
+    }
+
+    public Histogram getHistogram() {
+        return histogram;
+    }
+}

--- a/probes/src/test/java/com/hazelcast/stabilizer/probes/probes/ProbesResultXmlWriterTest.java
+++ b/probes/src/test/java/com/hazelcast/stabilizer/probes/probes/ProbesResultXmlWriterTest.java
@@ -1,7 +1,11 @@
 package com.hazelcast.stabilizer.probes.probes;
 
+import com.hazelcast.stabilizer.probes.probes.impl.HdrLatencyDistributionProbe;
+import com.hazelcast.stabilizer.probes.probes.impl.HdrLatencyProbeResult;
+import com.hazelcast.stabilizer.probes.probes.impl.LatencyDistributionProbe;
 import com.hazelcast.stabilizer.probes.probes.impl.LatencyDistributionResult;
 import com.hazelcast.stabilizer.probes.probes.impl.MaxLatencyResult;
+import org.HdrHistogram.Histogram;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -13,6 +17,16 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 public class ProbesResultXmlWriterTest {
+
+    @Test
+    public void testHdrLatencyProbeResult() throws Exception {
+        Map<String, Result> resultMap = new HashMap<String, Result>();
+        Histogram histogram = new Histogram(HdrLatencyDistributionProbe.MAXIMUM_LATENCY, 4);
+        HdrLatencyProbeResult originalResult = new HdrLatencyProbeResult(histogram);
+        resultMap.put("getLatency", originalResult);
+        Map<String, Result> result = serializeAndDeserializeAgain(resultMap);
+        assertEquals(originalResult, result.get("getLatency"));
+    }
 
     @Test
     public void testMaxLatencyResult() throws Exception {

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/Provisioner.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/Provisioner.java
@@ -88,6 +88,7 @@ public class Provisioner {
         bash.copyToAgentStabilizerDir(ip, STABILIZER_HOME + "/lib/commons-lang3*", "lib");
         bash.copyToAgentStabilizerDir(ip, STABILIZER_HOME + "/lib/cache-api*", "lib");
         bash.copyToAgentStabilizerDir(ip, STABILIZER_HOME + "/lib/probes-*", "lib");
+        bash.copyToAgentStabilizerDir(ip, STABILIZER_HOME + "/lib/HdrHistogram-*", "lib");
         bash.copyToAgentStabilizerDir(ip, STABILIZER_HOME + "/tests/", "tests");
 
         String script = loadInitScript();


### PR DESCRIPTION
...ead of our home-grown LinearHistogram.

When a type of a probe is set to "hdr" in a test.property file then a HdrHistogram-based probe will be injected.

Example:
$ cat test.properties
class=com.hazelcast.stabilizer.tests.map.StringMapTest
threadCount=1
keyLocality=remote
probe-putLatency=latency
probe-getLatency=hdr

In this example the getLatency probe will use the HdrHistogram probe. putLatency will use the original LinearHistogram probe.
In the future we can decide to remove the LinearHistogram altogether and make "latency" to be a synonymous to "hdr"

Serialization to XML is still a bit crude, based on base64 encoded internal state of HdrHistogram, however Visualized is able to read & visualize the data.
