### PR TITLE
Cleanup MapTimeToLiveTest.

### DIFF
--- a/dist/src/main/dist/simulator-tests/test.properties
+++ b/dist/src/main/dist/simulator-tests/test.properties
@@ -67,8 +67,8 @@ MapTTL@putAsyncTTLProb=0
 MapTTL@getProb=0.2
 MapTTL@getAsyncProb=0.1
 MapTTL@destroyProb=0.0
-MapTTL@maxTTLExpireyMs=3000
-MapTTL@minTTLExpireyMs=1
+MapTTL@maxTTLExpiryMs=3000
+MapTTL@minTTLExpiryMs=1
 MapTTL@basename=MapTTL
 
 MapEntryProc@class=com.hazelcast.simulator.tests.map.MapEntryProcessorTest

--- a/dist/src/main/dist/tests/map/map-time-to-live.properties
+++ b/dist/src/main/dist/tests/map/map-time-to-live.properties
@@ -3,4 +3,4 @@ ttlSeconds=1
 threadCount=3
 putIntervalMillis=10
 waitAfterMillis=2000
-basename=map
+basename=MapTTL

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
@@ -22,123 +22,144 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
-import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.tests.map.helpers.MapOperationCounter;
 import com.hazelcast.simulator.utils.AssertTask;
-import com.hazelcast.simulator.utils.ThreadSpawner;
+import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
+import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
+import com.hazelcast.util.EmptyStatement;
 
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.simulator.utils.TestUtils.assertTrueEventually;
 import static org.junit.Assert.assertEquals;
 
 /**
- * In this test we are using map put methods with an Expire time.
- * we put keys at random into the map using sync and async methods with some proablity distribution
- * in the end we verify that the map is empty and all key value pairs have expired out of the map
+ * In this test we are using map put methods with an expire time.
+ *
+ * We put keys at random into the map using sync and async methods with some probability distribution.
+ * In the end we verify that the map is empty and all key value pairs have expired out of the map.
  */
 public class MapTimeToLiveTest {
 
     private static final ILogger LOGGER = Logger.getLogger(MapTimeToLiveTest.class);
 
+    private enum Operation {
+        PUT_TTL,
+        ASYNC_PUT_TTL,
+        GET,
+        ASYNC_GET,
+        DESTROY
+    }
+
     // properties
     public String basename = this.getClass().getSimpleName();
-    public int threadCount = 3;
     public int keyCount = 10;
 
-    // check these add up to 1
     public double putTTLProb = 0.4;
     public double putAsyncTTLProb = 0.3;
     public double getProb = 0.2;
     public double getAsyncProb = 0.1;
     public double destroyProb = 0.0;
 
-    public int maxTTLExpireyMs = 3000;
-    public int minTTLExpireyMs = 1;
+    public int maxTTLExpiryMs = 3000;
+    public int minTTLExpiryMs = 1;
 
-    private TestContext testContext;
-    private HazelcastInstance targetInstance;
+    private final OperationSelectorBuilder<Operation> builder = new OperationSelectorBuilder<Operation>();
+
+    private IMap<Integer, Integer> map;
+    private IList<MapOperationCounter> results;
 
     @Setup
     public void setup(TestContext testContext) throws Exception {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
-    }
+        HazelcastInstance targetInstance = testContext.getTargetInstance();
+        map = targetInstance.getMap(basename);
+        results = targetInstance.getList(basename + "report");
 
-    @Run
-    public void run() {
-        ThreadSpawner spawner = new ThreadSpawner(testContext.getTestId());
-        for (int k = 0; k < threadCount; k++) {
-            spawner.spawn(new Worker());
-        }
-        spawner.awaitCompletion();
-    }
-
-    private class Worker implements Runnable {
-        private MapOperationCounter count = new MapOperationCounter();
-        private final Random random = new Random();
-
-        @Override
-        public void run() {
-            while (!testContext.isStopped()) {
-                try {
-                    final int key = random.nextInt(keyCount);
-                    final IMap map = targetInstance.getMap(basename);
-
-                    double chance = random.nextDouble();
-                    if ((chance -= putTTLProb) < 0) {
-                        final Object value = random.nextInt();
-                        int delayMs = minTTLExpireyMs + random.nextInt(maxTTLExpireyMs);
-                        map.put(key, value, delayMs, TimeUnit.MILLISECONDS);
-                        count.putTTLCount.incrementAndGet();
-                    } else if ((chance -= putAsyncTTLProb) < 0) {
-                        final Object value = random.nextInt();
-                        int delayMs = minTTLExpireyMs + random.nextInt(maxTTLExpireyMs);
-                        map.putAsync(key, value, delayMs, TimeUnit.MILLISECONDS);
-                        count.putAsyncTTLCount.incrementAndGet();
-                    } else if ((chance -= getProb) < 0) {
-                        map.get(key);
-                        count.getCount.incrementAndGet();
-                    } else if ((chance -= getAsyncProb) < 0) {
-                        map.getAsync(key);
-                        count.getAsyncCount.incrementAndGet();
-                    } else if ((chance -= destroyProb) <= 0) {
-                        map.destroy();
-                        count.destroyCount.incrementAndGet();
-                    }
-
-                } catch (DistributedObjectDestroyedException e) {
-                }
-            }
-            IList<MapOperationCounter> results = targetInstance.getList(basename + "report");
-            results.add(count);
-        }
+        builder.addOperation(Operation.PUT_TTL, putTTLProb)
+                .addOperation(Operation.ASYNC_PUT_TTL, putAsyncTTLProb)
+                .addOperation(Operation.GET, getProb)
+                .addOperation(Operation.ASYNC_GET, getAsyncProb)
+                .addOperation(Operation.DESTROY, destroyProb);
     }
 
     @Verify(global = true)
     public void globalVerify() throws Exception {
-
-        IList<MapOperationCounter> results = targetInstance.getList(basename + "report");
         MapOperationCounter total = new MapOperationCounter();
-        for (MapOperationCounter i : results) {
-            total.add(i);
+        for (MapOperationCounter counter : results) {
+            total.add(counter);
         }
         LOGGER.info(basename + ": " + total + " total of " + results.size());
-
-        final IMap map = targetInstance.getMap(basename);
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(basename + ": Map Size not 0, some TTL events not processed", 0, map.size());
+                assertEquals(basename + ": Map should be empty, some TTL events are not processed", 0, map.size());
             }
         });
     }
 
