### PR TITLE
SqlPredicateTest has a global warm-up

### DIFF
--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
@@ -55,7 +55,7 @@ public class SqlPredicateTest {
         LOGGER.info(getOperationCountInformation(targetInstance));
     }
 
-    @Warmup(global = false)
+    @Warmup(global = true)
     public void warmup() throws InterruptedException {
         Random random = new Random();
         MapStreamer<String, DataSerializableEmployee> streamer = new MapStreamer<String, DataSerializableEmployee>(map);


### PR DESCRIPTION
It yields the same result, but it's much faster
as just a single worker push the initial data.