### PR TITLE
AgentSmokeTest work out of the box

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import static com.hazelcast.simulator.common.GitInfo.getBuildTime;
 import static com.hazelcast.simulator.common.GitInfo.getCommitIdAbbrev;
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingDirectory;
 import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
@@ -39,6 +40,7 @@ public class Agent {
     private static final Logger LOGGER = Logger.getLogger(Coordinator.class);
 
     // internal state
+    public String bindAddress;
     public String cloudIdentity;
     public String cloudCredential;
     public String cloudProvider;
@@ -55,11 +57,8 @@ public class Agent {
         ensureExistingDirectory(WorkerJvmManager.WORKERS_HOME);
 
         startRestServer();
-
         workerJvmFailureMonitor.start();
-
         workerJvmManager.start();
-
         harakiriMonitor.start();
 
         LOGGER.info("Simulator Agent is ready for action");
@@ -82,7 +81,6 @@ public class Agent {
         if (testSuite == null) {
             return null;
         }
-
         return new File(WorkerJvmManager.WORKERS_HOME, testSuite.id);
     }
 
@@ -125,6 +123,7 @@ public class Agent {
             agent = new Agent();
             AgentCli.init(agent, args);
 
+            LOGGER.info("Bind address: " + agent.bindAddress);
             LOGGER.info("CloudIdentity: " + agent.cloudIdentity);
             LOGGER.info("CloudCredential " + agent.cloudCredential);
             LOGGER.info("CloudProvider " + agent.cloudProvider);
@@ -155,10 +154,5 @@ public class Agent {
 
     private static void logSystemProperty(String name) {
         LOGGER.info(format("%s=%s", name, System.getProperty(name)));
-    }
-
-    private static void exitWithError(Logger logger, String msg) {
-        logger.fatal(msg);
-        System.exit(1);
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/AgentCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/AgentCli.java
@@ -11,12 +11,18 @@ public class AgentCli {
     private final OptionParser parser = new OptionParser();
     private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
 
+    private final OptionSpec<String> bindAddress = parser.accepts("bindAddress",
+            "Address to bind the agent remote service to.")
+            .withRequiredArg().ofType(String.class);
+
     private final OptionSpec<String> cloudIdentitySpec = parser.accepts("cloudIdentity",
             "Cloud identity")
             .withRequiredArg().ofType(String.class);
+
     private final OptionSpec<String> cloudCredentialSpec = parser.accepts("cloudCredential",
             "Cloud credential")
             .withRequiredArg().ofType(String.class);
+
     private final OptionSpec<String> cloudProviderSpec = parser.accepts("cloudProvider",
             "Cloud provider")
             .withRequiredArg().ofType(String.class);
@@ -29,6 +35,10 @@ public class AgentCli {
         if (options.has(agentOptionSpec.helpSpec)) {
             agentOptionSpec.parser.printHelpOn(System.out);
             System.exit(0);
+        }
+
+        if (options.has(agentOptionSpec.bindAddress)) {
+            agent.bindAddress = options.valueOf(agentOptionSpec.bindAddress);
         }
 
         if (options.has(agentOptionSpec.cloudIdentitySpec)) {

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/remoting/AgentRemoteService.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/remoting/AgentRemoteService.java
@@ -43,8 +43,10 @@ public class AgentRemoteService {
     }
 
     public void start() throws IOException {
-        serverSocket = new ServerSocket(PORT, 0, InetAddress.getByName(getHostAddress()));
+        String bindAddress = (agent.bindAddress != null) ? agent.bindAddress : getHostAddress();
+        serverSocket = new ServerSocket(PORT, 0, InetAddress.getByName(bindAddress));
         LOGGER.info("Started Agent Remote Service on: " + serverSocket.getInetAddress().getHostAddress() + ":" + PORT);
+
         acceptorThread = new AcceptorThread();
         acceptorThread.start();
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/common/AgentAddress.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/AgentAddress.java
@@ -8,6 +8,7 @@ package com.hazelcast.simulator.common;
  * publicAddress and privateAddress are the same if there is no public/private address separation, e.g. a static setup.
  */
 public class AgentAddress {
+
     public final String publicAddress;
     public final String privateAddress;
 
@@ -21,7 +22,6 @@ public class AgentAddress {
         this.publicAddress = publicAddress;
         this.privateAddress = privateAddress;
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/simulator/src/main/java/com/hazelcast/simulator/common/AgentsFile.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/AgentsFile.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.FileUtils.fileAsText;
 import static com.hazelcast.simulator.utils.FileUtils.writeText;
 import static java.lang.String.format;
@@ -27,13 +28,15 @@ import static java.lang.String.format;
  */
 public final class AgentsFile {
 
+    public static final String NAME = "agents.txt";
+
     private static final Logger LOGGER = Logger.getLogger(AgentsFile.class);
 
     private AgentsFile() {
     }
 
     public static void save(File agentsFile, List<AgentAddress> addresses) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (AgentAddress agentAddress : addresses) {
             if (agentAddress.publicAddress.equals(agentAddress.privateAddress)) {
                 sb.append(agentAddress.publicAddress)
@@ -50,7 +53,6 @@ public final class AgentsFile {
 
     public static List<AgentAddress> load(File agentFile) {
         String content = fileAsText(agentFile);
-
         String[] addresses = content.split("\n");
         int lineNumber = 1;
         List<AgentAddress> pairs = new LinkedList<AgentAddress>();
@@ -74,10 +76,8 @@ public final class AgentsFile {
                     pairs.add(new AgentAddress(chunks[0], chunks[1]));
                     break;
                 default:
-                    LOGGER.fatal(format("Line %s of file %s is invalid, it should contain 1 or 2 addresses separated by a "
+                    exitWithError(LOGGER, format("Line %s of file %s is invalid, it should contain 1 or 2 addresses separated by a "
                             + "comma, but contains %s", lineNumber, agentFile, chunks.length));
-                    System.exit(1);
-                    break;
             }
         }
         return pairs;

--- a/simulator/src/main/java/com/hazelcast/simulator/communicator/Communicator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/communicator/Communicator.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
 import static java.lang.String.format;
 
@@ -35,10 +36,9 @@ public class Communicator {
         LOGGER.info(format("Loading agents file: %s", communicator.agentsFile.getAbsolutePath()));
         try {
             communicator.run();
-            System.exit(0);
         } catch (Exception e) {
             LOGGER.error("Failed to communicate", e);
-            System.exit(1);
+            exitWithError(LOGGER, e.getMessage());
         }
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/communicator/CommunicatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/communicator/CommunicatorCli.java
@@ -1,9 +1,9 @@
 package com.hazelcast.simulator.communicator;
 
+import com.hazelcast.simulator.common.AgentsFile;
 import com.hazelcast.simulator.common.messaging.Message;
 import com.hazelcast.simulator.common.messaging.MessageAddress;
 import com.hazelcast.simulator.common.messaging.MessageAddressParser;
-import com.hazelcast.simulator.provisioner.Provisioner;
 import joptsimple.BuiltinHelpFormatter;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
@@ -27,7 +27,7 @@ public class CommunicatorCli {
 
     private final OptionSpec<String> agentsFileSpec = parser.accepts("agentsFile",
             "The file containing the list of agent machines")
-            .withRequiredArg().ofType(String.class).defaultsTo(Provisioner.AGENTS_FILE);
+            .withRequiredArg().ofType(String.class).defaultsTo(AgentsFile.NAME);
 
     private final OptionSpec<String> messageTypeSpec = parser.accepts("message-type",
             String.format("Message type definition. Supported message types: %n%s", Message.getMessageHelp()))

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -56,9 +56,10 @@ public class Coordinator {
     public static final File SIMULATOR_HOME = getSimulatorHome();
     public static final File WORKING_DIRECTORY = new File(System.getProperty("user.dir"));
     public static final File UPLOAD_DIRECTORY = new File(WORKING_DIRECTORY, "upload");
+    
     private static final Logger LOGGER = Logger.getLogger(Coordinator.class);
 
-    //options.
+    // options
     public boolean monitorPerformance;
     public boolean verifyEnabled = true;
     public String workerClassPath;
@@ -73,8 +74,10 @@ public class Coordinator {
     public volatile double performance;
     public volatile long operationCount;
     public PerformanceMonitor performanceMonitor;
+    
     protected AgentsClient agentsClient;
-    //internal state.
+    
+    // internal state
     final BlockingQueue<Failure> failureList = new LinkedBlockingQueue<Failure>();
     private Bash bash;
 
@@ -470,10 +473,9 @@ public class Coordinator {
 
         try {
             coordinator.run();
-            System.exit(0);
         } catch (Exception e) {
             LOGGER.fatal("Failed to run testsuite", e);
-            System.exit(1);
+            exitWithError(LOGGER, e.getMessage());
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -1,7 +1,7 @@
 package com.hazelcast.simulator.coordinator;
 
 import com.hazelcast.simulator.agent.workerjvm.WorkerJvmSettings;
-import com.hazelcast.simulator.provisioner.Provisioner;
+import com.hazelcast.simulator.common.AgentsFile;
 import com.hazelcast.simulator.test.Failure;
 import com.hazelcast.simulator.test.TestSuite;
 import joptsimple.OptionException;
@@ -26,6 +26,7 @@ public class CoordinatorCli {
     private static final Logger LOGGER = Logger.getLogger(CoordinatorCli.class);
 
     private final OptionParser parser = new OptionParser();
+    private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
 
     private final OptionSpec<String> durationSpec = parser.accepts("duration",
             "Amount of time to run per test. Can be e.g. 10 or 10s, 1m or 2h or 3d.")
@@ -95,7 +96,7 @@ public class CoordinatorCli {
 
     private final OptionSpec<String> agentsFileSpec = parser.accepts("agentsFile",
             "The file containing the list of agent machines")
-            .withRequiredArg().ofType(String.class).defaultsTo(Provisioner.AGENTS_FILE);
+            .withRequiredArg().ofType(String.class).defaultsTo(AgentsFile.NAME);
 
     private final OptionSpec<String> propertiesFileSpec = parser.accepts("propertiesFile",
             "The file containing the simulator properties. If no file is explicitly configured, first the "
@@ -123,13 +124,13 @@ public class CoordinatorCli {
             "Maximum amount of time waiting for the Test to stop")
             .withRequiredArg().ofType(Integer.class).defaultsTo(60000);
 
-    private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
     private final Coordinator coordinator;
+
     private OptionSet options;
 
     private static String getDefaultHzFile() {
         File file = new File("hazelcast.xml");
-        // if something exists in the current working directory, use that.
+        // if something exists in the current working directory, use that
         if (file.exists()) {
             return file.getAbsolutePath();
         } else {
@@ -139,7 +140,7 @@ public class CoordinatorCli {
 
     private static String getDefaultClientHzFile() {
         File file = new File("client-hazelcast.xml");
-        // if something exists in the current working directory, use that.
+        // if something exists in the current working directory, use that
         if (file.exists()) {
             return file.getAbsolutePath();
         } else {
@@ -214,11 +215,6 @@ public class CoordinatorCli {
         coordinator.workerJvmSettings = workerJvmSettings;
     }
 
-    @SuppressWarnings("unused")
-    private String getProperties() {
-        return options.valueOf(propertiesFileSpec);
-    }
-
     private String loadClientHzConfig() {
         File file = getFile(clientHzFileSpec, options, "Worker Client Hazelcast config file");
         LOGGER.info("Loading Hazelcast client configuration: " + file.getAbsolutePath());
@@ -233,7 +229,7 @@ public class CoordinatorCli {
 
     private File getPropertiesFile() {
         if (options.has(propertiesFileSpec)) {
-            //a file was explicitly configured
+            // a file was explicitly configured
             return newFile(options.valueOf(propertiesFileSpec));
         } else {
             return null;
@@ -250,7 +246,7 @@ public class CoordinatorCli {
             testsuiteFileName = testsuiteFiles.get(0);
         } else if (testsuiteFiles.size() > 1) {
             exitWithError(LOGGER, "Too many testsuite files specified.");
-            //won't be executed.
+            // won't be executed
             return null;
         }
         if (testsuiteFileName == null) {

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/AwsProvisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/AwsProvisioner.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLo
 import com.hazelcast.simulator.common.AgentAddress;
 import com.hazelcast.simulator.common.AgentsFile;
 import com.hazelcast.simulator.common.SimulatorProperties;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
 
@@ -39,7 +41,6 @@ import static com.hazelcast.simulator.utils.FileUtils.appendText;
  * An AWS specific provisioning class which is using the AWS SDK to create AWS instances and AWS elastic load balancer.
  */
 public class AwsProvisioner {
-
 
     // AWS specific magic strings
     public static final String AWS_RUNNING_STATE = "running";
@@ -52,12 +53,13 @@ public class AwsProvisioner {
 
     private static final int SLEEPING_MS = 1000 * 30;
     private static final int MAX_SLEEPING_ITERATIONS = 12;
-    private static final org.apache.log4j.Logger LOGGER = org.apache.log4j.Logger.getLogger(Provisioner.class);
+    private static final Logger LOGGER = Logger.getLogger(Provisioner.class);
 
     private AmazonEC2 ec2;
     private AmazonElasticLoadBalancingClient elb;
     private SimulatorProperties props = new SimulatorProperties();
-    private final File agentsFile = new File(Provisioner.AGENTS_FILE);
+
+    private final File agentsFile = new File(AgentsFile.NAME);
     private final File elbFile = new File(AWS_ELB_FILE_NAME);
 
     private String securityGroup;
@@ -295,10 +297,9 @@ public class AwsProvisioner {
             AwsProvisioner provisioner = new AwsProvisioner();
             AwsProvisionerCli cli = new AwsProvisionerCli(provisioner);
             cli.run(args);
-
         } catch (Throwable e) {
             LOGGER.fatal(e);
-            System.exit(1);
+            exitWithError(LOGGER, e.getMessage());
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/AwsProvisionerCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/AwsProvisionerCli.java
@@ -1,5 +1,6 @@
 package com.hazelcast.simulator.provisioner;
 
+import com.hazelcast.simulator.common.AgentsFile;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
@@ -16,38 +17,39 @@ public class AwsProvisionerCli {
     private static final Logger LOGGER = Logger.getLogger(AwsProvisionerCli.class);
 
     private final OptionParser parser = new OptionParser();
+    private final OptionSpec help = parser.accepts("help", "Show help").forHelp();
 
     private final OptionSpec<String> makeLB = parser.accepts("newLb",
-            "Create new load balancer if it dose not exist."
-    ).withRequiredArg().ofType(String.class);
+            "Create new load balancer if it dose not exist.")
+            .withRequiredArg().ofType(String.class);
 
     private final OptionSpec<String> agentsToLB = parser.accepts("addToLb",
-            "Adds the ips in '" + Provisioner.AGENTS_FILE + "' file to the load balancer."
-    ).withRequiredArg().ofType(String.class);
+            "Adds the ips in '" + AgentsFile.NAME + "' file to the load balancer.")
+            .withRequiredArg().ofType(String.class);
 
     private final OptionSpec<Integer> scale = parser.accepts("scale",
-            "Desired number of machines to scale to."
-    ).withRequiredArg().ofType(Integer.class);
+            "Desired number of machines to scale to.")
+            .withRequiredArg().ofType(Integer.class);
 
     private final OptionSpec<String> propertiesFile = parser.accepts("propertiesFile",
             "The file containing the simulator properties. If no file is explicitly configured, first the working directory is "
-                    + "checked for a file 'simulator.properties'."
-    ).withRequiredArg().ofType(String.class);
-
-    private final OptionSpec help = parser.accepts("help", "Show help").forHelp();
+                    + "checked for a file 'simulator.properties'.")
+            .withRequiredArg().ofType(String.class);
 
     private final AwsProvisioner aws;
-    private OptionSet options;
 
     public AwsProvisionerCli(AwsProvisioner awsProvisioner) {
         this.aws = awsProvisioner;
     }
 
     public void run(String[] args) throws Exception {
+        OptionSet options;
+
         try {
             options = parser.parse(args);
         } catch (OptionException e) {
             exitWithError(LOGGER, e.getMessage() + ". Use --help to get overview of the help options.");
+            return;
         }
 
         if (options.has(help)) {

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/CloudInfo.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/CloudInfo.java
@@ -9,6 +9,8 @@ import org.jclouds.domain.Location;
 
 import java.util.Set;
 
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
+import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
 import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
 import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
 import static java.lang.String.format;
@@ -101,10 +103,9 @@ public class CloudInfo {
             CloudInfo cloudInfoCli = new CloudInfo();
             CloudInfoCli cli = new CloudInfoCli(cloudInfoCli);
             cli.run(args);
-            System.exit(0);
         } catch (Throwable e) {
             LOGGER.fatal(e);
-            System.exit(1);
+            exitWithError(LOGGER, e.getMessage());
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/CloudInfoCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/CloudInfoCli.java
@@ -15,6 +15,7 @@ public class CloudInfoCli {
     private static final Logger LOGGER = Logger.getLogger(ProvisionerCli.class);
 
     private final OptionParser parser = new OptionParser();
+    private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
 
     private final OptionSpec showLocationsSpec = parser.accepts("showLocations",
             "Shows all locations available. In Amazon for example this would be regions and zones.");
@@ -29,18 +30,17 @@ public class CloudInfoCli {
             "Shows very detailed info");
 
     private final OptionSpec<String> locationSpec = parser.accepts("location",
-            "The locationId."
-    ).withRequiredArg().ofType(String.class);
+            "The locationId.")
+            .withRequiredArg().ofType(String.class);
 
     private final OptionSpec<String> propertiesFileSpec = parser.accepts("propertiesFile",
             "The file containing the simulator properties. If no file is explicitly configured, first the working directory is "
                     + "checked for a file 'simulator.properties'. All missing properties are always loaded from "
-                    + "'$SIMULATOR_HOME/conf/simulator.properties'."
-    ).withRequiredArg().ofType(String.class);
-
-    private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
+                    + "'$SIMULATOR_HOME/conf/simulator.properties'.")
+            .withRequiredArg().ofType(String.class);
 
     private final CloudInfo cloudInfo;
+
     private OptionSet options;
 
     public CloudInfoCli(CloudInfo cloudInfo) {

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
 import static com.hazelcast.simulator.utils.CommonUtils.secondsToHuman;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
@@ -38,8 +39,6 @@ import static java.lang.String.format;
 
 public class Provisioner {
 
-    public static final String AGENTS_FILE = "agents.txt";
-
     private static final Logger LOGGER = Logger.getLogger(Provisioner.class);
     private static final String SIMULATOR_HOME = getSimulatorHome().getAbsolutePath();
 
@@ -49,15 +48,12 @@ public class Provisioner {
 
     // big number of threads, but they are used to offload SSH tasks, so there is no load on this machine
     private final ExecutorService executor = Executors.newFixedThreadPool(10);
-    private final File agentsFile = new File(AGENTS_FILE);
+    private final File agentsFile = new File(AgentsFile.NAME);
     private final List<AgentAddress> addresses = Collections.synchronizedList(new LinkedList<AgentAddress>());
 
     private Bash bash;
     private HazelcastJars hazelcastJars;
     private File initScript;
-
-    public Provisioner() {
-    }
 
     void init() {
         ensureExistingFile(agentsFile);
@@ -266,7 +262,7 @@ public class Provisioner {
     }
 
     public void listAgents() {
-        echo("Running Agents (from " + AGENTS_FILE + "):");
+        echo("Running Agents (from " + AgentsFile.NAME + "):");
         String agents = fileAsText(agentsFile);
         echo("    " + agents);
     }
@@ -438,10 +434,9 @@ public class Provisioner {
             Provisioner provisioner = new Provisioner();
             ProvisionerCli cli = new ProvisionerCli(provisioner);
             cli.run(args);
-            System.exit(0);
         } catch (Throwable e) {
             LOGGER.fatal(e);
-            System.exit(1);
+            exitWithError(LOGGER, e.getMessage());
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/ProvisionerCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/ProvisionerCli.java
@@ -16,29 +16,30 @@ public class ProvisionerCli {
     private static final Logger LOGGER = Logger.getLogger(ProvisionerCli.class);
 
     private final OptionParser parser = new OptionParser();
+    private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
 
     private final OptionSpec<String> gitSpec = parser.accepts("git",
             "Overrides the HAZELCAST_VERSION_SPEC property and forces Provisioner to build Hazelcast JARs from a given GIT "
                     + "version. This makes it easier to run a test with different versions of Hazelcast, e.g.\n"
                     + "     --git f0288f713                to use the Git revision f0288f713\n"
                     + "     --git myRepository/myBranch    to use branch myBranch from a repository myRepository.\n"
-                    + "You can specify custom repositories in 'simulator.properties'."
-    ).withRequiredArg().ofType(String.class);
+                    + "You can specify custom repositories in 'simulator.properties'.")
+            .withRequiredArg().ofType(String.class);
 
     private final OptionSpec restartSpec = parser.accepts("restart",
             "Restarts all agents");
 
     private final OptionSpec<String> downloadSpec = parser.accepts("download",
-            "Download all the files from the workers directory. To delete all worker directories, run with --clean"
-    ).withOptionalArg().defaultsTo("workers").ofType(String.class);
+            "Download all the files from the workers directory. To delete all worker directories, run with --clean")
+            .withOptionalArg().defaultsTo("workers").ofType(String.class);
 
     private final OptionSpec cleanSpec = parser.accepts("clean",
             "Cleans the workers directories.");
 
     private final OptionSpec<Integer> scaleSpec = parser.accepts("scale",
             "Number of agent machines to scale to. If the number of machines already exists, the call is ignored. If the "
-                    + "desired number of machines is smaller than the actual number of machines, machines are terminated."
-    ).withRequiredArg().ofType(Integer.class);
+                    + "desired number of machines is smaller than the actual number of machines, machines are terminated.")
+            .withRequiredArg().ofType(Integer.class);
 
     private final OptionSpec terminateSpec = parser.accepts("terminate",
             "Terminate all agent machines in the provisioner");
@@ -52,16 +53,15 @@ public class ProvisionerCli {
     private final OptionSpec<String> propertiesFileSpec = parser.accepts("propertiesFile",
             "The file containing the simulator properties. If no file is explicitly configured, first the working directory is "
                     + "checked for a file 'simulator.properties'. All missing properties are always loaded from "
-                    + "'$SIMULATOR_HOME/conf/simulator.properties'."
-    ).withRequiredArg().ofType(String.class);
+                    + "'$SIMULATOR_HOME/conf/simulator.properties'.")
+            .withRequiredArg().ofType(String.class);
 
     private final OptionSpec<Boolean> enterpriseEnabledSpec = parser.accepts("enterpriseEnabled",
-            "Use hazelcast enterprise edition JARs."
-    ).withRequiredArg().ofType(Boolean.class).defaultsTo(false);
-
-    private final OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
+            "Use hazelcast enterprise edition JARs.")
+            .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
 
     private final Provisioner provisioner;
+
     private OptionSet options;
 
     public ProvisionerCli(Provisioner provisioner) {

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -37,8 +37,8 @@ import static org.junit.Assert.assertEquals;
 @Ignore
 public class AgentSmokeTest {
 
+    private static final String AGENT_IP_ADDRESS = System.getProperty("agentBindAddress", "127.0.0.1");
     private static final int TEST_RUNTIME_SECONDS = Integer.parseInt(System.getProperty("testRuntimeSeconds", "10"));
-    private static final String AGENT_IP_ADDRESS = System.getProperty("agentIpAddress", "127.0.0.1");
 
     private static final Logger log = Logger.getLogger(Coordinator.class);
 
@@ -50,8 +50,8 @@ public class AgentSmokeTest {
         System.setProperty("worker.testmethod.timeout", "5");
         System.setProperty("user.dir", "./dist/src/main/dist");
 
+        log.info("Agent bind address for smoke test: " + AGENT_IP_ADDRESS);
         log.info("Test runtime for smoke test: " + TEST_RUNTIME_SECONDS + " seconds");
-        log.info("IP address for smoke test: " + AGENT_IP_ADDRESS);
 
         startAgent();
         agentsClient = getAgentsClient();
@@ -167,14 +167,16 @@ public class AgentSmokeTest {
         agentThread = new Thread() {
             public void run() {
                 try {
-                    Agent.createAgent(new String[]{});
+                    String[] args = new String[] {
+                            "--bindAddress", AGENT_IP_ADDRESS
+                    };
+                    Agent.createAgent(args);
                 } catch (Throwable t) {
                     t.printStackTrace();
                 }
             }
         };
         agentThread.start();
-
         sleepSeconds(5);
     }
 


### PR DESCRIPTION
* Added bind address for Agent.
* Used bind address in AgentSmokeTest.
* Found better place for 'agents.txt' constant.
* Unified format of command line parser classes.
* Got rid of some System.exit() calls.