### PR TITLE
Increased code coverage of some util classes

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-
 <!DOCTYPE suppressions PUBLIC
         "-//Puppy Crawl//DTD Suppressions 1.1//EN"
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
@@ -18,5 +17,7 @@
     <suppress checks="MagicNumber" files="[\\/]"/>
     <suppress checks="VisibilityModifier" files="[\\/]"/>
 
-</suppressions>
+    <!-- Suppress some checks for JUnit tests -->
+    <suppress checks="MethodName" files=".*Test\.java$"/>
 
+</suppressions>

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/AnnotationReflectionUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/AnnotationReflectionUtils.java
@@ -13,7 +13,7 @@ import static java.lang.String.format;
 
 public final class AnnotationReflectionUtils {
 
-    private static final AnnotationFilter.AlwaysFilter ALWAYS_FILTER = new AnnotationFilter.AlwaysFilter();
+    static final AnnotationFilter.AlwaysFilter ALWAYS_FILTER = new AnnotationFilter.AlwaysFilter();
 
     private AnnotationReflectionUtils() {
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/BindException.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/BindException.java
@@ -8,8 +8,4 @@ public class BindException extends RuntimeException {
     public BindException(String message) {
         super(message);
     }
-
-    public BindException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/PropertyBindingSupport.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/PropertyBindingSupport.java
@@ -232,7 +232,8 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindClass(Object object, String value, Field field) throws IllegalAccessException, ClassNotFoundException {
+    private static void bindClass(Object object, String value, Field field) throws IllegalAccessException,
+            ClassNotFoundException {
         if ("null".equals(value)) {
             field.set(object, null);
         } else {

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotationFilterTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotationFilterTest.java
@@ -1,0 +1,93 @@
+package com.hazelcast.simulator.utils;
+
+import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.test.annotations.Teardown;
+import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.utils.AnnotationFilter.TeardownFilter;
+import com.hazelcast.simulator.utils.AnnotationFilter.VerifyFilter;
+import com.hazelcast.simulator.utils.AnnotationFilter.WarmupFilter;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.ALWAYS_FILTER;
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.getAtMostOneVoidMethodWithoutArgs;
+import static org.junit.Assert.assertEquals;
+
+public class AnnotationFilterTest {
+
+    @Test
+    public void testAlwaysFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Setup.class, ALWAYS_FILTER);
+        assertEquals("setupMethod", method.getName());
+    }
+
+    @Test
+    public void testLocalTeardownFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Teardown.class, new TeardownFilter(false));
+        assertEquals("localTearDown", method.getName());
+    }
+
+    @Test
+    public void testGlobalTeardownFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Teardown.class, new TeardownFilter(true));
+        assertEquals("globalTearDown", method.getName());
+    }
+
+    @Test
+    public void testLocalWarmupFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Warmup.class, new WarmupFilter(false));
+        assertEquals("localWarmup", method.getName());
+    }
+
+    @Test
+    public void testGlobalWarmupFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Warmup.class, new WarmupFilter(true));
+        assertEquals("globalWarmup", method.getName());
+    }
+
+    @Test
+    public void testLocalVerifyFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Verify.class, new VerifyFilter(false));
+        assertEquals("localVerify", method.getName());
+    }
+
+    @Test
+    public void testGlobalVerifyFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Verify.class, new VerifyFilter(true));
+        assertEquals("globalVerify", method.getName());
+    }
+
+    @SuppressWarnings("unused")
+    private static class AnnotationTestClass {
+
+        @Setup
+        private void setupMethod() {
+        }
+
+        @Teardown(global = false)
+        private void localTearDown() {
+        }
+
+        @Teardown(global = true)
+        private void globalTearDown() {
+        }
+
+        @Warmup(global = false)
+        private void localWarmup() {
+        }
+
+        @Warmup(global = true)
+        private void globalWarmup() {
+        }
+
+        @Verify(global = false)
+        private void localVerify() {
+        }
+
+        @Verify(global = true)
+        private void globalVerify() {
+        }
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotationReflectionUtilsTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotationReflectionUtilsTest.java
@@ -1,0 +1,194 @@
+package com.hazelcast.simulator.utils;
+
+import com.hazelcast.simulator.test.annotations.Name;
+import com.hazelcast.simulator.test.annotations.Performance;
+import com.hazelcast.simulator.test.annotations.Receive;
+import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.RunWithWorker;
+import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.test.annotations.Teardown;
+import com.hazelcast.simulator.test.annotations.Verify;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.ALWAYS_FILTER;
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.getAtMostOneMethodWithoutArgs;
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.getAtMostOneVoidMethodSkipArgsCheck;
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.getAtMostOneVoidMethodWithoutArgs;
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.getValueFromNameAnnotation;
+import static com.hazelcast.simulator.utils.AnnotationReflectionUtils.getValueFromNameAnnotations;
+import static com.hazelcast.simulator.utils.ReflectionUtils.getField;
+import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AnnotationReflectionUtilsTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        invokePrivateConstructor(AnnotationReflectionUtils.class);
+    }
+
+    @Test
+    public void testGetValueFromNameAnnotation() {
+        Field field = getField(AnnotationTestClass.class, "annotatedField", Object.class);
+
+        String actual = getValueFromNameAnnotation(field);
+        assertEquals("testName", actual);
+    }
+
+    @Test
+    public void testGetValueFromNameAnnotation_noAnnotation() {
+        Field field = getField(AnnotationTestClass.class, "notAnnotatedField", Object.class);
+
+        String actual = getValueFromNameAnnotation(field);
+        assertEquals("notAnnotatedField", actual);
+    }
+
+    @Test
+    public void testGetValueFromNameAnnotations() throws Exception {
+        Annotation[] annotations = new Annotation[1];
+        annotations[0] = new TestAnnotation("testValue");
+
+        String actual = getValueFromNameAnnotations(annotations, "notReturned");
+        assertEquals("testValue", actual);
+    }
+
+    @Test
+    public void testGetValueFromNameAnnotations_multipleAnnotations() throws Exception {
+        Annotation[] annotations = new Annotation[2];
+        annotations[0] = new TestAnnotation("firstValue");
+        annotations[1] = new TestAnnotation("secondValue");
+
+        String actual = getValueFromNameAnnotations(annotations, "notReturned");
+        assertEquals("firstValue", actual);
+    }
+
+    @Test
+    public void testGetValueFromNameAnnotations_defaultValue() throws Exception {
+        Annotation[] annotations = new Annotation[2];
+        annotations[0] = new TestAnnotation("notReturned1", Annotation.class);
+        annotations[1] = new TestAnnotation("notReturned2", Annotation.class);
+
+        String actual = getValueFromNameAnnotations(annotations, "defaultValue");
+        assertEquals("defaultValue", actual);
+    }
+
+    @Test
+    public void testGetAtMostOneVoidMethodSkipArgsCheck() {
+        Method method = getAtMostOneVoidMethodSkipArgsCheck(AnnotationTestClass.class, Setup.class);
+        assertEquals("voidMethod", method.getName());
+    }
+
+    @Test
+    public void testGetAtMostOneVoidMethodWithoutArgs() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Setup.class);
+        assertEquals("voidMethod", method.getName());
+    }
+
+    @Test
+    public void testGetAtMostOneVoidMethodWithoutArgs_AnnotationFilter() {
+        Method method = getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Setup.class, ALWAYS_FILTER);
+        assertEquals("voidMethod", method.getName());
+    }
+
+    @Test
+    public void testGetAtMostOneMethodWithoutArgs() {
+        Method method = getAtMostOneMethodWithoutArgs(AnnotationTestClass.class, Teardown.class, String.class);
+        assertEquals("stringMethod", method.getName());
+    }
+
+    @Test
+    public void testGetAtMostOneMethodWithoutArgs_nothingFound() {
+        Method method = getAtMostOneMethodWithoutArgs(AnnotationTestClass.class, Verify.class, Long.class);
+        assertNull(method);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetAtMostOneVoidMethodWithoutArgs_multipleMethodsFound() {
+        getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Run.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetAtMostOneVoidMethodWithoutArgs_staticMethodsFound() {
+        getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, RunWithWorker.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetAtMostOneVoidMethodWithoutArgs_wrongReturnTypeArgsFound() {
+        getAtMostOneMethodWithoutArgs(AnnotationTestClass.class, Receive.class, String.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetAtMostOneVoidMethodWithoutArgs_methodsWithArgsFound() {
+        getAtMostOneVoidMethodWithoutArgs(AnnotationTestClass.class, Performance.class);
+    }
+
+    @SuppressWarnings("unused")
+    private static class AnnotationTestClass {
+
+        @Name(value = "testName")
+        private Object annotatedField;
+
+        private Object notAnnotatedField;
+
+        @Setup
+        private void voidMethod() {
+        }
+
+        @Teardown
+        private String stringMethod() {
+            return null;
+        }
+
+        @Run
+        private void multipleMethod1() {
+        }
+
+        @Run
+        private void multipleMethod2() {
+        }
+
+        @RunWithWorker
+        private static void staticMethod() {
+        }
+
+        @Receive
+        private long wrongReturnType() {
+            return 0;
+        }
+
+        @Performance
+        private void hasArguments(String ignored) {
+        }
+    }
+
+    @SuppressWarnings("all")
+    private class TestAnnotation implements Name {
+
+        private final String value;
+        private final Class<? extends Annotation> annotationType;
+
+        public TestAnnotation(String value) {
+            this(value, Name.class);
+        }
+
+        public TestAnnotation(String value, Class<? extends Annotation> annotationType) {
+            this.value = value;
+            this.annotationType = annotationType;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return annotationType;
+        }
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupportTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupportTest.java
@@ -1,132 +1,206 @@
 package com.hazelcast.simulator.utils;
 
+import com.hazelcast.simulator.test.TestCase;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.simulator.utils.PropertyBindingSupport.bindOptionalProperty;
+import static com.hazelcast.simulator.utils.PropertyBindingSupport.bindProperties;
 import static com.hazelcast.simulator.utils.PropertyBindingSupport.bindProperty;
+import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class PropertyBindingSupportTest {
 
+    private final BindPropertyTestClass bindPropertyTestClass = new BindPropertyTestClass();
+
+    @Test
+    public void testConstructor() throws Exception {
+        invokePrivateConstructor(PropertyBindingSupport.class);
+    }
+
+    @Test
+    public void bindProperties_notFound_optional() throws NoSuchFieldException, IllegalAccessException {
+        TestCase testCase = new TestCase();
+        testCase.setProperty("class", "willBeIgnored");
+        testCase.setProperty("probe-getLatency", "willBeIgnored");
+        testCase.setProperty("notExist", "isOptional");
+
+        Set<String> optionalProperties = new HashSet<String>();
+        optionalProperties.add("notExist");
+
+        bindProperties(bindPropertyTestClass, testCase, optionalProperties);
+    }
+
+    @Test
+    public void testBindOptionalProperty_testcaseIsNull() throws NoSuchFieldException, IllegalAccessException {
+        bindOptionalProperty(bindPropertyTestClass, null, "ignored");
+    }
+
+    @Test
+    public void testBindOptionalProperty_propertyNotDefined() throws NoSuchFieldException, IllegalAccessException {
+        TestCase testCase = new TestCase();
+        testCase.setProperty("class", "willBeIgnored");
+        testCase.setProperty("probe-getLatency", "willBeIgnored");
+        testCase.setProperty("notExist", "isOptional");
+
+        bindOptionalProperty(bindPropertyTestClass, testCase, "propertyNotDefined");
+    }
+
+    @Test
+    public void testBindOptionalProperty_propertyNotFound() throws NoSuchFieldException, IllegalAccessException {
+        TestCase testCase = new TestCase();
+        testCase.setProperty("class", "willBeIgnored");
+        testCase.setProperty("probe-getLatency", "willBeIgnored");
+        testCase.setProperty("notExist", "isOptional");
+
+        bindOptionalProperty(bindPropertyTestClass, testCase, "notExist");
+    }
+
+    @Test
+    public void testBindOptionalProperty() throws NoSuchFieldException, IllegalAccessException {
+        TestCase testCase = new TestCase();
+        testCase.setProperty("class", "willBeIgnored");
+        testCase.setProperty("probe-getLatency", "willBeIgnored");
+        testCase.setProperty("stringField", "foo");
+
+        bindOptionalProperty(bindPropertyTestClass, testCase, "stringField");
+        assertEquals(bindPropertyTestClass.stringField, "foo");
+    }
+
     @Test
     public void bindProperty_string() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
+        bindProperty(bindPropertyTestClass, "stringField", "null");
+        assertNull(bindPropertyTestClass.stringField);
 
-        bindProperty(someObject, "stringField", "null");
-        assertNull(someObject.stringField);
-
-        bindProperty(someObject, "stringField", "foo");
-        assertEquals(someObject.stringField, "foo");
+        bindProperty(bindPropertyTestClass, "stringField", "foo");
+        assertEquals(bindPropertyTestClass.stringField, "foo");
     }
 
     @Test
     public void bindProperty_class() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
+        bindProperty(bindPropertyTestClass, "clazz", "null");
+        assertNull(bindPropertyTestClass.clazz);
 
-        bindProperty(someObject, "clazz", "null");
-        assertNull(someObject.clazz);
-
-        bindProperty(someObject, "clazz", ArrayList.class.getName());
-        assertEquals(someObject.clazz, ArrayList.class);
+        bindProperty(bindPropertyTestClass, "clazz", ArrayList.class.getName());
+        assertEquals(bindPropertyTestClass.clazz, ArrayList.class);
     }
 
     @Test
     public void bindProperty_enum_nullValue() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "enumField", "null");
-        assertNull(someObject.enumField);
+        bindProperty(bindPropertyTestClass, "enumField", "null");
+        assertNull(bindPropertyTestClass.enumField);
     }
 
     @Test
     public void bindProperty_enum() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "enumField", TimeUnit.HOURS.name());
-        assertEquals(someObject.enumField, TimeUnit.HOURS);
+        bindProperty(bindPropertyTestClass, "enumField", TimeUnit.HOURS.name());
+        assertEquals(bindPropertyTestClass.enumField, TimeUnit.HOURS);
     }
 
     @Test
     public void bindProperty_enum_caseInsensitive() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "enumField", "dAyS");