+    @RunWithWorker
+    public Worker createWorker() {
+        return new Worker();
+    }
+
+    private class Worker extends AbstractWorker<Operation> {
+
+        private final MapOperationCounter count = new MapOperationCounter();
+
+        public Worker() {
+            super(builder);
+        }
+
+        @Override
+        protected void timeStep(Operation operation) {
+            try {
+                int key = randomInt(keyCount);
+                int value;
+                int delayMs;
+
+                switch (operation) {
+                    case PUT_TTL:
+                        value = randomInt();
+                        delayMs = minTTLExpiryMs + randomInt(maxTTLExpiryMs);
+                        map.put(key, value, delayMs, TimeUnit.MILLISECONDS);
+                        count.putTTLCount.incrementAndGet();
+                        break;
+                    case ASYNC_PUT_TTL:
+                        value = randomInt();
+                        delayMs = minTTLExpiryMs + randomInt(maxTTLExpiryMs);
+                        map.putAsync(key, value, delayMs, TimeUnit.MILLISECONDS);
+                        count.putAsyncTTLCount.incrementAndGet();
+                        break;
+                    case GET:
+                        map.get(key);
+                        count.getCount.incrementAndGet();
+                        break;
+                    case ASYNC_GET:
+                        map.getAsync(key);
+                        count.getAsyncCount.incrementAndGet();
+                        break;
+                    case DESTROY:
+                        map.destroy();
+                        count.destroyCount.incrementAndGet();
+                        break;
+                    default:
+                        throw new UnsupportedOperationException();
+                }
+            } catch (DistributedObjectDestroyedException e) {
+                EmptyStatement.ignore(e);
+            }
+        }
+
+        @Override
+        protected void afterRun() {
+            results.add(count);
+        }
+    }
 
     public static void main(String[] args) throws Exception {
         new TestRunner<MapAsyncOpsTest>(new MapAsyncOpsTest()).run();


### PR DESCRIPTION
Test was chosen because of:
```
MapTimeToLiveTest.java:93:33: Inner assignments should be avoided.
MapTimeToLiveTest.java:98:40: Inner assignments should be avoided.
MapTimeToLiveTest.java:103:40: Inner assignments should be avoided.
MapTimeToLiveTest.java:106:40: Inner assignments should be avoided.
MapTimeToLiveTest.java:109:40: Inner assignments should be avoided.
MapTimeToLiveTest.java:114:65: Must have at least one statement.
```