### PR TITLE
Cleanup of AddRemoveListenerICacheTest.

### DIFF
--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
@@ -15,8 +15,8 @@ import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
-import com.hazelcast.simulator.tests.icache.helpers.MyCacheEntryEventFilter;
-import com.hazelcast.simulator.tests.icache.helpers.MyCacheEntryListener;
+import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryEventFilter;
+import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryListener;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 import com.hazelcast.util.EmptyStatement;
 
@@ -68,8 +68,8 @@ public class ListenerICacheTest {
 
     private CacheConfig<Integer, Long> config = new CacheConfig<Integer, Long>();
     private ICache<Integer, Long> cache;
-    private MyCacheEntryListener<Integer, Long> listener;
-    private MyCacheEntryEventFilter<Integer, Long> filter;
+    private ICacheEntryListener<Integer, Long> listener;
+    private ICacheEntryEventFilter<Integer, Long> filter;
 
     @Setup
     public void setup(TestContext textConTx) {
@@ -99,8 +99,8 @@ public class ListenerICacheTest {
     public void warmup() {
         cache = (ICache) cacheManager.getCache(basename);
 
-        listener = new MyCacheEntryListener<Integer, Long>();
-        filter = new MyCacheEntryEventFilter<Integer, Long>();
+        listener = new ICacheEntryListener<Integer, Long>();
+        filter = new ICacheEntryEventFilter<Integer, Long>();
 
         CacheEntryListenerConfiguration<Integer, Long> conf = new MutableCacheEntryListenerConfiguration<Integer, Long>(
                 FactoryBuilder.factoryOf(listener),
@@ -193,9 +193,9 @@ public class ListenerICacheTest {
         }
         LOGGER.info(basename + ": " + total + " from " + results.size() + " worker Threads");
 
-        IList<MyCacheEntryListener> listeners = targetInstance.getList(basename + "listeners");
-        MyCacheEntryListener totalEvents = new MyCacheEntryListener();
-        for (MyCacheEntryListener listener : listeners) {
+        IList<ICacheEntryListener> listeners = targetInstance.getList(basename + "listeners");
+        ICacheEntryListener totalEvents = new ICacheEntryListener();
+        for (ICacheEntryListener listener : listeners) {
             totalEvents.add(listener);
         }
         LOGGER.info(basename + ": totalEvents " + totalEvents);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheEntryEventFilter.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheEntryEventFilter.java
@@ -7,7 +7,7 @@ import javax.cache.event.EventType;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class MyCacheEntryEventFilter<K, V> implements CacheEntryEventFilter<K, V>, Serializable {
+public class ICacheEntryEventFilter<K, V> implements CacheEntryEventFilter<K, V>, Serializable {
 
     private final AtomicLong filtered = new AtomicLong();
 

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheEntryListener.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheEntryListener.java
@@ -8,7 +8,7 @@ import javax.cache.event.CacheEntryUpdatedListener;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class MyCacheEntryListener<K, V> implements CacheEntryCreatedListener<K, V>, CacheEntryRemovedListener<K, V>,
+public class ICacheEntryListener<K, V> implements CacheEntryCreatedListener<K, V>, CacheEntryRemovedListener<K, V>,
         CacheEntryUpdatedListener<K, V>, Serializable {
 
     private AtomicLong created = new AtomicLong();
@@ -21,7 +21,7 @@ public class MyCacheEntryListener<K, V> implements CacheEntryCreatedListener<K, 
         return unExpected.get();
     }
 
-    public void add(MyCacheEntryListener listener) {
+    public void add(ICacheEntryListener listener) {
         created.addAndGet(listener.created.get());
         updated.addAndGet(listener.updated.get());
         removed.addAndGet(listener.removed.get());

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheListenerOperationCounter.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/helpers/ICacheListenerOperationCounter.java
@@ -1,0 +1,30 @@
+package com.hazelcast.simulator.tests.icache.helpers;
+
+import java.io.Serializable;
+
+public final class ICacheListenerOperationCounter implements Serializable {
+
+    public long register;
+    public long registerIllegalArgException;
+    public long deRegister;
+    public long put;
+    public long get;
+
+    public void add(ICacheListenerOperationCounter counter) {
+        register += counter.register;
+        registerIllegalArgException += counter.registerIllegalArgException;
+        deRegister += counter.deRegister;
+        put += counter.put;
+        get += counter.get;
+    }
+
+    public String toString() {
+        return "Counter{"
+                + "register=" + register
+                + ", registerIllegalArgException=" + registerIllegalArgException
+                + ", deRegister=" + deRegister
+                + ", put=" + put
+                + ", get=" + get
+                + '}';
+    }
+}


### PR DESCRIPTION
Test was chosen because of:
```
AddRemoveListenerICacheTest.java:111:29: Inner assignments should be avoided.
AddRemoveListenerICacheTest.java:118:36: Inner assignments should be avoided.
AddRemoveListenerICacheTest.java:122:36: Inner assignments should be avoided.
AddRemoveListenerICacheTest.java:125:36: Inner assignments should be avoided.
```