### PR TITLE
Cleanup of MangleICacheTest.

### DIFF
--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
@@ -10,19 +10,17 @@ import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
-import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.utils.ThreadSpawner;
-import com.hazelcast.simulator.worker.selector.OperationSelector;
+import com.hazelcast.simulator.tests.icache.helpers.ICacheOperationCounter;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
+import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
 import javax.cache.Cache;
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
-import java.io.Serializable;
-import java.util.Random;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
 
@@ -49,7 +47,7 @@ public class MangleICacheTest {
 
     private static final ILogger LOGGER = Logger.getLogger(MangleICacheTest.class);
 
-    public int threadCount = 3;
+    public String basename = MangleICacheTest.class.getSimpleName();
     public int maxCaches = 100;
 
     public double createCacheManagerProb = 0.1;
@@ -60,176 +58,200 @@ public class MangleICacheTest {
     public double putCacheProb = 0.3;
     public double closeCacheProb = 0.1;
 
-    private TestContext testContext;
-    private HazelcastInstance targetInstance;
-    private String basename;
+    private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
+    private HazelcastInstance targetInstance;
+    private IList<ICacheOperationCounter> results;
 
     @Setup
     public void setup(TestContext testContext) throws Exception {
-        this.testContext = testContext;
         targetInstance = testContext.getTargetInstance();
-        basename = testContext.getTestId();
+        results = targetInstance.getList(basename);
 
         operationSelectorBuilder.addOperation(Operation.CREATE_CACHE_MANAGER, createCacheManagerProb)
-                                .addOperation(Operation.CLOSE_CACHE_MANAGER, cacheManagerCloseProb)
-                                .addOperation(Operation.CLOSE_CACHING_PROVIDER, cachingProviderCloseProb)
-                                .addOperation(Operation.CREATE_CACHE, createCacheProb)
-                                .addOperation(Operation.DESTROY_CACHE, destroyCacheProb)
-                                .addOperation(Operation.PUT, putCacheProb)
-                                .addOperation(Operation.CLOSE_CACHE, closeCacheProb);
+                .addOperation(Operation.CLOSE_CACHE_MANAGER, cacheManagerCloseProb)
+                .addOperation(Operation.CLOSE_CACHING_PROVIDER, cachingProviderCloseProb)
+                .addOperation(Operation.CREATE_CACHE, createCacheProb)
+                .addOperation(Operation.DESTROY_CACHE, destroyCacheProb)
+                .addOperation(Operation.PUT, putCacheProb)
+                .addOperation(Operation.CLOSE_CACHE, closeCacheProb);
     }
 
-    @Run
-    public void run() {
-        ThreadSpawner spawner = new ThreadSpawner(testContext.getTestId());
-        for (int k = 0; k < threadCount; k++) {
-            spawner.spawn(new Worker());
+    @Verify(global = true)
+    public void verify() throws Exception {
+        ICacheOperationCounter total = new ICacheOperationCounter();
+        for (ICacheOperationCounter counter : results) {
+            total.add(counter);
         }
-        spawner.awaitCompletion();
+        LOGGER.info(basename + ": " + total + " from " + results.size() + " worker threads");
     }
 
-    private class Worker implements Runnable {
-        private final OperationSelector<Operation> selector = operationSelectorBuilder.build();
-        private final Random random = new Random();
+    @RunWithWorker
+    public Worker createWorker() {
+        return new Worker();
+    }
+
+    private class Worker extends AbstractWorker<Operation> {
+
         private final CacheConfig config = new CacheConfig();
-        private final Counter counter = new Counter();
+        private final ICacheOperationCounter counter = new ICacheOperationCounter();
 
-        private CacheManager cacheManager = null;
+        private CacheManager cacheManager;
 
-        public void run() {
+        public Worker() {
+            super(operationSelectorBuilder);
             config.setName(basename);
-            createCacheManager();
-
-            while (!testContext.isStopped()) {
-                int cacheNumber = random.nextInt(maxCaches);
-
-                Operation operation = selector.select();
-                switch (operation) {
-                    case CLOSE_CACHING_PROVIDER: {
-                        try {
-                            CachingProvider provider = cacheManager.getCachingProvider();
-                            if (provider != null) {
-                                provider.close();
-                                counter.cachingProviderClose++;
-                            }
-                        } catch (CacheException e) {
-                            counter.cachingProviderCloseException++;
-                        }
-                        break;
-                    }
-                    case CREATE_CACHE_MANAGER: {
-                        try {
-                            createCacheManager();
-                            counter.createCacheManager++;
-
-                        } catch (CacheException e) {
-                            counter.createCacheManagerException++;
-
-                        }
-                        break;
-                    }
-                    case CLOSE_CACHE_MANAGER: {
-                        try {
-                            cacheManager.close();
-                            counter.cacheManagerClose++;
-
-                        } catch (CacheException e) {
-                            counter.cacheManagerCloseException++;
-
-                        }
-                        break;
-                    }
-                    case CREATE_CACHE: {
-                        try {
-                            cacheManager.createCache(basename + cacheNumber, config);
-                            counter.create++;
-
-                        } catch (CacheException e) {
-                            counter.createException++;
-
-                        } catch (IllegalStateException e) {
-                            counter.createException++;
-
-                        }
-                        break;
-                    }
-                    case CLOSE_CACHE: {
-                        Cache cache = getCacheIfExists(cacheNumber);
-                        try {
-                            if (cache != null) {
-                                cache.close();
-                                counter.cacheClose++;
-                            }
-                        } catch (CacheException e) {
-                            counter.cacheCloseException++;
-
-                        } catch (IllegalStateException e) {
-                            counter.cacheCloseException++;
-
-                        }
-                        break;
-                    }
-                    case DESTROY_CACHE: {
-                        try {
-                            cacheManager.destroyCache(basename + cacheNumber);
-                            counter.destroy++;
-
-                        } catch (CacheException e) {
-                            counter.destroyException++;
-
-                        } catch (IllegalStateException e) {
-                            counter.destroyException++;
-
-                        }
-                        break;
-                    }
-                    case PUT: {
-                        Cache<Integer, Integer> cache = getCacheIfExists(cacheNumber);
-                        try {
-                            if (cache != null) {
-                                cache.put(random.nextInt(), random.nextInt());
-                                counter.put++;
-                            }
-                        } catch (CacheException e) {
-                            counter.getPutException++;
-
-                        } catch (IllegalStateException e) {
-                            counter.getPutException++;
-
-                        }
-                        break;
-                    }
-                }
-            }
-            targetInstance.getList(basename).add(counter);
+            createNewCacheManager();
         }
 
-        public void createCacheManager() {
+        @Override
+        protected void timeStep(Operation operation) {
+            switch (operation) {
+                case CLOSE_CACHING_PROVIDER:
+                    closeCachingProvider();
+                    break;
+                case CREATE_CACHE_MANAGER:
+                    createCacheManager();
+                    break;
+                case CLOSE_CACHE_MANAGER:
+                    closeCacheManager();
+                    break;
+                case CREATE_CACHE:
+                    createCache();
+                    break;
+                case CLOSE_CACHE:
+                    closeCache();
+                    break;
+                case DESTROY_CACHE:
+                    destroyCache();
+                    break;
+                case PUT:
+                    put();
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        private void closeCachingProvider() {
+            try {
+                CachingProvider provider = cacheManager.getCachingProvider();
+                if (provider != null) {
+                    provider.close();
+                    counter.cachingProviderClose++;
+                }
+            } catch (CacheException e) {
+                counter.cachingProviderCloseException++;
+            }
+        }
+
+        private void createCacheManager() {
+            try {
+                createNewCacheManager();
+                counter.createCacheManager++;
+            } catch (CacheException e) {
+                counter.createCacheManagerException++;
+            }
+        }
+
+        private void closeCacheManager() {
+            try {
+                cacheManager.close();
+                counter.cacheManagerClose++;
+            } catch (CacheException e) {
+                counter.cacheManagerCloseException++;
+            }
+        }
+
+        private void createCache() {
+            try {
+                int cacheNumber = randomInt(maxCaches);
+                cacheManager.createCache(basename + cacheNumber, config);
+                counter.create++;
+            } catch (CacheException e) {
+                counter.createException++;
+            } catch (IllegalStateException e) {
+                counter.createException++;
+            }
+        }
+
+        private void closeCache() {
+            int cacheNumber = randomInt(maxCaches);
+            Cache cache = getCacheIfExists(cacheNumber);
+            try {
+                if (cache != null) {
+                    cache.close();
+                    counter.cacheClose++;
+                }
+            } catch (CacheException e) {
+                counter.cacheCloseException++;
+            } catch (IllegalStateException e) {
+                counter.cacheCloseException++;
+            }
+        }
+
+        private void destroyCache() {
+            try {
+                int cacheNumber = randomInt(maxCaches);
+                cacheManager.destroyCache(basename + cacheNumber);
+                counter.destroy++;
+            } catch (CacheException e) {
+                counter.destroyException++;
+            } catch (IllegalStateException e) {
+                counter.destroyException++;
+            }
+        }
+
+        private void put() {
+            int cacheNumber = randomInt(maxCaches);
+            Cache<Integer, Integer> cache = getCacheIfExists(cacheNumber);
+            try {
+                if (cache != null) {
+                    cache.put(randomInt(), randomInt());
+                    counter.put++;
+                }
+            } catch (CacheException e) {
+                counter.getPutException++;
+            } catch (IllegalStateException e) {
+                counter.getPutException++;
+            }
+        }
+
+        @Override
+        protected void afterRun() {
+            results.add(counter);
+        }
+
+        private void createNewCacheManager() {
             CachingProvider currentCachingProvider = null;
             if (cacheManager != null) {
                 currentCachingProvider = cacheManager.getCachingProvider();
                 cacheManager.close();
             }
             if (isMemberNode(targetInstance)) {
-                HazelcastServerCachingProvider hcp = (HazelcastServerCachingProvider) currentCachingProvider;
-                if (hcp == null) {
-                    hcp = new HazelcastServerCachingProvider();
-                }
-                cacheManager = new HazelcastServerCacheManager(hcp, targetInstance, hcp.getDefaultURI(),
-                        hcp.getDefaultClassLoader(), null);
+                cacheManager = createServerCacheManager((HazelcastServerCachingProvider) currentCachingProvider);
             } else {
-                HazelcastClientCachingProvider hcp = (HazelcastClientCachingProvider) currentCachingProvider;
-                if (hcp == null) {
-                    hcp = new HazelcastClientCachingProvider();
-                }
-                cacheManager = new HazelcastClientCacheManager(hcp, targetInstance, hcp.getDefaultURI(),
-                        hcp.getDefaultClassLoader(), null);
+                cacheManager = createClientCacheManager((HazelcastClientCachingProvider) currentCachingProvider);
             }
         }
 
-        public Cache<Integer, Integer> getCacheIfExists(int cacheNumber) {
+        private HazelcastServerCacheManager createServerCacheManager(HazelcastServerCachingProvider currentCachingProvider) {
+            HazelcastServerCachingProvider hcp = currentCachingProvider;
+            if (hcp == null) {
+                hcp = new HazelcastServerCachingProvider();
+            }
+            return new HazelcastServerCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
+        }
+
+        private HazelcastClientCacheManager createClientCacheManager(HazelcastClientCachingProvider currentCachingProvider) {
+            HazelcastClientCachingProvider hcp = currentCachingProvider;
+            if (hcp == null) {
+                hcp = new HazelcastClientCachingProvider();
+            }
+            return new HazelcastClientCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
+        }
+
+        private Cache<Integer, Integer> getCacheIfExists(int cacheNumber) {
             try {
                 Cache<Integer, Integer> cache = cacheManager.getCache(basename + cacheNumber);
                 counter.getCache++;
@@ -240,87 +262,8 @@ public class MangleICacheTest {
 
             } catch (IllegalStateException e) {
                 counter.getCacheException++;
-
             }
             return null;
-        }
-    }
-
-    @Verify(global = true)
-    public void verify() throws Exception {
-        IList<Counter> counters = targetInstance.getList(basename);
-        Counter total = new Counter();
-        for (Counter c : counters) {
-            total.add(c);
-        }
-        LOGGER.info(basename + ": " + total + " from " + counters.size() + " worker threads");
-    }
-
-    static class Counter implements Serializable {
-
-        public long createCacheManager = 0;
-        public long createCacheManagerException = 0;
-
-        public long getCache = 0;
-        public long put = 0;
-        public long create = 0;
-        public long destroy = 0;
-        public long cacheClose = 0;
-
-        public long getCacheException = 0;
-        public long getPutException = 0;
-        public long createException = 0;
-        public long destroyException = 0;
-        public long cacheCloseException = 0;
-
-        public long cacheManagerClose = 0;
-        public long cachingProviderClose = 0;
-
-        public long cacheManagerCloseException = 0;
-        public long cachingProviderCloseException = 0;
-
-        public void add(Counter c) {
-
-            createCacheManager += c.createCacheManager;
-            createCacheManagerException += c.createCacheManagerException;
-
-            getCache += c.getCache;
-            put += c.put;
-            create += c.create;
-            destroy += c.destroy;
-            cacheClose += c.cacheClose;
-
-            getCacheException += c.getCacheException;
-            getPutException += c.getPutException;
-            createException += c.createException;
-            destroyException += c.destroyException;
-            cacheCloseException += c.cacheCloseException;
-
-            cacheManagerClose += c.cacheManagerClose;
-            cachingProviderClose += c.cachingProviderClose;
-            cacheManagerCloseException += c.cacheManagerCloseException;
-            cachingProviderCloseException += c.cachingProviderCloseException;
-        }
-
-        public String toString() {
-            return "Counter{"
-                    + "createCacheManager=" + createCacheManager
-                    + ", createCacheManagerException=" + createCacheManagerException
-                    + ", getCache=" + getCache
-                    + ", put=" + put
-                    + ", create=" + create
-                    + ", destroy=" + destroy
-                    + ", cacheClose=" + cacheClose
-                    + ", getCacheException=" + getCacheException
-                    + ", getPutException=" + getPutException
-                    + ", createException=" + createException
-                    + ", destroyException=" + destroyException
-                    + ", cacheCloseException=" + cacheCloseException
-                    + ", cacheManagerClose=" + cacheManagerClose
-                    + ", cachingProviderClose=" + cachingProviderClose
-                    + ", cacheManagerCloseException=" + cacheManagerCloseException
-                    + ", cachingProviderCloseException=" + cachingProviderCloseException
-                    + '}';
         }
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheOperationCounter.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheOperationCounter.java
@@ -1,0 +1,70 @@
+package com.hazelcast.simulator.tests.icache.helpers;
+
+import java.io.Serializable;
+
+public final class ICacheOperationCounter implements Serializable {
+
+    public long createCacheManager;
+    public long createCacheManagerException;
+
+    public long getCache;
+    public long put;
+    public long create;
+    public long destroy;
+    public long cacheClose;
+
+    public long getCacheException;
+    public long getPutException;
+    public long createException;
+    public long destroyException;
+    public long cacheCloseException;
+
+    public long cacheManagerClose;
+    public long cachingProviderClose;
+
+    public long cacheManagerCloseException;
+    public long cachingProviderCloseException;
+
+    public void add(ICacheOperationCounter counter) {
+        createCacheManager += counter.createCacheManager;
+        createCacheManagerException += counter.createCacheManagerException;
+
+        getCache += counter.getCache;
+        put += counter.put;
+        create += counter.create;
+        destroy += counter.destroy;
+        cacheClose += counter.cacheClose;
+
+        getCacheException += counter.getCacheException;
+        getPutException += counter.getPutException;
+        createException += counter.createException;
+        destroyException += counter.destroyException;
+        cacheCloseException += counter.cacheCloseException;
+
+        cacheManagerClose += counter.cacheManagerClose;
+        cachingProviderClose += counter.cachingProviderClose;
+        cacheManagerCloseException += counter.cacheManagerCloseException;
+        cachingProviderCloseException += counter.cachingProviderCloseException;
+    }
+
+    public String toString() {
+        return "ICacheOperationCounter{"
+                + "createCacheManager=" + createCacheManager
+                + ", createCacheManagerException=" + createCacheManagerException
+                + ", getCache=" + getCache
+                + ", put=" + put
+                + ", create=" + create
+                + ", destroy=" + destroy
+                + ", cacheClose=" + cacheClose
+                + ", getCacheException=" + getCacheException
+                + ", getPutException=" + getPutException
+                + ", createException=" + createException
+                + ", destroyException=" + destroyException
+                + ", cacheCloseException=" + cacheCloseException
+                + ", cacheManagerClose=" + cacheManagerClose
+                + ", cachingProviderClose=" + cachingProviderClose
+                + ", cacheManagerCloseException=" + cacheManagerCloseException
+                + ", cachingProviderCloseException=" + cachingProviderCloseException
+                + '}';
+    }
+}


### PR DESCRIPTION
Test was chosen because of:
```
MangleICacheTest.java:101:9: Cyclomatic Complexity is 23 (max allowed is 12).
MangleICacheTest.java:101:9: Method length is 91 lines (max allowed is 60).
MangleICacheTest.java:101:9: NPath Complexity is 434 (max allowed is 50).
MangleICacheTest.java:109:17: switch without "default" clause.
MangleICacheTest.java:110:50: Avoid nested blocks.
MangleICacheTest.java:122:48: Avoid nested blocks.
MangleICacheTest.java:133:47: Avoid nested blocks.
MangleICacheTest.java:144:40: Avoid nested blocks.
MangleICacheTest.java:158:39: Avoid nested blocks.
MangleICacheTest.java:174:41: Avoid nested blocks.
MangleICacheTest.java:188:31: Avoid nested blocks.
```