### PR TITLE
Fixed warning during build of missing dist jar.

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>dist</artifactId>
     <name>Hazelcast Simulator Distribution</name>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
 
     <parent>
         <groupId>com.hazelcast.simulator</groupId>

--- a/dist/src/main/config/build-distribution-archive.xml
+++ b/dist/src/main/config/build-distribution-archive.xml
@@ -25,6 +25,7 @@
     <dependencySets>
         <dependencySet>
             <outputDirectory>/lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
There is no content in the JAR of the dist module, all files are determined in the maven assembly configuration. So it's not an error that it can't be included, it's not necessary.