### PR TITLE
Improved TestRunner to set properties in test object

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorHelper.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorHelper.java
@@ -78,8 +78,9 @@ final class CoordinatorHelper {
     static int getMaxTestCaseIdLength(List<TestCase> testCaseList) {
         int maxLength = Integer.MIN_VALUE;
         for (TestCase testCase : testCaseList) {
-            if (testCase.id != null && !testCase.id.isEmpty() && testCase.id.length() > maxLength) {
-                maxLength = testCase.id.length();
+            String testCaseId = testCase.getId();
+            if (testCaseId != null && !testCaseId.isEmpty() && testCaseId.length() > maxLength) {
+                maxLength = testCaseId.length();
             }
         }
         return (maxLength > 0) ? maxLength : 0;

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestCase.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestCase.java
@@ -24,16 +24,26 @@ import java.util.Map;
 
 public class TestCase implements Serializable {
 
-    public String id;
-
+    private final String id;
     private final Map<String, String> properties = new HashMap<String, String>();
 
-    public String getClassname() {
-        return properties.get("class");
+    public TestCase(String id) {
+        this(id, null);
+    }
+
+    public TestCase(String id, Map<String, String> properties) {
+        this.id = id;
+        if (properties != null) {
+            this.properties.putAll(properties);
+        }
     }
 
     public String getId() {
         return id;
+    }
+
+    public String getClassname() {
+        return properties.get("class");
     }
 
     public String getProperty(String name) {

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestRunner.java
@@ -26,10 +26,12 @@ import org.apache.log4j.Logger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
+import static com.hazelcast.simulator.utils.PropertyBindingSupport.bindProperties;
 import static java.lang.String.format;
 
 /**
@@ -54,11 +56,21 @@ public class TestRunner<E> {
     private HazelcastInstance hazelcastInstance;
 
     public TestRunner(E test) {
+        this(test, null);
+    }
+
+    public TestRunner(E test, Map<String, String> properties) {
         if (test == null) {
             throw new NullPointerException("test can't be null");
         }
 
-        this.testInvoker = new TestContainer<TestContext>(test, testContext, new ProbesConfiguration());
+        TestCase testCase = null;
+        if (properties != null) {
+            testCase = new TestCase("TestRunner", properties);
+            bindProperties(test, testCase, null);
+        }
+
+        this.testInvoker = new TestContainer<TestContext>(test, testContext, new ProbesConfiguration(), testCase);
         this.test = test;
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestSuite.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestSuite.java
@@ -130,8 +130,7 @@ public class TestSuite implements Serializable {
                 ));
             }
 
-            testCase = new TestCase();
-            testCase.id = testCaseId;
+            testCase = new TestCase(testCaseId);
             testCases.put(testCaseId, testCase);
         }
         return testCase;

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
@@ -117,10 +117,6 @@ public class TestContainer<T extends TestContext> {
     private IWorker operationCountWorkerInstance;
     private ThreadSpawner workerThreadSpawner;
 
-    public TestContainer(Object testObject, T testContext, ProbesConfiguration probesConfiguration) {
-        this(testObject, testContext, probesConfiguration, null);
-    }
-
     public TestContainer(Object testObject, T testContext, ProbesConfiguration probesConfiguration, TestCase testCase) {
         if (testObject == null) {
             throw new NullPointerException();

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
@@ -165,7 +165,7 @@ class WorkerCommandRequestProcessor {
 
                 Object testInstance = InitCommand.class.getClassLoader().loadClass(testCase.getClassname()).newInstance();
                 bindProperties(testInstance, testCase, TestContainer.OPTIONAL_TEST_PROPERTIES);
-                TestContextImpl testContext = new TestContextImpl(testCase.id, getHazelcastInstance());
+                TestContextImpl testContext = new TestContextImpl(testCase.getId(), getHazelcastInstance());
                 ProbesConfiguration probesConfiguration = parseProbeConfiguration(testCase);
 
                 tests.put(testContext.getTestId(), new TestContainer<TestContext>(testInstance, testContext, probesConfiguration,
@@ -173,7 +173,7 @@ class WorkerCommandRequestProcessor {
                 testsPending.incrementAndGet();
 
                 if (serverInstance != null) {
-                    serverInstance.getUserContext().put(getUserContextKeyFromTestId(testCase.id), testInstance);
+                    serverInstance.getUserContext().put(getUserContextKeyFromTestId(testCase.getId()), testInstance);
                 }
             } catch (Exception e) {
                 throw e;

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -78,17 +78,15 @@ public class AgentSmokeTest {
 
     @Test
     public void testSuccess() throws Exception {
-        TestCase testCase = new TestCase();
+        TestCase testCase = new TestCase("testSuccess");
         testCase.setProperty("class", SuccessTest.class.getName());
-        testCase.id = "testSuccess";
         executeTestCase(testCase);
     }
 
     @Test
     public void testThrowingFailures() throws Exception {
-        TestCase testCase = new TestCase();
+        TestCase testCase = new TestCase("testThrowingFailures");
         testCase.setProperty("class", FailingTest.class.getName());
-        testCase.id = "testThrowingFailures";
         executeTestCase(testCase);
 
         cooldown();
@@ -97,7 +95,7 @@ public class AgentSmokeTest {
         assertEquals("Expected 1 failure!", 1, failures.size());
 
         Failure failure = failures.get(0);
-        assertEquals("Expected started test to fail", testCase.id, failure.testId);
+        assertEquals("Expected started test to fail", testCase.getId(), failure.testId);
         assertTrue("Expected started test to fail", failure.cause.contains("This test should fail"));
     }
 
@@ -119,18 +117,18 @@ public class AgentSmokeTest {
         agentsClient.executeOnAllWorkers(initTestCommand);
 
         LOGGER.info("Setup phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "setUp"));
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "setUp"));
 
         LOGGER.info("Local warmup phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "localWarmup"));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "localWarmup");
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "localWarmup"));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "localWarmup");
 
         LOGGER.info("Global warmup phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "globalWarmup"));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "globalWarmup");
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "globalWarmup"));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "globalWarmup");
 
         LOGGER.info("Run phase...");
-        RunCommand runCommand = new RunCommand(testCase.id);
+        RunCommand runCommand = new RunCommand(testCase.getId());
         runCommand.clientOnly = false;
         agentsClient.executeOnAllWorkers(runCommand);
 
@@ -139,24 +137,24 @@ public class AgentSmokeTest {
         LOGGER.info("Finished running");
 
         LOGGER.info("Stopping test...");
-        agentsClient.executeOnAllWorkers(new StopCommand(testCase.id));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "stop");
+        agentsClient.executeOnAllWorkers(new StopCommand(testCase.getId()));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "stop");
 
         LOGGER.info("Local verify phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "localVerify"));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "localVerify");
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "localVerify"));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "localVerify");
 
         LOGGER.info("Global verify phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "globalVerify"));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "globalVerify");
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "globalVerify"));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "globalVerify");
 
         LOGGER.info("Global teardown phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "globalTeardown"));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "globalTeardown");
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "globalTeardown"));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "globalTeardown");
 
         LOGGER.info("Local teardown phase...");
-        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.id, "localTeardown"));
-        agentsClient.waitForPhaseCompletion("", testCase.id, "localTeardown");
+        agentsClient.executeOnAllWorkers(new GenericCommand(testCase.getId(), "localTeardown"));
+        agentsClient.waitForPhaseCompletion("", testCase.getId(), "localTeardown");
 
         LOGGER.info("Terminating workers...");
         agentsClient.terminateWorkers();

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunTestSuiteTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunTestSuiteTest.java
@@ -63,11 +63,8 @@ public class CoordinatorRunTestSuiteTest {
         List<String> privateAddressList = new ArrayList<String>(1);
         privateAddressList.add("127.0.0.1");
 
-        TestCase testCase1 = new TestCase();
-        testCase1.id = "CoordinatorTest1";
-
-        TestCase testCase2 = new TestCase();
-        testCase2.id = "CoordinatorTest2";
+        TestCase testCase1 = new TestCase("CoordinatorTest1");
+        TestCase testCase2 = new TestCase("CoordinatorTest2");
 
         testSuite.addTest(testCase1);
         testSuite.addTest(testCase2);

--- a/simulator/src/test/java/com/hazelcast/simulator/test/TestRunnerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/TestRunnerTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.simulator.test;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.simulator.tests.PropertiesTest;
 import com.hazelcast.simulator.tests.SuccessTest;
 import com.hazelcast.simulator.tests.TestContextImplTest;
 import com.hazelcast.simulator.utils.FileUtils;
@@ -9,6 +10,8 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -37,11 +40,28 @@ public class TestRunnerTest {
         assertNull(testRunner.getHazelcastInstance());
         assertTrue(testRunner.getDurationSeconds() > 0);
 
-        testRunner.withDuration(5);
-        assertEquals(5, testRunner.getDurationSeconds());
+        testRunner.withDuration(3);
+        assertEquals(3, testRunner.getDurationSeconds());
 
         testRunner.run();
         assertNotNull(testRunner.getHazelcastInstance());
+    }
+
+    @Test
+    public void testWithProperties() throws Exception {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("testProperty", "testValue");
+
+        PropertiesTest propertiesTest = new PropertiesTest();
+        assertNull(propertiesTest.testProperty);
+
+        TestRunner testRunner = new TestRunner<PropertiesTest>(propertiesTest, properties);
+
+        testRunner.withDuration(1);
+        assertEquals(1, testRunner.getDurationSeconds());
+
+        testRunner.run();
+        assertEquals("testValue", propertiesTest.testProperty);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/simulator/src/test/java/com/hazelcast/simulator/tests/PropertiesTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/tests/PropertiesTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.tests;
+
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.Setup;
+
+import static org.junit.Assert.assertNotNull;
+
+public class PropertiesTest {
+
+    public String testProperty;
+
+    @Setup
+    public void setUp(TestContext context) {
+    }
+
+    @Run
+    void run() {
+        assertNotNull(testProperty);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupportTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupportTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 public class PropertyBindingSupportTest {
 
+    private final TestCase testCase = new TestCase("PropertyBindingSupportTest");
     private final BindPropertyTestClass bindPropertyTestClass = new BindPropertyTestClass();
 
     @Test
@@ -24,7 +25,6 @@ public class PropertyBindingSupportTest {
 
     @Test
     public void bindProperties_notFound_optional() {
-        TestCase testCase = new TestCase();
         testCase.setProperty("class", "willBeIgnored");
         testCase.setProperty("probe-getLatency", "willBeIgnored");
         testCase.setProperty("notExist", "isOptional");
@@ -42,7 +42,6 @@ public class PropertyBindingSupportTest {
 
     @Test
     public void testBindOptionalProperty_propertyNotDefined() {
-        TestCase testCase = new TestCase();
         testCase.setProperty("class", "willBeIgnored");
         testCase.setProperty("probe-getLatency", "willBeIgnored");
         testCase.setProperty("notExist", "isOptional");
@@ -52,7 +51,6 @@ public class PropertyBindingSupportTest {
 
     @Test
     public void testBindOptionalProperty_propertyNotFound() {
-        TestCase testCase = new TestCase();
         testCase.setProperty("class", "willBeIgnored");
         testCase.setProperty("probe-getLatency", "willBeIgnored");
         testCase.setProperty("notExist", "isOptional");
@@ -62,7 +60,6 @@ public class PropertyBindingSupportTest {
 
     @Test
     public void testBindOptionalProperty() {
-        TestCase testCase = new TestCase();
         testCase.setProperty("class", "willBeIgnored");
         testCase.setProperty("probe-getLatency", "willBeIgnored");
         testCase.setProperty("stringField", "foo");
@@ -73,7 +70,6 @@ public class PropertyBindingSupportTest {
 
     @Test
     public void testParseProbesConfiguration() {
-        TestCase testCase = new TestCase();
         testCase.setProperty("class", "foobar");
         testCase.setProperty("probe-probe1", "latency");
         testCase.setProperty("probe-probe2", "hdr");

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/TestContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/TestContainerTest.java
@@ -40,9 +40,25 @@ public class TestContainerTest {
     private TestContainer<DummyTestContext> invoker;
 
     @Before
-    public void init() {
+    public void setUp() {
         testContext = new DummyTestContext();
         probesConfiguration = new ProbesConfiguration();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructor_testObject_isNull() {
+        createTestContainer(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructor_testContext_isNull() {
+        new TestContainer<DummyTestContext>(new DummyTest(), null, probesConfiguration, null);
+    }
+
+    @Test
+    public void testConstructor_getTestContext() {
+        invoker = createTestContainer(new DummyTest());
+        assertEquals(testContext, invoker.getTestContext());
     }
 
     // =============================================================
@@ -51,7 +67,7 @@ public class TestContainerTest {
 
     @Test(expected = IllegalTestException.class)
     public void testRunAnnotationMissing() throws Exception {
-        new TestContainer<DummyTestContext>(new MissingRunAnnotationTest(), testContext, probesConfiguration);
+        createTestContainer(new MissingRunAnnotationTest());
     }
 
     private static class MissingRunAnnotationTest {
@@ -59,7 +75,7 @@ public class TestContainerTest {
 
     @Test(expected = IllegalTestException.class)
     public void testTooManyMixedRunAnnotations() throws Exception {
-        new TestContainer<DummyTestContext>(new TooManyMixedRunAnnotationsTest(), testContext, probesConfiguration);
+        createTestContainer(new TooManyMixedRunAnnotationsTest());
     }
 
     private static class TooManyMixedRunAnnotationsTest {
@@ -76,7 +92,7 @@ public class TestContainerTest {
 
     @Test(expected = IllegalTestException.class)
     public void testDuplicateSetupAnnotation() {
-        new TestContainer<DummyTestContext>(new DuplicateSetupAnnotationTest(), testContext, probesConfiguration);
+        createTestContainer(new DuplicateSetupAnnotationTest());
     }
 
     private static class DuplicateSetupAnnotationTest {
@@ -95,7 +111,7 @@ public class TestContainerTest {
         // @Setup method will be called from child class, not from dummy class
         // @Run method will be called from dummy class, not from child class
         ChildWithOwnSetupMethodTest test = new ChildWithOwnSetupMethodTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.setUp();
         invoker.run();
 
@@ -122,7 +138,7 @@ public class TestContainerTest {
         // @Setup method will be called from dummy class, not from child class
         // @Run method will be called from child class, not from dummy class
         ChildWithOwnRunMethodTest test = new ChildWithOwnRunMethodTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.setUp();
         invoker.run();
 
@@ -150,7 +166,7 @@ public class TestContainerTest {
     @Test
     public void testRun() throws Exception {
         DummyTest test = new DummyTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.run();
 
         assertTrue(test.runCalled);
@@ -159,7 +175,7 @@ public class TestContainerTest {
     @Test
     public void testRunWithWorker() throws Exception {
         final RunWithWorkerTest test = new RunWithWorkerTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Thread testStopper = new Thread() {
             @Override
             public void run() {
@@ -203,7 +219,7 @@ public class TestContainerTest {
     @Test
     public void testRunWithIWorker() throws Exception {
         final RunWithIWorkerTest test = new RunWithIWorkerTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Thread testStopper = new Thread() {
             @Override
             public void run() {
@@ -247,7 +263,7 @@ public class TestContainerTest {
 
     @Test()
     public void testSetupWithoutArguments() throws Exception {
-        new TestContainer<DummyTestContext>(new SetupWithoutArgumentsTest(), testContext, probesConfiguration);
+        createTestContainer(new SetupWithoutArgumentsTest());
     }
 
     private static class SetupWithoutArgumentsTest extends DummyTest {
@@ -259,7 +275,7 @@ public class TestContainerTest {
 
     @Test()
     public void testSetupWithTestContextOnly() throws Exception {
-        new TestContainer<DummyTestContext>(new SetupWithTextContextOnlyTest(), testContext, probesConfiguration);
+        createTestContainer(new SetupWithTextContextOnlyTest());
     }
 
     private static class SetupWithTextContextOnlyTest extends DummyTest {
@@ -271,7 +287,7 @@ public class TestContainerTest {
 
     @Test(expected = IllegalTestException.class)
     public void testSetupWithSimpleProbeOnly() throws Exception {
-        new TestContainer<DummyTestContext>(new SetupWithSimpleProbeOnly(), testContext, probesConfiguration);
+        createTestContainer(new SetupWithSimpleProbeOnly());
     }
 
     private static class SetupWithSimpleProbeOnly extends DummyTest {
@@ -283,7 +299,7 @@ public class TestContainerTest {
 
     @Test(expected = IllegalTestException.class)
     public void testIllegalSetupArguments() throws Exception {
-        new TestContainer<DummyTestContext>(new IllegalSetupArgumentsTest(), testContext, probesConfiguration);
+        createTestContainer(new IllegalSetupArgumentsTest());
     }
 
     private static class IllegalSetupArgumentsTest extends DummyTest {
@@ -295,7 +311,7 @@ public class TestContainerTest {
 
     @Test
     public void testSetupWithValidArguments() throws Exception {
-        new TestContainer<DummyTestContext>(new SetupWithValidArgumentsTest(), testContext, probesConfiguration);
+        createTestContainer(new SetupWithValidArgumentsTest());
     }
 
     private static class SetupWithValidArgumentsTest extends DummyTest {
@@ -308,7 +324,7 @@ public class TestContainerTest {
     @Test
     public void testSetup() throws Exception {
         DummySetupTest test = new DummySetupTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.setUp();
 
         assertTrue(test.setupCalled);
@@ -323,7 +339,7 @@ public class TestContainerTest {
     @Test
     public void testLocalProbeInjected() throws Exception {
         ProbeTest test = new ProbeTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.setUp();
 
         assertNotNull(test.simpleProbe);
@@ -333,7 +349,7 @@ public class TestContainerTest {
     public void testProbeExplicitNameSetViaAnnotation() throws Exception {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("explicitProbeName", ProbesType.THROUGHPUT.getName());
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Map probeResults = invoker.getProbeResults();
 
         assertTrue(probeResults.keySet().contains("explicitProbeName"));
@@ -343,7 +359,7 @@ public class TestContainerTest {
     public void testProbeImplicitName() throws Exception {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("Probe2", ProbesType.THROUGHPUT.getName());
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Map probeResults = invoker.getProbeResults();
 
         assertTrue(probeResults.keySet().contains("Probe2"));
@@ -353,7 +369,7 @@ public class TestContainerTest {
     public void testProbeInjectSimpleProbeToField() {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("throughputProbe", ProbesType.THROUGHPUT.getName());
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Map probeResults = invoker.getProbeResults();
 
         assertNotNull(test.throughputProbe);
@@ -364,7 +380,7 @@ public class TestContainerTest {
     public void testProbeInjectIntervalProbeToField() {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("latencyProbe", ProbesType.LATENCY.getName());
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Map probeResults = invoker.getProbeResults();
 
         assertNotNull(test.latencyProbe);
@@ -375,7 +391,7 @@ public class TestContainerTest {
     public void testProbeInjectExplicitlyNamedProbeToField() {
         ProbeTest test = new ProbeTest();
         probesConfiguration.addConfig("explicitProbeInjectedToField", ProbesType.THROUGHPUT.getName());
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Map probeResults = invoker.getProbeResults();
 
         assertNotNull(test.fooProbe);
@@ -385,7 +401,7 @@ public class TestContainerTest {
     @Test
     public void testProbeInjectDisabledToField() {
         ProbeTest test = new ProbeTest();
-        new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        createTestContainer(test);
 
         assertNotNull(test.disabled);
         assertTrue(test.disabled instanceof DisabledProbe);
@@ -417,7 +433,7 @@ public class TestContainerTest {
     @Test
     public void testLocalWarmup() throws Exception {
         WarmupTest test = new WarmupTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.localWarmup();
 
         assertTrue(test.localWarmupCalled);
@@ -427,7 +443,7 @@ public class TestContainerTest {
     @Test
     public void testGlobalWarmup() throws Exception {
         WarmupTest test = new WarmupTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.globalWarmup();
 
         assertFalse(test.localWarmupCalled);
@@ -457,7 +473,7 @@ public class TestContainerTest {
     @Test
     public void testLocalVerify() throws Exception {
         VerifyTest test = new VerifyTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.localVerify();
 
         assertTrue(test.localVerifyCalled);
@@ -467,7 +483,7 @@ public class TestContainerTest {
     @Test
     public void testGlobalVerify() throws Exception {
         VerifyTest test = new VerifyTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.globalVerify();
 
         assertFalse(test.localVerifyCalled);
@@ -497,7 +513,7 @@ public class TestContainerTest {
     @Test
     public void testLocalTeardown() throws Exception {
         TeardownTest test = new TeardownTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.localTeardown();
 
         assertTrue(test.localTeardownCalled);
@@ -507,7 +523,7 @@ public class TestContainerTest {
     @Test
     public void testGlobalTeardown() throws Exception {
         TeardownTest test = new TeardownTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         invoker.globalTeardown();
 
         assertFalse(test.localTeardownCalled);
@@ -537,7 +553,7 @@ public class TestContainerTest {
     @Test
     public void testPerformance() throws Exception {
         PerformanceTest test = new PerformanceTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         long count = invoker.getOperationCount();
 
         assertEquals(20, count);
@@ -562,7 +578,7 @@ public class TestContainerTest {
     @Test
     public void testMessageReceiver() throws Exception {
         ReceiveTest test = new ReceiveTest();
-        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker = createTestContainer(test);
         Message message = Mockito.mock(Message.class);
         invoker.sendMessage(message);
 
@@ -582,6 +598,10 @@ public class TestContainerTest {
     // ==========================================================
     // =================== dummy classes ========================
     // ==========================================================
+
+    private <T> TestContainer<DummyTestContext> createTestContainer(T test) {
+        return new TestContainer<DummyTestContext>(test, testContext, probesConfiguration, null);
+    }
 
     private static class DummyTest {
 


### PR DESCRIPTION
* Improved `TestRunner` to set properties in test object
* Cleanup of `TestCase` (Visibility Modifier issue from Sonar)
* Increased code coverage of `TestContainer`

We can now pass properties to a test via `TestRunner` to be a bit more flexible in developing and debugging tests.

All changed code is covered by tests, beside the small change in `WorkerCommandRequestProcessor`.