-        assertEquals(someObject.enumField, TimeUnit.DAYS);
+        bindProperty(bindPropertyTestClass, "enumField", "dAyS");
+        assertEquals(bindPropertyTestClass.enumField, TimeUnit.DAYS);
     }
 
     @Test(expected = BindException.class)
     public void bindProperty_enum_notFound() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
+        bindProperty(bindPropertyTestClass, "enumField", "notExist");
+    }
 
-        bindProperty(someObject, "enumField", "dontexist");
+    @Test
+    public void bindProperty_boolean() throws IllegalAccessException {
+        bindProperty(bindPropertyTestClass, "booleanField", "true");
+        assertEquals(bindPropertyTestClass.booleanField, true);
+
+        bindProperty(bindPropertyTestClass, "booleanField", "false");
+        assertEquals(bindPropertyTestClass.booleanField, false);
+    }
+
+    @Test(expected = BindException.class)
+    public void bindProperty_boolean_invalid() throws IllegalAccessException {
+        bindProperty(bindPropertyTestClass, "booleanField", "invalid");
+    }
+
+    @Test
+    public void bindProperty_Boolean() throws IllegalAccessException {
+        bindProperty(bindPropertyTestClass, "booleanObjectField", "null");
+        assertNull(bindPropertyTestClass.booleanObjectField);
+
+        bindProperty(bindPropertyTestClass, "booleanObjectField", "true");
+        assertEquals(bindPropertyTestClass.booleanObjectField, true);
+
+        bindProperty(bindPropertyTestClass, "booleanObjectField", "false");
+        assertEquals(bindPropertyTestClass.booleanObjectField, false);
+    }
+
+    @Test(expected = BindException.class)
+    public void bindProperty_Boolean_invalid() throws IllegalAccessException {
+        bindProperty(bindPropertyTestClass, "booleanObjectField", "invalid");
     }
 
     @Test
     public void bindProperty_int() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "intField", "10");
