### PR TITLE
Fixed SyntheticTest to compile with Hazelcast 3.5 (and other fixes + cleanup)

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/IWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/IWorker.java
@@ -11,6 +11,9 @@ import com.hazelcast.simulator.worker.TestContainer;
  * {@link com.hazelcast.simulator.test.TestContext TestContext} testContext;
  * {@link com.hazelcast.simulator.probes.probes.IntervalProbe IntervalProbe} intervalProbe;
  * <code>long</code> logFrequency;
+ *
+ * You have to implement a method with the {@link com.hazelcast.simulator.test.annotations.Performance} annotation, which will
+ * be executed on a single worker instance (the last one which was created).
  */
 public interface IWorker extends Runnable {
 

--- a/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticRequest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticRequest.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 import java.security.Permission;
 
 public class SyntheticRequest extends PartitionClientRequest {
-    private int partitionId;
+
     private int syncBackupCount;
     private int asyncBackupCount;
     private long backupDelayNanos;
-    private String serviceName;
+    private int partitionId;
 
     public SyntheticRequest() {
     }
@@ -22,18 +22,18 @@ public class SyntheticRequest extends PartitionClientRequest {
         this.syncBackupCount = syncBackupCount;
         this.asyncBackupCount = asyncBackupCount;
         this.backupDelayNanos = backupDelayNanos;
-        this.serviceName = serviceName;
     }
 
-    public void setPartitionId(int partitionId) {
+    public void setLocalPartitionId(int partitionId) {
         this.partitionId = partitionId;
     }
 
     @Override
     protected Operation prepareOperation() {
-        SyntheticOperation op = new SyntheticOperation((byte)syncBackupCount, (byte)asyncBackupCount, backupDelayNanos);
-        op.setPartitionId(partitionId);
-        return op;
+        SyntheticOperation operation = new SyntheticOperation((byte) syncBackupCount, (byte) asyncBackupCount, backupDelayNanos);
+        operation.setPartitionId(partitionId);
+
+        return operation;
     }
 
     @Override
@@ -69,7 +69,6 @@ public class SyntheticRequest extends PartitionClientRequest {
         writer.writeInt("asyncBackupCount", asyncBackupCount);
         writer.writeLong("backupDelayNanos", backupDelayNanos);
         writer.writeInt("partitionId", partitionId);
-        writer.writeUTF("serviceName",serviceName);
     }
 
     @Override
@@ -80,6 +79,5 @@ public class SyntheticRequest extends PartitionClientRequest {
         asyncBackupCount = reader.readInt("asyncBackupCount");
         backupDelayNanos = reader.readLong("backupDelayNanos");
         partitionId = reader.readInt("partitionId");
-        serviceName = reader.readUTF("serviceName");
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticTest.java
@@ -16,18 +16,18 @@ import com.hazelcast.simulator.probes.probes.IntervalProbe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Performance;
-import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.utils.ExceptionReporter;
-import com.hazelcast.simulator.utils.ThreadSpawner;
+import com.hazelcast.simulator.worker.tasks.IWorker;
 import com.hazelcast.spi.OperationService;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getNode;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
@@ -37,7 +37,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntKey;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getObjectFromField;
 
 /**
- * The SyntheticBackPressureTest tests back pressure.
+ * The SyntheticTest can be used to test features like back pressure.
  *
  * It can be configured with:
  * - sync invocation
@@ -46,119 +46,115 @@ import static com.hazelcast.simulator.utils.ReflectionUtils.getObjectFromField;
  * - number of async backups
  * - delay of back pressing.
  *
- * This test doesn't make use of any normal data-structures like an IMap; but uses the SPI directly to execute operations
- * and backups. This gives a lot of control on the behavior.
+ * This test doesn't make use of any normal data-structures like an {@link com.hazelcast.core.IMap}, but uses the SPI directly to
+ * execute operations and backups. This gives a lot of control on the behavior.
  *
- * If for example we want to test back pressure on async backups; just set the asyncBackupCount to a value larger than 0 and
- * if you want to simulate a slow down, also set the backupDelayNanos. If this is set to a high value, on the backup you will
- * get a pileup of back up commands which eventually can lead to an OOME.
+ * If for example we want to test back pressure on async backups, just set the asyncBackupCount to a value larger than 0 and if
+ * you want to simulate a slow down, also set the backupDelayNanos. If this is set to a high value, on the backup you will get a
+ * pileup of back up commands which eventually can lead to an OOME.
  *
- * Another interesting scenario to test is a normal async invocation of a readonly operation (so no async/sync-backups) and see
- * if the system can be flooded with too many request. Normal sync operations don't cause that many problems because there is a
+ * Another interesting scenario to test is a normal async invocation of a readonly operation (so no async/sync-backups) and see if
+ * the system can be flooded with too many request. Normal sync operations don't cause that many problems because there is a
  * natural balance between the number of threads and the number of pending invocations.
  */
 public class SyntheticTest {
-    private static final ILogger log = Logger.getLogger(SyntheticTest.class);
 
-    //props
+    private static final ILogger LOGGER = Logger.getLogger(SyntheticTest.class);
+
+    // properties
     public boolean syncInvocation = true;
     public byte syncBackupCount = 0;
     public byte asyncBackupCount = 1;
     public long backupDelayNanos = 1000 * 1000;
     public boolean randomizeBackupDelay = true;
-    public int threadCount = 10;
     public int logFrequency = 10000;
     public int performanceUpdateFrequency = 1000;
     public KeyLocality keyLocality = KeyLocality.RANDOM;
+    public int keyCount = 1000;
     public int syncFrequency = 1;
     public String serviceName;
 
-    private AtomicLong operations = new AtomicLong();
-    private TestContext context;
     private HazelcastInstance targetInstance;
-    public IntervalProbe latency;
 
     @Setup
-    public void setup(TestContext context) throws Exception {
-        this.context = context;
-        this.targetInstance = context.getTargetInstance();
+    public void setup(TestContext testContext) throws Exception {
+        targetInstance = testContext.getTargetInstance();
     }
 
     @Teardown
     public void teardown() throws Exception {
-        log.info(getOperationCountInformation(targetInstance));
-        log.info(getPartitionDistributionInformation(targetInstance));
+        LOGGER.info(getOperationCountInformation(targetInstance));
+        LOGGER.info(getPartitionDistributionInformation(targetInstance));
     }
 
-    @Run
-    public void run() {
-        ThreadSpawner spawner = new ThreadSpawner(context.getTestId());
-        for (int k = 0; k < threadCount; k++) {
-            spawner.spawn(new Worker());
-        }
-        spawner.awaitCompletion();
+    @RunWithWorker
+    public Worker createWorker() {
+        return new Worker();
     }
 
-    @Performance
-    public long getOperationCount() {
-        return operations.get();
-    }
+    private class Worker implements IWorker, ExecutionCallback<Object> {
 
-    private class Worker implements Runnable, ExecutionCallback {
-        private final ArrayList<Integer> partitionSequence = new ArrayList<Integer>();
+        // these fields will be injected by the TestContainer
+        TestContext testContext;
+        IntervalProbe intervalProbe;
+
+        private final List<Integer> partitionSequence = new ArrayList<Integer>();
+        private final List<ICompletableFuture> futureList = new ArrayList<ICompletableFuture>(syncFrequency);
         private final Random random = new Random();
-        private final OperationService operationService;
+
         private final boolean isClient;
+        private final OperationService operationService;
         private final ClientInvocationService clientInvocationService;
         private final ClientPartitionService clientPartitionService;
-        private final ArrayList<ICompletableFuture> futureList = new ArrayList<ICompletableFuture>(syncFrequency);
-        int partitionIndex = 0;
+
+        private int partitionIndex;
+        private long iteration;
 
         public Worker() {
             isClient = isClient(targetInstance);
+            checkClientKeyLocality();
+
             if (isClient) {
                 HazelcastClientProxy hazelcastClientProxy = (HazelcastClientProxy) targetInstance;
-                operationService = null;
                 PartitionServiceProxy partitionService = (PartitionServiceProxy) hazelcastClientProxy.client.getPartitionService();
-                clientPartitionService = getObjectFromField(partitionService, "partitionService");
+
+                operationService = null;
                 clientInvocationService = hazelcastClientProxy.client.getInvocationService();
+                clientPartitionService = getObjectFromField(partitionService, "partitionService");
             } else {
+                Node node = getNode(targetInstance);
+
+                operationService = node.getNodeEngine().getOperationService();
                 clientInvocationService = null;
                 clientPartitionService = null;
-                Node node = getNode(context.getTargetInstance());
-                node.getPartitionService().getPartitionCount();
-                operationService = node.getNodeEngine().getOperationService();
             }
 
-            if (isClient) {
-                if (keyLocality == KeyLocality.LOCAL)
-                    throw new IllegalStateException("A KeyLocality has been set to Local, but test is running on a client. " +
-                            "It doesn't make sense as no keys are stored on clients. ");
-            }
-
-            int keys = 1000;
-            for (int k = 0; k < keys; k++) {
-                Integer key = generateIntKey(keys, keyLocality, targetInstance);
+            for (int i = 0; i < keyCount; i++) {
+                Integer key = generateIntKey(keyCount, keyLocality, targetInstance);
                 Partition partition = targetInstance.getPartitionService().getPartition(key);
                 partitionSequence.add(partition.getPartitionId());
             }
             Collections.shuffle(partitionSequence);
         }
 
-        @Override
-        public void onResponse(Object response) {
-            operations.addAndGet(1);
+        private void checkClientKeyLocality() {
+            if (isClient && keyLocality == KeyLocality.LOCAL) {
+                throw new IllegalStateException("The KeyLocality has been set to LOCAL, but the test is running on a client."
+                        + " This doesn't make sense as no keys are stored on clients.");
+            }
         }
 
-        @Override
-        public void onFailure(Throwable t) {
-            ExceptionReporter.report(context.getTestId(), t);
+        @Performance
+        public long getOperationCount() {
+            return intervalProbe.getInvocationCount();
         }
 
         @Override
         public void run() {
             try {
-                doRun();
+                while (!testContext.isStopped()) {
+                    timeStep();
+                }
             } catch (RuntimeException e) {
                 throw e;
             } catch (Exception e) {
@@ -166,69 +162,46 @@ public class SyntheticTest {
             }
         }
 
-        public void doRun() throws Exception {
-            long iteration = 0;
-
-            while (!context.isStopped()) {
-
-                int partitionId = nextPartitionId();
-
-                ICompletableFuture f = invoke(partitionId);
-                //latency.started();
-
-                if (syncInvocation) {
-                    if (syncFrequency == 1) {
-                        f.get();
-                    } else {
-                        if (iteration > 0 && iteration % syncFrequency == 0) {
-                            for (ICompletableFuture future : futureList) {
-                                future.get();
-                            }
-                            futureList.clear();
-                        } else {
-                            futureList.add(f);
-                        }
-                    }
+        private void timeStep() throws Exception {
+            ICompletableFuture<Object> future = invokeOnNextPartition();
+            if (syncInvocation) {
+                intervalProbe.started();
+                if (syncFrequency == 1) {
+                    future.get();
                 } else {
-                    f.andThen(this);
-                }
-                //latency.done();
-
-                iteration++;
-                if (iteration % logFrequency == 0) {
-                    log.info(Thread.currentThread().getName() + " At iteration: " + iteration);
-                }
-
-                if (iteration % performanceUpdateFrequency == 0) {
-                    if (syncInvocation) {
-                        operations.addAndGet(performanceUpdateFrequency);
+                    futureList.add(future);
+                    if (iteration > 0 && iteration % syncFrequency == 0) {
+                        for (ICompletableFuture innerFuture : futureList) {
+                            innerFuture.get();
+                        }
+                        futureList.clear();
                     }
                 }
+                intervalProbe.done();
+            } else {
+                future.andThen(this);
             }
-            operations.addAndGet(iteration % performanceUpdateFrequency);
+
+            iteration++;
+            if (iteration % logFrequency == 0) {
+                LOGGER.info(Thread.currentThread().getName() + " at iteration: " + iteration);
+            }
         }
 
-        private ICompletableFuture invoke(int partitionId) throws Exception {
-            ICompletableFuture f;
+        private ICompletableFuture<Object> invokeOnNextPartition() throws Exception {
+            int partitionId = nextPartitionId();
             if (isClient) {
                 SyntheticRequest request = new SyntheticRequest(syncBackupCount, asyncBackupCount, backupDelayNanos, null);
-                request.setPartitionId(partitionId);
+                request.setLocalPartitionId(partitionId);
                 Address target = clientPartitionService.getPartitionOwner(partitionId);
-                f = clientInvocationService.invokeOnTarget(request, target);
-            } else {
-                SyntheticOperation operation = new SyntheticOperation(syncBackupCount, asyncBackupCount, getBackupDelayNanos());
-                f = operationService.invokeOnPartition(serviceName, operation, partitionId);
+                return clientInvocationService.invokeOnTarget(request, target);
             }
-            return f;
+            SyntheticOperation operation = new SyntheticOperation(syncBackupCount, asyncBackupCount, getBackupDelayNanos());
+            return operationService.invokeOnPartition(serviceName, operation, partitionId);
         }
 
         private int nextPartitionId() {
-            int partitionId = partitionSequence.get(partitionIndex);
-            partitionIndex++;
-            if (partitionIndex >= partitionSequence.size()) {
-                partitionIndex = 0;
-            }
-            return partitionId;
+            return partitionSequence.get(partitionIndex++ % partitionSequence.size());
         }
 
         private long getBackupDelayNanos() {
@@ -245,6 +218,21 @@ public class SyntheticTest {
             }
 
             return Math.abs(random.nextLong() + 1) % backupDelayNanos;
+        }
+
+        @Override
+        public void onResponse(Object response) {
+            intervalProbe.done();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            ExceptionReporter.report(testContext.getTestId(), t);
+        }
+
+        @Override
+        public void afterCompletion() {
+            // nothing to do here
         }
     }
 

--- a/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/GetOperation.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/GetOperation.java
@@ -15,7 +15,8 @@ public class GetOperation extends AbstractOperation implements PartitionAwareOpe
     private Data key;
     private Data response;
 
-    public GetOperation(){}
+    public GetOperation() {
+    }
 
     public GetOperation(String mapName, Data key) {
         this.mapName = mapName;

--- a/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/PutOperation.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/PutOperation.java
@@ -9,14 +9,16 @@ import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 
-public class PutOperation extends AbstractOperation implements PartitionAwareOperation, IdentifiedDataSerializable{
+public class PutOperation extends AbstractOperation implements PartitionAwareOperation, IdentifiedDataSerializable {
+
     private String mapName;
     private Data key;
     private Data value;
 
-    public PutOperation(){}
+    public PutOperation() {
+    }
 
-    public PutOperation(String mapName, Data key, Data value){
+    public PutOperation(String mapName, Data key, Data value) {
         this.mapName = mapName;
         this.key = key;
         this.value = value;

--- a/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/SyntheticMap.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/SyntheticMap.java
@@ -2,7 +2,7 @@ package com.hazelcast.simulator.tests.syntheticmap;
 
 import com.hazelcast.core.DistributedObject;
 
-public interface SyntheticMap<K,V> extends DistributedObject {
+public interface SyntheticMap<K, V> extends DistributedObject {
 
     V get(K key);
 

--- a/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/SyntheticMapService.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/SyntheticMapService.java
@@ -24,7 +24,6 @@ public class SyntheticMapService implements ManagedService, RemoteService {
 
     @Override
     public void destroyDistributedObject(String objectName) {
-
     }
 
     @Override
@@ -32,8 +31,8 @@ public class SyntheticMapService implements ManagedService, RemoteService {
         this.nodeEngine = nodeEngine;
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         partitions = new Partition[partitionCount];
-        for (int k = 0; k < partitionCount; k++) {
-            partitions[k] = new Partition();
+        for (int i = 0; i < partitionCount; i++) {
+            partitions[i] = new Partition();
         }
     }
 
@@ -60,20 +59,20 @@ public class SyntheticMapService implements ManagedService, RemoteService {
     }
 
     private static class Partition {
-        private Map<String,RecordStore> stores = new HashMap<String, RecordStore>();
+        private Map<String, RecordStore> stores = new HashMap<String, RecordStore>();
 
-        public RecordStore get(String name){
+        public RecordStore get(String name) {
             RecordStore store = stores.get(name);
-            if(store == null){
+            if (store == null) {
                 store = new RecordStore();
                 stores.put(name, store);
             }
-            return  store;
+            return store;
         }
     }
 
-    private static class RecordStore{
-        private final Map<Data,Data> map = new HashMap<Data, Data>();
+    private static class RecordStore {
+        private final Map<Data, Data> map = new HashMap<Data, Data>();
 
         public Data get(Data key) {
             return map.get(key);


### PR DESCRIPTION
* Fixed compilation issue with Hazelcast 3.5
* Fixed dropped future in async mode of SyntheticTest if syncFrequency > 1
* Made usage of IWorker to get rid of ThreadSpawner and atomic operation counter in SyntheticTest
* Cleanup of SyntheticTest and StringStringSyntheticMapTest> to increase checkstyle compliance
* Improved JavaDoc of IWorker