### PR TITLE
MapCasTest is Racy fix

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/map/MapCasTest.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/tests/map/MapCasTest.java
@@ -115,10 +115,6 @@ public class MapCasTest {
 
         @Override
         public void run() {
-            for (int k = 0; k < keyCount; k++) {
-                result.put(k, 0L);
-            }
-
             long iteration = 0;
             while (!testContext.isStopped()) {
                 Integer key = random.nextInt(keyCount);


### PR DESCRIPTION
The MapCasTest was broken because when a worker starts, it initializes all keys.

This is already done in the warmup phase (so not needed)
But it also overwrites changes made by oher workers; so you can get lost updates.