-        assertEquals(someObject.intField, 10);
+        bindProperty(bindPropertyTestClass, "intField", "10");
+        assertEquals(bindPropertyTestClass.intField, 10);
     }
 
     @Test
     public void bindProperty_Integer() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
+        bindProperty(bindPropertyTestClass, "integerField", "null");
+        assertNull(bindPropertyTestClass.integerField);
 
-        bindProperty(someObject, "integerField", "null");
-        assertNull(someObject.integerField);
-
-        bindProperty(someObject, "integerField", "10");
-        assertEquals(someObject.integerField, new Integer(10));
+        bindProperty(bindPropertyTestClass, "integerField", "10");
+        assertEquals(bindPropertyTestClass.integerField, new Integer(10));
     }
 
     @Test(expected = BindException.class)
     public void bindProperty_unknownField() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "notexist", "null");
+        bindProperty(bindPropertyTestClass, "notExist", "null");
     }
 
     @Test
     public void bindProperty_withPath() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "otherObject.stringField", "newvalue");
-
-        assertEquals("newvalue",someObject.otherObject.stringField);
+        bindProperty(bindPropertyTestClass, "otherObject.stringField", "newValue");
+        assertEquals("newValue", bindPropertyTestClass.otherObject.stringField);
     }
 
     @Test(expected = BindException.class)
     public void bindProperty_withPathAndNullValue() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "nullOtherObject.stringField", "newvalue");
