### PR TITLE
Cleanup of "throws Throwable"

### DIFF
--- a/archetype/src/main/resources/archetype-resources/src/main/java/ExampleTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/main/java/ExampleTest.java
@@ -95,7 +95,7 @@ public class ExampleTest {
 
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         ExampleTest test = new ExampleTest();
         new TestRunner<ExampleTest>(test).run();
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestRunner.java
@@ -112,7 +112,7 @@ public class TestRunner<E> {
         return this;
     }
 
-    public void run() throws Throwable {
+    public void run() throws Exception {
         if (hazelcastInstance == null) {
             hazelcastInstance = Hazelcast.newHazelcastInstance();
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
@@ -152,7 +152,7 @@ public class TestContainer<T extends TestContext> {
         return testContext;
     }
 
-    public void run() throws Throwable {
+    public void run() throws Exception {
         long now = Clock.currentTimeMillis();
         for (SimpleProbe probe : probeMap.values()) {
             probe.startProbing(now);
@@ -168,41 +168,41 @@ public class TestContainer<T extends TestContext> {
         }
     }
 
-    public void setUp() throws Throwable {
+    public void setUp() throws Exception {
         invokeMethod(testClassInstance, setupMethod, setupArguments);
     }
 
-    public void localWarmup() throws Throwable {
+    public void localWarmup() throws Exception {
         invokeMethod(testClassInstance, localWarmupMethod);
     }
 
-    public void globalWarmup() throws Throwable {
+    public void globalWarmup() throws Exception {
         invokeMethod(testClassInstance, globalWarmupMethod);
     }
 
-    public void localVerify() throws Throwable {
+    public void localVerify() throws Exception {
         invokeMethod(testClassInstance, localVerifyMethod);
     }
 
-    public void globalVerify() throws Throwable {
+    public void globalVerify() throws Exception {
         invokeMethod(testClassInstance, globalVerifyMethod);
     }
 
-    public void globalTeardown() throws Throwable {
+    public void globalTeardown() throws Exception {
         invokeMethod(testClassInstance, globalTeardownMethod);
     }
 
-    public void localTeardown() throws Throwable {
+    public void localTeardown() throws Exception {
         invokeMethod(testClassInstance, localTeardownMethod);
     }
 
-    public long getOperationCount() throws Throwable {
+    public long getOperationCount() throws Exception {
         Long count = invokeMethod((operationCountWorkerInstance != null) ? operationCountWorkerInstance : testClassInstance,
                 operationCountMethod);
         return (count == null ? -1 : count);
     }
 
-    public void sendMessage(Message message) throws Throwable {
+    public void sendMessage(Message message) throws Exception {
         invokeMethod(testClassInstance, messageConsumerMethod, message);
     }
 
@@ -339,7 +339,7 @@ public class TestContainer<T extends TestContext> {
         return (P) probe;
     }
 
-    private void invokeRunWithWorkerMethod(long now) throws Throwable {
+    private void invokeRunWithWorkerMethod(long now) throws Exception {
         bindOptionalProperty(this, testCase, OptionalTestProperties.THREAD_COUNT.propertyName);
         bindOptionalProperty(this, testCase, OptionalTestProperties.WORKER_PROBE_TYPE.propertyName);
 

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerMessageProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerMessageProcessor.java
@@ -119,7 +119,7 @@ class WorkerMessageProcessor {
         }
     }
 
-    private void processTestMessage(Message message) throws Throwable {
+    private void processTestMessage(Message message) throws Exception {
         String testAddress = message.getMessageAddress().getTestAddress();
         if (MessageAddress.BROADCAST.equals(testAddress)) {
             for (TestContainer<TestContext> testContainer : tests.values()) {

--- a/simulator/src/test/java/com/hazelcast/simulator/test/TestRunnerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/TestRunnerTest.java
@@ -26,7 +26,7 @@ public class TestRunnerTest {
     }
 
     @Test
-    public void testBasics() throws Throwable {
+    public void testBasics() throws Exception {
         assertEquals(successTest, testRunner.getTest());
         assertNull(testRunner.getHazelcastInstance());
         assertTrue(testRunner.getDurationSeconds() > 0);
@@ -39,7 +39,7 @@ public class TestRunnerTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testTestContextImpl() throws Throwable {
+    public void testTestContextImpl() throws Exception {
         TestContextImplTest test = new TestContextImplTest();
         TestRunner<TestContextImplTest> testRunner = new TestRunner<TestContextImplTest>(test);
 

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/TestContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/TestContainerTest.java
@@ -50,7 +50,7 @@ public class TestContainerTest {
     // =============================================================
 
     @Test(expected = IllegalTestException.class)
-    public void testRunAnnotationMissing() throws Throwable {
+    public void testRunAnnotationMissing() throws Exception {
         new TestContainer<DummyTestContext>(new MissingRunAnnotationTest(), testContext, probesConfiguration);
     }
 
@@ -58,7 +58,7 @@ public class TestContainerTest {
     }
 
     @Test(expected = IllegalTestException.class)
-    public void testTooManyMixedRunAnnotations() throws Throwable {
+    public void testTooManyMixedRunAnnotations() throws Exception {
         new TestContainer<DummyTestContext>(new TooManyMixedRunAnnotationsTest(), testContext, probesConfiguration);
     }
 
@@ -91,7 +91,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testSetupAnnotationInheritance() throws Throwable {
+    public void testSetupAnnotationInheritance() throws Exception {
         // @Setup method will be called from child class, not from dummy class
         // @Run method will be called from dummy class, not from child class
         ChildWithOwnSetupMethodTest test = new ChildWithOwnSetupMethodTest();
@@ -118,7 +118,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testRunAnnotationInheritance() throws Throwable {
+    public void testRunAnnotationInheritance() throws Exception {
         // @Setup method will be called from dummy class, not from child class
         // @Run method will be called from child class, not from dummy class
         ChildWithOwnRunMethodTest test = new ChildWithOwnRunMethodTest();
@@ -148,7 +148,7 @@ public class TestContainerTest {
     // ================================================
 
     @Test
-    public void testRun() throws Throwable {
+    public void testRun() throws Exception {
         DummyTest test = new DummyTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.run();
@@ -157,7 +157,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testRunWithWorker() throws Throwable {
+    public void testRunWithWorker() throws Exception {
         final RunWithWorkerTest test = new RunWithWorkerTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Thread testStopper = new Thread() {
@@ -201,7 +201,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testRunWithIWorker() throws Throwable {
+    public void testRunWithIWorker() throws Exception {
         final RunWithIWorkerTest test = new RunWithIWorkerTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Thread testStopper = new Thread() {
@@ -246,7 +246,7 @@ public class TestContainerTest {
     // ==================================================
 
     @Test()
-    public void testSetupWithoutArguments() throws Throwable {
+    public void testSetupWithoutArguments() throws Exception {
         new TestContainer<DummyTestContext>(new SetupWithoutArgumentsTest(), testContext, probesConfiguration);
     }
 
@@ -258,7 +258,7 @@ public class TestContainerTest {
     }
 
     @Test()
-    public void testSetupWithTestContextOnly() throws Throwable {
+    public void testSetupWithTestContextOnly() throws Exception {
         new TestContainer<DummyTestContext>(new SetupWithTextContextOnlyTest(), testContext, probesConfiguration);
     }
 
@@ -270,7 +270,7 @@ public class TestContainerTest {
     }
 
     @Test(expected = IllegalTestException.class)
-    public void testSetupWithSimpleProbeOnly() throws Throwable {
+    public void testSetupWithSimpleProbeOnly() throws Exception {
         new TestContainer<DummyTestContext>(new SetupWithSimpleProbeOnly(), testContext, probesConfiguration);
     }
 
@@ -282,7 +282,7 @@ public class TestContainerTest {
     }
 
     @Test(expected = IllegalTestException.class)
-    public void testIllegalSetupArguments() throws Throwable {
+    public void testIllegalSetupArguments() throws Exception {
         new TestContainer<DummyTestContext>(new IllegalSetupArgumentsTest(), testContext, probesConfiguration);
     }
 
@@ -294,7 +294,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testSetupWithValidArguments() throws Throwable {
+    public void testSetupWithValidArguments() throws Exception {
         new TestContainer<DummyTestContext>(new SetupWithValidArgumentsTest(), testContext, probesConfiguration);
     }
 
@@ -306,7 +306,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testSetup() throws Throwable {
+    public void testSetup() throws Exception {
         DummySetupTest test = new DummySetupTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.setUp();
@@ -321,7 +321,7 @@ public class TestContainerTest {
     // ===================================================
 
     @Test
-    public void testLocalProbeInjected() throws Throwable {
+    public void testLocalProbeInjected() throws Exception {
         ProbeTest test = new ProbeTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.setUp();
@@ -330,7 +330,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testProbeExplicitNameSetViaAnnotation() throws Throwable {
+    public void testProbeExplicitNameSetViaAnnotation() throws Exception {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("explicitProbeName", ProbesType.THROUGHPUT.string);
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
@@ -340,7 +340,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testProbeImplicitName() throws Throwable {
+    public void testProbeImplicitName() throws Exception {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("Probe2", ProbesType.THROUGHPUT.string);
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
@@ -415,7 +415,7 @@ public class TestContainerTest {
     // ===================================================
 
     @Test
-    public void testLocalWarmup() throws Throwable {
+    public void testLocalWarmup() throws Exception {
         WarmupTest test = new WarmupTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.localWarmup();
@@ -425,7 +425,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testGlobalWarmup() throws Throwable {
+    public void testGlobalWarmup() throws Exception {
         WarmupTest test = new WarmupTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.globalWarmup();
@@ -455,7 +455,7 @@ public class TestContainerTest {
     // ===================================================
 
     @Test
-    public void testLocalVerify() throws Throwable {
+    public void testLocalVerify() throws Exception {
         VerifyTest test = new VerifyTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.localVerify();
@@ -465,7 +465,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testGlobalVerify() throws Throwable {
+    public void testGlobalVerify() throws Exception {
         VerifyTest test = new VerifyTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.globalVerify();
@@ -495,7 +495,7 @@ public class TestContainerTest {
     // =====================================================
 
     @Test
-    public void testLocalTeardown() throws Throwable {
+    public void testLocalTeardown() throws Exception {
         TeardownTest test = new TeardownTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.localTeardown();
@@ -505,7 +505,7 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testGlobalTeardown() throws Throwable {
+    public void testGlobalTeardown() throws Exception {
         TeardownTest test = new TeardownTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.globalTeardown();
@@ -535,7 +535,7 @@ public class TestContainerTest {
     // ========================================================
 
     @Test
-    public void testPerformance() throws Throwable {
+    public void testPerformance() throws Exception {
         PerformanceTest test = new PerformanceTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         long count = invoker.getOperationCount();
@@ -560,7 +560,7 @@ public class TestContainerTest {
     // ====================================================
 
     @Test
-    public void testMessageReceiver() throws Throwable {
+    public void testMessageReceiver() throws Exception {
         ReceiveTest test = new ReceiveTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Message message = Mockito.mock(Message.class);

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerMessageProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerMessageProcessorTest.java
@@ -52,7 +52,7 @@ public class WorkerMessageProcessorTest {
     }
 
     @Test
-    public void testMessageToAllTests() throws Throwable {
+    public void testMessageToAllTests() throws Exception {
         MessageAddress messageAddress = MessageAddress.builder().toAllAgents().toAllWorkers().toAllTests().build();
         DummyRunnableMessage message = new DummyRunnableMessage(messageAddress);
 
@@ -64,7 +64,7 @@ public class WorkerMessageProcessorTest {
     }
 
     @Test
-    public void testMessageToRandomTest() throws Throwable {
+    public void testMessageToRandomTest() throws Exception {
         MessageAddress messageAddress = MessageAddress.builder().toAllAgents().toAllWorkers().toRandomTest().build();
         final DummyRunnableMessage message = new DummyRunnableMessage(messageAddress);
 
@@ -73,7 +73,7 @@ public class WorkerMessageProcessorTest {
     }
 
     private void verifyMessageSentToEitherOr(TestContainer<?> container1, TestContainer<?> container2, Message message)
-            throws Throwable {
+            throws Exception {
         try {
             verify(container1, timeout(TIMEOUT)).sendMessage(message);
         } catch (WantedButNotInvoked e) {

--- a/tests/src/main/java/com/hazelcast/simulator/tests/ExampleTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/ExampleTest.java
@@ -97,7 +97,7 @@ public class ExampleTest {
 
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         ExampleTest test = new ExampleTest();
         new TestRunner<ExampleTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
@@ -202,7 +202,7 @@ public class AsyncAtomicLongTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         AsyncAtomicLongTest test = new AsyncAtomicLongTest();
         new TestRunner<AsyncAtomicLongTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
@@ -167,7 +167,7 @@ public class AtomicLongTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         AtomicLongTest test = new AtomicLongTest();
         new TestRunner<AtomicLongTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/atomicreference/AtomicReferenceTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/atomicreference/AtomicReferenceTest.java
@@ -156,7 +156,7 @@ public class AtomicReferenceTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         AtomicReferenceTest test = new AtomicReferenceTest();
         new TestRunner<AtomicReferenceTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
@@ -161,7 +161,7 @@ public class LockTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         LockTest test = new LockTest();
         new TestRunner<LockTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/executor/ExecutorTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/executor/ExecutorTest.java
@@ -161,7 +161,7 @@ public class ExecutorTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         ExecutorTest test = new ExecutorTest();
         new TestRunner<ExecutorTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
@@ -176,7 +176,7 @@ public class BatchingICacheTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         PerformanceICacheTest test = new PerformanceICacheTest();
         new TestRunner<PerformanceICacheTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
@@ -164,7 +164,7 @@ public class CasICacheTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         CasICacheTest test = new CasICacheTest();
         new TestRunner<CasICacheTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
@@ -209,7 +209,7 @@ public class EntryProcessorICacheTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         EntryProcessorICacheTest test = new EntryProcessorICacheTest();
         new TestRunner<EntryProcessorICacheTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
@@ -186,7 +186,7 @@ public class ExpiryICacheTest {
         log.info(basename + "usedOfMax = " + usedOfMax + "%");
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         new TestRunner<ExpiryICacheTest>(new ExpiryICacheTest()).run();
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
@@ -155,7 +155,7 @@ public class PerformanceICacheTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         PerformanceICacheTest test = new PerformanceICacheTest();
         new TestRunner<PerformanceICacheTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
@@ -199,7 +199,7 @@ public class StringICacheTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         StringICacheTest test = new StringICacheTest();
         test.writePercentage = 10;
         new TestRunner<StringICacheTest>(test).run();

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/GrowingMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/GrowingMapTest.java
@@ -150,7 +150,7 @@ public class GrowingMapTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         GrowingMapTest test = new GrowingMapTest();
         new TestRunner<GrowingMapTest>(test).withDuration(30).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
@@ -142,7 +142,7 @@ public class IntIntMapTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         IntIntMapTest test = new IntIntMapTest();
         new TestRunner<IntIntMapTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapAsyncOpsTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapAsyncOpsTest.java
@@ -123,7 +123,7 @@ public class MapAsyncOpsTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         new TestRunner<MapAsyncOpsTest>(new MapAsyncOpsTest()).run();
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapCasTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapCasTest.java
@@ -118,7 +118,7 @@ public class MapCasTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         MapCasTest test = new MapCasTest();
         new TestRunner<MapCasTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapEntryProcessorTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapEntryProcessorTest.java
@@ -136,7 +136,7 @@ public class MapEntryProcessorTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         MapEntryProcessorTest test = new MapEntryProcessorTest();
         new TestRunner<MapEntryProcessorTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapEntryProcessorTest2.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapEntryProcessorTest2.java
@@ -138,7 +138,7 @@ public class MapEntryProcessorTest2 {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         MapEntryProcessorTest2 test = new MapEntryProcessorTest2();
         new TestRunner<MapEntryProcessorTest2>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapLongPerformanceTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapLongPerformanceTest.java
@@ -103,7 +103,7 @@ public class MapLongPerformanceTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         MapLongPerformanceTest test = new MapLongPerformanceTest();
         new TestRunner<MapLongPerformanceTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapRaceTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapRaceTest.java
@@ -107,7 +107,7 @@ public class MapRaceTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         MapRaceTest test = new MapRaceTest();
         new TestRunner<MapRaceTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTTLSaturationTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTTLSaturationTest.java
@@ -138,7 +138,7 @@ public class MapTTLSaturationTest {
         log.info(basename + "usedOfMax = " + usedOfMax + "%");
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         Config config = new Config();
         config.addMapConfig(new MapConfig("mapttlsaturation*").setBackupCount(0).setStatisticsEnabled(false));
         HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
@@ -140,7 +140,7 @@ public class MapTimeToLiveTest {
     }
 
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         new TestRunner<MapAsyncOpsTest>(new MapAsyncOpsTest()).run();
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
@@ -176,7 +176,7 @@ public class MapTransactionReadWriteTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         MapTransactionReadWriteTest test = new MapTransactionReadWriteTest();
         new TestRunner<MapTransactionReadWriteTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
@@ -182,7 +182,7 @@ public class StringStringMapTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         StringStringMapTest test = new StringStringMapTest();
         new TestRunner<StringStringMapTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapLatencyTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapLatencyTest.java
@@ -92,7 +92,7 @@ public class MapLatencyTest extends AbstractMapTest {
         return baseRunWithWorker(operationType);
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         new TestRunner<MapLatencyTest>(new MapLatencyTest()).run();
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapResultSizeLimitTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapResultSizeLimitTest.java
@@ -85,7 +85,7 @@ public class MapResultSizeLimitTest extends AbstractMapTest {
         return baseRunWithWorker(operationType);
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         new TestRunner<MapResultSizeLimitTest>(new MapResultSizeLimitTest()).run();
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/misc/FailingTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/misc/FailingTest.java
@@ -44,7 +44,7 @@ public class FailingTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         FailingTest test = new FailingTest();
         new TestRunner<FailingTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/queue/ProducerConsumerTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/queue/ProducerConsumerTest.java
@@ -151,7 +151,7 @@ public class ProducerConsumerTest {
     static class Work implements Serializable {
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         ProducerConsumerTest test = new ProducerConsumerTest();
         new TestRunner<ProducerConsumerTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/queue/QueueTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/queue/QueueTest.java
@@ -131,7 +131,7 @@ public class QueueTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         QueueTest test = new QueueTest();
         new TestRunner<QueueTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/queue/TxnQueueWithLockTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/queue/TxnQueueWithLockTest.java
@@ -114,7 +114,7 @@ public class TxnQueueWithLockTest {
         //assertEquals(total.committed - total.rolled, queue.size());
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         TxnQueueWithLockTest test = new TxnQueueWithLockTest();
         new TestRunner<TxnQueueWithLockTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/slow/SlowOperationMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/slow/SlowOperationMapTest.java
@@ -220,7 +220,7 @@ public class SlowOperationMapTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         SlowOperationMapTest test = new SlowOperationMapTest();
         new TestRunner<SlowOperationMapTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/special/InvocationLatencyTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/special/InvocationLatencyTest.java
@@ -129,7 +129,7 @@ public class InvocationLatencyTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         InvocationLatencyTest test = new InvocationLatencyTest();
         new TestRunner<InvocationLatencyTest>(test).withDuration(5).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticTest.java
@@ -236,7 +236,7 @@ public class SyntheticTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         SyntheticTest test = new SyntheticTest();
         new TestRunner<SyntheticTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -124,7 +124,7 @@ public class StringStringSyntheticMapTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         StringStringSyntheticMapTest test = new StringStringSyntheticMapTest();
         new TestRunner<StringStringSyntheticMapTest>(test).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/topic/ITopicTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/topic/ITopicTest.java
@@ -175,7 +175,7 @@ public class ITopicTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         ITopicTest test = new ITopicTest();
         new TestRunner<ITopicTest>(test).withDuration(10).run();
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/webContainer/TomCatContainerTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/webContainer/TomCatContainerTest.java
@@ -8,7 +8,6 @@ import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
-import static org.junit.Assert.assertEquals;
 
 
 /*
@@ -40,7 +39,7 @@ public class TomCatContainerTest {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) throws Exception {
         TomCatContainerTest test = new TomCatContainerTest();
         new TestRunner<TomCatContainerTest>(test).run();
     }

--- a/tests/src/test/java/com/hazelcast/simulator/tests/map/MapCasTestTest.java
+++ b/tests/src/test/java/com/hazelcast/simulator/tests/map/MapCasTestTest.java
@@ -4,8 +4,9 @@ import com.hazelcast.simulator.test.TestRunner;
 import org.junit.Test;
 
 public class MapCasTestTest {
+
     @Test
-    public void test() throws Throwable {
+    public void test() throws Exception {
         MapCasTest test = new MapCasTest();
         new TestRunner<MapCasTest>(test).withDuration(10).run();
     }

--- a/tests/src/test/java/com/hazelcast/simulator/tests/map/MapRaceTestTest.java
+++ b/tests/src/test/java/com/hazelcast/simulator/tests/map/MapRaceTestTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 public class MapRaceTestTest {
 
     @Test(expected = AssertionError.class)
-    public void test() throws Throwable {
+    public void test() throws Exception {
         MapRaceTest test = new MapRaceTest();
         new TestRunner<MapRaceTest>(test).withDuration(10).run();
     }

--- a/utils/src/main/java/com/hazelcast/simulator/utils/ReflectionUtils.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/ReflectionUtils.java
@@ -20,6 +20,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import static java.lang.String.format;
+
 public final class ReflectionUtils {
 
     private ReflectionUtils() {
@@ -32,7 +34,7 @@ public final class ReflectionUtils {
     }
 
     @SuppressWarnings("unchecked")
-    public static <E> E invokeMethod(Object classInstance, Method method, Object... args) throws Throwable {
+    public static <E> E invokeMethod(Object classInstance, Method method, Object... args) throws Exception {
         if (method == null) {
             return null;
         }
@@ -40,7 +42,14 @@ public final class ReflectionUtils {
         try {
             return (E) method.invoke(classInstance, args);
         } catch (InvocationTargetException e) {
-            throw e.getCause();
+            if (e.getCause() instanceof Error) {
+                throw (Error) e.getCause();
+            }
+            if (e.getCause() instanceof Exception) {
+                throw (Exception) e.getCause();
+            }
+            throw new RuntimeException(format("Error while invoking method %s on instance of type %s",
+                    method.getName(), classInstance.getClass().getSimpleName()), e.getCause());
         }
     }
 

--- a/utils/src/test/java/com/hazelcast/simulator/utils/ReflectionUtilsTest.java
+++ b/utils/src/test/java/com/hazelcast/simulator/utils/ReflectionUtilsTest.java
@@ -47,12 +47,12 @@ public class ReflectionUtilsTest {
     }
 
     @Test()
-    public void testInvokeMethodNull() throws Throwable {
+    public void testInvokeMethodNull() throws Exception {
         assertNull(invokeMethod(new InvokeMethodTest(), null));
     }
 
     @Test
-    public void testInvokeMethod() throws Throwable {
+    public void testInvokeMethod() throws Exception {
         assertFalse(InvokeMethodTest.hasBeenInvoked);
 
         Method method = getMethodByName(InvokeMethodTest.class, "testMethod");
@@ -62,13 +62,13 @@ public class ReflectionUtilsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testInvokeMethodThrowsException() throws Throwable {
+    public void testInvokeMethodThrowsException() throws Exception {
         Method method = getMethodByName(InvokeMethodTest.class, "throwExceptionMethod");
         invokeMethod(new InvokeMethodTest(), method);
     }
 
     @Test(expected = IllegalAccessException.class)
-    public void testInvokeMethodPrivate() throws Throwable {
+    public void testInvokeMethodPrivate() throws Exception {
         Method method = getMethodByName(InvokeMethodTest.class, "cannotAccessMethod");
         invokeMethod(new InvokeMethodTest(), method);
     }


### PR DESCRIPTION
Got rid of all `throws Throwable` by casting to `Error` or `Exception` if possible or creating a `RuntimeException`.