### PR TITLE
Confusing message removed.

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -161,8 +161,6 @@ public class TestCaseRunner {
                             R combinedValue = combinedResults.get(probeName);
                             combinedValue = currentResult.combine(combinedValue);
                             combinedResults.put(probeName, combinedValue);
-                        } else {
-                            LOGGER.warn("Probe " + probeName + " has null value for some member. This should not happen.");
                         }
                     }
                 }


### PR DESCRIPTION
Fixing #402

A member can actually report NULL as its output - it's perfectly fine - just imagine you have more agents than configured test members.