+        bindProperty(bindPropertyTestClass, "nullOtherObject.stringField", "newValue");
     }
 
     @Test(expected = BindException.class)
     public void bindProperty_withPath_missingProperty() throws IllegalAccessException {
-        SomeObject someObject = new SomeObject();
-
-        bindProperty(someObject, "notexist.stringField", "newvalue");
+        bindProperty(bindPropertyTestClass, "notExist.stringField", "newValue");
     }
 
     @SuppressWarnings("unused")
-    private class SomeObject {
-        private String stringField;
-        private TimeUnit enumField;
-        private int intField;
-        private Integer integerField;
-        private Object objectField;
+    private class BindPropertyTestClass {
+
         public OtherObject otherObject = new OtherObject();
         public OtherObject nullOtherObject;
         public Class clazz;
+
+        private Object objectField;
+        private String stringField;
+        private TimeUnit enumField;
+
+        private boolean booleanField;
+        private Boolean booleanObjectField;
+
+        private int intField;
+        private Integer integerField;
     }
 
     private class OtherObject {
-        public String stringField;
 
+        public String stringField;
     }
 }


### PR DESCRIPTION
* Increased code coverage of `AnnotationFilter`, `AnnotationReflectionUtils` and `PropertyBindingSupport`.
* Suppressed method name checks for test classes (was too annoying)

I'm not completely done with `PropertyBindingSupport` yet, but this should already be a noticeable improvement to merge.

```
com.hazelcast.simulator.utils	10% (2/20)	6% (10/149)		9% (79/846)
com.hazelcast.simulator.utils	40% (8/20)	27% (41/148)	23% (197/844)
```
(it's a bit hard to measure since we still have the package `com.hazelcast.simulator.utils` twice in the project)