### PR TITLE
Created tests for unbound return values feature.

### DIFF
--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/unbound/AbstractMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/unbound/AbstractMapTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.tests.map.unbound;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.IMap;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.tests.helpers.KeyLocality;
+import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
+import com.hazelcast.simulator.worker.tasks.AbstractWorker;
+
+import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
+import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntKeys;
+import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
+
+abstract class AbstractMapTest {
+
+    private static final ILogger LOGGER = Logger.getLogger(AbstractMapTest.class);
+
+    HazelcastInstance hazelcastInstance;
+    IMap<Object, Object> map;
+    IAtomicLong operationCounter;
+    IAtomicLong exceptionCounter;
+
+    long globalKeyCount;
+    int localKeyCount;
+
+    void baseSetup(TestContext testContext, String basename) {
+        hazelcastInstance = testContext.getTargetInstance();
+
+        map = hazelcastInstance.getMap(basename);
+        operationCounter = hazelcastInstance.getAtomicLong(basename + "Ops");
+        exceptionCounter = hazelcastInstance.getAtomicLong(basename + "Exceptions");
+
+        Class classType = null;
+        try {
+            classType = Class.forName("com.hazelcast.map.impl.MapQueryResultSizeLimitHelper");
+        } catch (ClassNotFoundException e) {
+            LOGGER.warning("Feature is not enabled in this version of Hazelcast!", e);
+        }
+
+        Integer minResultSizeLimit = 150000;
+        Float resultLimitFactor = 1.15f;
+        try {
+            if (classType != null) {
+                minResultSizeLimit = (Integer) classType.getDeclaredField("MINIMUM_MAX_RESULT_LIMIT").get(null);
+                resultLimitFactor = (Float) classType.getDeclaredField("MAX_RESULT_LIMIT_FACTOR").get(null);
+            }
+        } catch (NoSuchFieldException e) {
+            LOGGER.severe("Could not find expected field!", e);
+        } catch (IllegalAccessException e) {
+            LOGGER.severe("Could not read expected field!", e);
+        }
+
+        globalKeyCount = getGlobalKeyCount(minResultSizeLimit, resultLimitFactor);
+        localKeyCount = 1 + (int) (globalKeyCount / hazelcastInstance.getCluster().getMembers().size());
+    }
+
+    abstract long getGlobalKeyCount(Integer minResultSizeLimit, Float resultLimitFactor);
+
+    void baseWarmup(String keyType) {
+        if (!isMemberNode(hazelcastInstance)) {
+            return;
+        }
+
+        if ("String".equals(keyType)) {
+            baseWarmupStringKey();
+        } else if ("Integer".equals(keyType)) {
+            baseWarmupIntKey();
+        } else {
+            throw new IllegalArgumentException("Unknown key type " + keyType);
+        }
+    }
+
+    void baseWarmupStringKey() {
+        String[] keys = generateStringKeys(localKeyCount, 10, KeyLocality.Local, hazelcastInstance);
+        int i = 0;
+        for (String key : keys) {
+            map.put(key, i++);
+        }
+    }
+
+    void baseWarmupIntKey() {
+        int[] keys = generateIntKeys(localKeyCount, Integer.MAX_VALUE, KeyLocality.Local, hazelcastInstance);
+        int i = 0;
+        for (int key : keys) {
+            map.put(key, i++);
+        }
+    }
+
+    AbstractWorker baseRunWithWorker(String operationType) {
+        if ("values".equals(operationType)) {
+            return new ValuesWorker();
+        } else if ("keySet".equals(operationType)) {
+            return new KeySetWorker();
+        } else if ("entrySet".equals(operationType)) {
+            return new EntrySetWorker();
+        } else {
+            throw new IllegalArgumentException("Unknown operation type: " + operationType);
+        }
+    }
+
+    private abstract class BaseWorker extends AbstractMonotonicWorker {
+
+        protected long localOperationCounter;
+        protected long localExceptionCounter;
+
+        @Override
+        protected void afterRun() {
+            operationCounter.addAndGet(localOperationCounter);
+            exceptionCounter.addAndGet(localExceptionCounter);
+        }
+    }
+
+    class ValuesWorker extends BaseWorker {
+
+        @Override
+        protected void timeStep() {
+            localOperationCounter++;
+            try {
+                map.values();
+            } catch (Exception e) {
+                localExceptionCounter++;
+            }
+        }
+    }
+
+    class KeySetWorker extends BaseWorker {
+
+        @Override
+        protected void timeStep() {
+            localOperationCounter++;
+            try {
+                map.keySet();
+            } catch (Exception e) {
+                localExceptionCounter++;
+            }
+        }
+    }
+
+    class EntrySetWorker extends BaseWorker {
+
+        @Override
+        protected void timeStep() {
+            localOperationCounter++;
+            try {
+                map.entrySet();
+            } catch (Exception e) {
+                localExceptionCounter++;
+            }
+        }
+    }
+}

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/unbound/MapLatencyTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/unbound/MapLatencyTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.tests.map.unbound;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.TestRunner;
+import com.hazelcast.simulator.test.annotations.RunWithWorker;
+import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.worker.tasks.AbstractWorker;
+
+import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test creates latency probe results for {@link IMap#values()}, {@link IMap#keySet()} and {@link IMap#entrySet()}. It is
+ * used to ensure that the "Unbounded return values" feature has no bad impact on the latency of those method calls. The test
+ * can be configured to use {@link String} or {@link Integer} keys.
+ */
+public class MapLatencyTest extends AbstractMapTest {
+
+    // properties
+    public String basename = this.getClass().getSimpleName();
+    public String keyType = "String";
+    public String operationType = "values";
+
+    @Setup
+    public void setUp(TestContext testContext) throws Exception {
+        baseSetup(testContext, basename);
+    }
+
+    @Override
+    long getGlobalKeyCount(Integer minResultSizeLimit, Float resultLimitFactor) {
+        return Math.round(minResultSizeLimit * resultLimitFactor * 0.9);
+    }
+
+    @Warmup
+    public void warmup() {
+        baseWarmup(keyType);
+    }
+
+    @Verify(global = true)
+    public void globalVerify() {
+        if (!isMemberNode(hazelcastInstance)) {
+            fail("We need a member worker to execute the global verify!");
+            return;
+        }
+
+        int mapSize = map.size();
+        assertTrue(format("Expected mapSize >= globalKeyCount (%d >= %d)", mapSize, globalKeyCount), mapSize >= globalKeyCount);
+
+        long ops = operationCounter.get();
+        assertTrue(format("Expected ops > 0 (%d > 0)", ops), ops > 0);
+
+        assertEquals("Expected 0 exceptions", 0, exceptionCounter.get());
+    }
+
+    @RunWithWorker
+    public AbstractWorker run() {
+        return baseRunWithWorker(operationType);
+    }
+
+    public static void main(String[] args) throws Throwable {
+        new TestRunner<MapLatencyTest>(new MapLatencyTest()).run();
+    }
+}

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/unbound/MapResultSizeLimitTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/unbound/MapResultSizeLimitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.tests.map.unbound;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.TestRunner;
+import com.hazelcast.simulator.test.annotations.RunWithWorker;
+import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.worker.tasks.AbstractWorker;
+
+import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test verifies that {@link IMap#values()}, {@link IMap#keySet()} and {@link IMap#entrySet()} throw an exception if the
+ * configured result size limit is exceeded. It will create a failure on Hazelcast version prior 3.5. The test can be configured
+ * to use {@link String} or {@link Integer} keys.
+ */
+public class MapResultSizeLimitTest extends AbstractMapTest {
+
+    // properties
+    public String basename = this.getClass().getSimpleName();
+    public String keyType = "String";
+    public String operationType = "values";
+
+    @Setup
+    public void setUp(TestContext testContext) throws Exception {
+        baseSetup(testContext, basename);
+    }
+
+    @Override
+    long getGlobalKeyCount(Integer minResultSizeLimit, Float resultLimitFactor) {
+        return Math.round(minResultSizeLimit * resultLimitFactor * 1.1);
+    }
+
+    @Warmup
+    public void warmup() {
+        baseWarmup(keyType);
+    }
+
+    @Verify(global = true)
+    public void globalVerify() {
+        if (!isMemberNode(hazelcastInstance)) {
+            fail("We need a member worker to execute the global verify!");
+            return;
+        }
+
+        int mapSize = map.size();
+        assertTrue(format("Expected mapSize >= globalKeyCount (%d >= %d)", mapSize, globalKeyCount), mapSize >= globalKeyCount);
+
+        long ops = operationCounter.get();
+        long exceptions = exceptionCounter.get();
+        assertEquals("Expected as many exceptions as operations", ops, exceptions);
+    }
+
+    @RunWithWorker
+    public AbstractWorker run() {
+        return baseRunWithWorker(operationType);
+    }
+
+    public static void main(String[] args) throws Throwable {
+        new TestRunner<MapResultSizeLimitTest>(new MapResultSizeLimitTest()).run();
+    }
+}


### PR DESCRIPTION
`MapResultSizeLimitTest` performs `IMap.values()` etc. on a map filled slightly over the result size limit and checks the number of thrown exceptions.

`MapLatencyTest` performs `IMap.values()` etc. on a map filled slightly below the result size limit to create latency probe results (and checks that no exceptions are thrown).