### PR TITLE
Fixed total performance count in PerformanceMonitor

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/PerformanceMonitor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/PerformanceMonitor.java
@@ -23,15 +23,17 @@ import static java.lang.String.format;
  * Responsible for collecting performance metrics from the agents and logging/storing it.
  */
 public class PerformanceMonitor {
+
     private static final AtomicBoolean PERFORMANCE_WRITTEN = new AtomicBoolean();
     private static final Logger LOGGER = Logger.getLogger(PerformanceMonitor.class);
 
-    public long previousTime = System.currentTimeMillis();
     private final AgentsClient client;
     private final Coordinator coordinator;
     private final ConcurrentMap<AgentClient, Long> operationCountPerAgent = new ConcurrentHashMap<AgentClient, Long>();
-    private long previousCount;
     private final AtomicBoolean started = new AtomicBoolean();
+
+    private long previousTime = System.currentTimeMillis();
+    private long previousCount;
 
     public PerformanceMonitor(Coordinator coordinator) {
         this.client = coordinator.agentsClient;
@@ -45,7 +47,7 @@ public class PerformanceMonitor {
     }
 
     class PerformanceThread extends Thread {
-        
+
         public PerformanceThread() {
             super("PerformanceThread");
             setDaemon(true);
@@ -73,16 +75,12 @@ public class PerformanceMonitor {
         long totalCount = 0;
         for (Map.Entry<AgentClient, List<Long>> entry : result.entrySet()) {
             AgentClient agentClient = entry.getKey();
-            Long countPerAgent = operationCountPerAgent.get(agentClient);
 
-            if (countPerAgent == null) {
-                countPerAgent = 0L;
-            }
-
+            long countPerAgent = 0;
             for (Long value : entry.getValue()) {
                 if (value != null) {
                     totalCount += value;
-                    countPerAgent = value;
+                    countPerAgent += value;
                 }
             }
 
@@ -104,33 +102,29 @@ public class PerformanceMonitor {
             return;
         }
 
-        StringBuilder sb = new StringBuilder();
-
-        long operationCount = coordinator.operationCount;
-        if (operationCount < 0) {
-            sb.append("Operations: not available");
-        } else {
-            double performance = (operationCount * 1.0d) / duration;
-            sb.append(format("Total performance   %s%% %s ops %s ops/s%n",
-                    formatDouble(100, 7),
-                    formatLong(operationCount, 15),
-                    formatDouble(performance, 15)));
-
-            appendText(performance + "\n", new File("performance.txt"));
+        long totalOperationCount = coordinator.operationCount;
+        if (totalOperationCount < 0) {
+            LOGGER.info("Performance information is not available!");
+            return;
         }
+
+        double performance = (totalOperationCount * 1.0d) / duration;
+        appendText(performance + "\n", new File("performance.txt"));
+        LOGGER.info(format("Total performance     %s%% %s ops %s ops/s",
+                formatDouble(100, 7),
+                formatLong(totalOperationCount, 15),
+                formatDouble(performance, 15)));
 
         for (Map.Entry<AgentClient, Long> entry : operationCountPerAgent.entrySet()) {
             AgentClient client = entry.getKey();
             long operationCountPerAgent = entry.getValue();
-            double performance = (operationCountPerAgent * 1.0d) / duration;
-            double percentage = 100 * (operationCountPerAgent * 1.0d) / operationCount;
-            sb.append(format("               Agent %s %s%% %s ops %s ops/s%n",
+            double percentage = 100 * (operationCountPerAgent * 1.0d) / totalOperationCount;
+            performance = (operationCountPerAgent * 1.0d) / duration;
+            LOGGER.info(format("  Agent %s %s%% %s ops %s ops/s",
                     client.getPublicAddress(),
                     formatDouble(percentage, 7),
                     formatLong(operationCountPerAgent, 15),
                     formatDouble(performance, 15)));
         }
-
-        LOGGER.info(sb.toString());
     }
 }


### PR DESCRIPTION
Performance count per agent was fetched and always overwritten. But the overwritten value was just from the first worker and not summed up (like the total value).

Layout:
```
INFO  17:06:04 Total number of agents: 2
INFO  17:06:04 Total number of Hazelcast member workers: 4
INFO  17:06:04 Total number of Hazelcast client workers: 0
INFO  17:06:04     Agent 172.16.16.206 members: 2 clients: 0
INFO  17:06:04     Agent 172.16.16.209 members: 2 clients: 0
```

Before:
```
INFO  17:07:28 Total performance    100.00%         596,803 ops       19,893.43 ops/s
               Agent 172.16.16.209   24.38%         145,488 ops        4,849.60 ops/s
               Agent 172.16.16.206   25.00%         149,187 ops        4,972.90 ops/s
```

After:
```
INFO  17:00:32 Total performance      100.00%         575,700 ops       19,190.00 ops/s
INFO  17:00:32   Agent 172.16.16.209   49.30%         283,809 ops        9,460.30 ops/s
INFO  17:00:32   Agent 172.16.16.206   50.70%         291,891 ops        9,729.70 ops/s
```