### PR TITLE
Fixed AtomicLongTest and AsyncAtomicLongTest to work with multiple workers

### DIFF
--- a/dist/src/main/dist/tests/atomiclong/asyncatomiclong.properties
+++ b/dist/src/main/dist/tests/atomiclong/asyncatomiclong.properties
@@ -1,7 +1,6 @@
 class=com.hazelcast.simulator.tests.concurrent.atomiclong.AsyncAtomicLongTest
 countersLength = 1000
 threadCount = 10
-logFrequency = 10000
 keyLocality = remote
-writePercentage = 100
+writeProb = 1.0
 assertEventuallySeconds = 300

--- a/dist/src/main/dist/tests/atomiclong/atomiclong.properties
+++ b/dist/src/main/dist/tests/atomiclong/atomiclong.properties
@@ -1,4 +1,3 @@
 class=com.hazelcast.simulator.tests.concurrent.atomiclong.AtomicLongTest
 threadCount=1
 countersLength=10
-basename=atomiclong


### PR DESCRIPTION
* Fixed verify methods in `AtomicLongTest` and `AsyncAtomicLongTest` for multiple workers
* Fixed `AsyncAtomicLongTest` for client usage
* Used configurable `Metronome` instead of `sleepSeconds()`
* Made usage of new `IWorker` API
* Improved API of `AbstractAsyncWorker`