### PR TITLE
Fixed NPE in GitInfo

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/common/GitInfo.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/GitInfo.java
@@ -9,14 +9,16 @@ import java.util.Properties;
 import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
 
 public final class GitInfo {
-    private static final String GIT_INFO_FILE = "simulator-git.properties";
-    private static final String UNKNOWN = "Unknown";
 
-    private static final String GIT_COMMIT_ID_AABREV = "git.commit.id.abbrev";
-    private static final String GIT_COMMIT_ID = "git.commit.id";
-    private static final String GIT_COMMIT_TIME = "git.commit.time";
-    private static final String GIT_BUILD_TIME = "git.build.time";
-    private static final String GIT_REMOTE_ORIGIN_URL = "git.remote.origin.url";
+    static final String GIT_INFO_FILE = "simulator-git.properties";
+
+    static final String UNKNOWN = "Unknown";
+
+    static final String GIT_COMMIT_ID_AABREV = "git.commit.id.abbrev";
+    static final String GIT_COMMIT_ID = "git.commit.id";
+    static final String GIT_COMMIT_TIME = "git.commit.time";
+    static final String GIT_BUILD_TIME = "git.build.time";
+    static final String GIT_REMOTE_ORIGIN_URL = "git.remote.origin.url";
 
     private static final Logger LOGGER = Logger.getLogger(GitInfo.class);
 
@@ -25,7 +27,7 @@ public final class GitInfo {
     private final Properties properties;
 
     private GitInfo() {
-        properties = loadGitProperties();
+        properties = loadGitProperties(GIT_INFO_FILE);
     }
 
     public static String getCommitIdAbbrev() {
@@ -48,22 +50,26 @@ public final class GitInfo {
         return INSTANCE.properties.getProperty(GIT_REMOTE_ORIGIN_URL, UNKNOWN);
     }
 
-    private Properties loadGitProperties() {
-        Properties properties = new Properties();
+    static Properties loadGitProperties(String fileName) {
         InputStream gitPropsStream = null;
         try {
-            gitPropsStream = getClass().getClassLoader().getResourceAsStream(GIT_INFO_FILE);
+            gitPropsStream = GitInfo.class.getClassLoader().getResourceAsStream(fileName);
+            if (gitPropsStream == null) {
+                return new DummyProperties();
+            }
+            Properties properties = new Properties();
             properties.load(gitPropsStream);
+            return properties;
         } catch (IOException e) {
-            LOGGER.warn("Error while loading Git properties.", e);
-            properties = new DummyProperties();
+            LOGGER.warn("Error while loading Git properties from " + fileName, e);
+            return new DummyProperties();
         } finally {
             closeQuietly(gitPropsStream);
         }
-        return properties;
     }
 
-    private static class DummyProperties extends Properties {
+    static class DummyProperties extends Properties {
+
         @Override
         public String getProperty(String key) {
             return UNKNOWN;

--- a/simulator/src/test/java/com/hazelcast/simulator/common/GitInfoTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/common/GitInfoTest.java
@@ -2,7 +2,12 @@ package com.hazelcast.simulator.common;
 
 import org.junit.Test;
 
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class GitInfoTest {
 
@@ -29,5 +34,32 @@ public class GitInfoTest {
     @Test
     public void testGetRemoteOriginUrl() throws Exception {
         assertNotNull(GitInfo.getRemoteOriginUrl());
+    }
+
+    @Test
+    public void testLoadProperties() {
+        Properties properties = GitInfo.loadGitProperties(GitInfo.GIT_INFO_FILE);
+        assertNotNull(properties);
+        assertFalse(properties instanceof GitInfo.DummyProperties);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testLoadProperties_null() {
+        GitInfo.loadGitProperties(null);
+    }
+
+    @Test
+    public void testLoadProperties_notExists() {
+        Properties properties = GitInfo.loadGitProperties("notExists");
+        assertNotNull(properties);
+        assertTrue(properties instanceof GitInfo.DummyProperties);
+
+        assertEquals(GitInfo.UNKNOWN, properties.getProperty(GitInfo.GIT_COMMIT_ID_AABREV));
+        assertEquals(GitInfo.UNKNOWN, properties.getProperty(GitInfo.GIT_COMMIT_ID));
+        assertEquals(GitInfo.UNKNOWN, properties.getProperty(GitInfo.GIT_COMMIT_TIME));
+        assertEquals(GitInfo.UNKNOWN, properties.getProperty(GitInfo.GIT_BUILD_TIME));
+        assertEquals(GitInfo.UNKNOWN, properties.getProperty(GitInfo.GIT_REMOTE_ORIGIN_URL));
+
+        assertEquals("default", properties.getProperty(GitInfo.GIT_COMMIT_ID_AABREV, "default"));
     }
 }


### PR DESCRIPTION
Fixes #629. The output is now as expected "Unknown" and not a NPE:
```
INFO  17:14:39 Hazelcast Simulator Provisioner
INFO  17:14:39 Version: 0.5, Commit: Unknown, Build Time: Unknown
INFO  17:14:39 SIMULATOR_HOME: /home/donnerbart/bin/hazelcast-simulator
WARN  17:14:39 /home/donnerbart/bin/simulator.properties is not found, relying on defaults
```

Increased code coverage to test this case. Also tried it by compiling without git repo and run the `Provisioner` afterwards.