### PR TITLE
Fixed HDR Probe

### DIFF
--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbe.java
@@ -16,7 +16,7 @@ public class HdrLatencyDistributionProbe
         if (started == 0) {
             throw new IllegalStateException("You have to call started() before done()");
         }
-        histogram.recordValue((int) TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started));
+        histogram.recordValue((int) TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - started));
         invocations++;
     }
 

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionResult.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionResult.java
@@ -30,9 +30,10 @@ public class HdrLatencyDistributionResult implements Result<HdrLatencyDistributi
         if (other == null) {
             return this;
         }
-        Histogram histogramCopy = new Histogram(histogram);
-        histogramCopy.add(other.histogram);
-        return new HdrLatencyDistributionResult(histogramCopy);
+        Histogram combinedHistogram = new Histogram(histogram);
+        combinedHistogram.add(histogram);
+        combinedHistogram.add(other.histogram);
+        return new HdrLatencyDistributionResult(combinedHistogram);
     }
 
     @Override


### PR DESCRIPTION
* Fixed HDR Probe measurement.
* Fixed HDR Probe combine.
* Fixed HDR Probe histogram creation.
* Fixed Latency Probe histogram creation.

HDR probe measurements were in milliseconds not microseconds. The combine didn't copy one of the histogram's content. The accuracy buttons for HDR probe were not implemented in Visualizer yet. The Latency Probe had an issue with aggregating big numbers in Visualizer.