### PR TITLE
Fix MapStreamer issue with Hazelcast versions prior 3.5

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AsyncMapStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AsyncMapStreamer.java
@@ -1,0 +1,100 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+
+import java.util.concurrent.Semaphore;
+
+import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+/**
+ * Asynchronous implementation of MapStreamer.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class AsyncMapStreamer<K, V> implements MapStreamer<K,V> {
+
+    private static final int DEFAULT_CONCURRENCY_LEVEL = 1000;
+    private static final long DEFAULT_TIMEOUT_MINUTES = 2;
+
+    private final IMap<K, V> map;
+    private final Semaphore semaphore;
+    private final int concurrencyLevel;
+    private final ExecutionCallback<V> callback;
+
+    private Throwable storedException;
+
+    AsyncMapStreamer(IMap<K, V> map) {
+        this.map = map;
+        this.concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL;
+        this.semaphore = new Semaphore(concurrencyLevel);
+        this.callback = new MyExecutionCallback();
+    }
+
+    /**
+     * Push key/value pair into a map. It's a non-blocking operation.
+     * You have to call {@link #await()} to make sure the entry has been created successfully.
+     *
+     * @param key   the key of the map entry
+     * @param value the new value of the map entry
+     */
+    @Override
+    public void pushEntry(K key, V value) {
+        acquirePermit(1);
+        ICompletableFuture<V> future = (ICompletableFuture<V>) map.putAsync(key, value);
+        future.andThen(callback);
+    }
+
+    /**
+     * Wait until all in-flight operations are finished.
+     *
+     * @throws RuntimeException if at least any pushEntry operation failed
+     */
+    @Override
+    public void await() {
+        waitForInFlightOperationsFinished();
+        releasePermit(concurrencyLevel);
+        rethrowExceptionIfAny();
+    }
+
+    private void waitForInFlightOperationsFinished() {
+        acquirePermit(concurrencyLevel);
+    }
+
+    private void rethrowExceptionIfAny() {
+        if (storedException != null) {
+            rethrow(storedException);
+        }
+    }
+
+    private void releasePermit(int count) {
+        semaphore.release(count);
+    }
+
+    private void acquirePermit(int count) {
+        try {
+            if (!semaphore.tryAcquire(count, DEFAULT_TIMEOUT_MINUTES, MINUTES)) {
+                throw new IllegalStateException("Timeout when trying to acquire a permit!");
+            }
+        } catch (InterruptedException e) {
+            rethrow(e);
+        }
+    }
+
+    private final class MyExecutionCallback implements ExecutionCallback<V> {
+
+        @Override
+        public void onResponse(V response) {
+            releasePermit(1);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            storedException = t;
+            releasePermit(1);
+        }
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/MapStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/MapStreamer.java
@@ -1,18 +1,12 @@
 package com.hazelcast.simulator.worker.loadsupport;
 
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.core.IMap;
-
-import java.util.concurrent.Semaphore;
-
-import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
-import static java.util.concurrent.TimeUnit.MINUTES;
-
 /**
  * MapStreamer is used for map initialization during a warm-up phase.
- * It does use asynchronous IMap operations so it's extremely fast,
+ *
+ * With Hazelcast version 3.5 or newer it does use asynchronous IMap operations so it's extremely fast,
  * but it has own back-pressure and doesn't rely on back-pressure provided by Hazelcast.
+ *
+ * For older Hazelcast versions a synchronous version is available.
  *
  * <pre>
  * {@code
@@ -26,27 +20,10 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  * }
  * </pre>
  *
- * @param <K>
- * @param <V>
+ * @param <K> key type
+ * @param <V> value type
  */
-public class MapStreamer<K, V> {
-
-    private static final int DEFAULT_CONCURRENCY_LEVEL = 1000;
-    private static final long DEFAULT_TIMEOUT_MINUTES = 2;
-
-    private final IMap<K, V> map;
-    private final Semaphore semaphore;
-    private final int concurrencyLevel;
-    private final ExecutionCallback<V> callback;
-
-    private Throwable storedException;
-
-    public MapStreamer(IMap<K, V> map) {
-        this.map = map;
-        this.concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL;
-        this.semaphore = new Semaphore(concurrencyLevel);
-        this.callback = new MyExecutionCallback();
-    }
+public interface MapStreamer<K, V> {
 
     /**
      * Push key/value pair into a map. It's a non-blocking operation.
@@ -55,57 +32,12 @@ public class MapStreamer<K, V> {
      * @param key   the key of the map entry
      * @param value the new value of the map entry
      */
-    public void pushEntry(K key, V value) {
-        acquirePermit(1);
-        ICompletableFuture<V> future = (ICompletableFuture<V>) map.putAsync(key, value);
-        future.andThen(callback);
-    }
+    void pushEntry(K key, V value);
 
     /**
      * Wait until all in-flight operations are finished.
      *
      * @throws RuntimeException if at least any pushEntry operation failed
      */
-    public void await() {
-        waitForInFlightOperationsFinished();
-        releasePermit(concurrencyLevel);
-        rethrowExceptionIfAny();
-    }
-
-    private void waitForInFlightOperationsFinished() {
-        acquirePermit(concurrencyLevel);
-    }
-
-    private void rethrowExceptionIfAny() {
-        if (storedException != null) {
-            rethrow(storedException);
-        }
-    }
-
-    private void releasePermit(int count) {
-        semaphore.release(count);
-    }
-
-    private void acquirePermit(int count) {
-        try {
-            if (!semaphore.tryAcquire(count, DEFAULT_TIMEOUT_MINUTES, MINUTES)) {
-                throw new IllegalStateException("Timeout when trying to acquire a permit!");
-            }
-        } catch (InterruptedException e) {
-            rethrow(e);
-        }
-    }
-
-    private class MyExecutionCallback implements ExecutionCallback<V> {
-        @Override
-        public void onResponse(V response) {
-            releasePermit(1);
-        }
-
-        @Override
-        public void onFailure(Throwable t) {
-            storedException = t;
-            releasePermit(1);
-        }
-    }
+    void await();
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/MapStreamerFactory.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/MapStreamerFactory.java
@@ -1,0 +1,40 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.BuildInfo;
+import com.hazelcast.instance.BuildInfoProvider;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.simulator.utils.VersionUtils.isMinVersion;
+
+public final class MapStreamerFactory {
+
+    private static final AtomicBoolean CREATE_ASYNC;
+
+    static {
+        boolean createAsync = false;
+        try {
+            BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
+            if (isMinVersion(buildInfo.getVersion(), "3.5")) {
+                createAsync = true;
+            }
+        } finally {
+            CREATE_ASYNC = new AtomicBoolean(createAsync);
+        }
+    }
+
+    private MapStreamerFactory() {
+    }
+
+    public static <K, V> MapStreamer<K, V> getInstance(IMap<K, V> map) {
+        if (CREATE_ASYNC.get()) {
+            return new AsyncMapStreamer<K, V>(map);
+        }
+        return new SyncMapStreamer<K, V>(map);
+    }
+
+    static void enforceAsync(boolean enforceAsync) {
+        CREATE_ASYNC.set(enforceAsync);
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/SyncMapStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/SyncMapStreamer.java
@@ -1,0 +1,27 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.IMap;
+
+/**
+ * Synchronous implementation of MapStreamer.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class SyncMapStreamer<K, V> implements MapStreamer<K, V> {
+
+    private final IMap<K, V> map;
+
+    SyncMapStreamer(IMap<K, V> map) {
+        this.map = map;
+    }
+
+    @Override
+    public void pushEntry(K key, V value) {
+        map.put(key, value);
+    }
+
+    @Override
+    public void await() {
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/loadsupport/AsyncMapStreamerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/loadsupport/AsyncMapStreamerTest.java
@@ -1,0 +1,40 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class AsyncMapStreamerTest {
+
+    @SuppressWarnings("unchecked")
+    private final IMap<Integer, String> map = mock(IMap.class);
+
+    @SuppressWarnings("unchecked")
+    private final ICompletableFuture<String> future = mock(ICompletableFuture.class);
+
+    private MapStreamer<Integer, String> streamer;
+
+    @Before
+    public void setUp() {
+        when(map.putAsync(anyInt(), anyString())).thenReturn(future);
+
+        MapStreamerFactory.enforceAsync(true);
+        streamer = MapStreamerFactory.getInstance(map);
+    }
+
+    @Test
+    public void testPushEntry() {
+        streamer.pushEntry(15, "value");
+
+        verify(map).putAsync(15, "value");
+        verifyNoMoreInteractions(map);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/loadsupport/MapStreamerFactoryTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/loadsupport/MapStreamerFactoryTest.java
@@ -1,0 +1,41 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.IMap;
+import org.junit.Test;
+
+import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class MapStreamerFactoryTest {
+
+    private final IMap map = mock(IMap.class);
+
+    @Test
+    public void testConstructor() throws Exception {
+        invokePrivateConstructor(MapStreamerFactory.class);
+    }
+
+    @Test
+    public void testGetInstance() {
+        MapStreamer streamer = MapStreamerFactory.getInstance(map);
+        assertNotNull(streamer);
+    }
+
+    @Test
+    public void testGetInstance_forceAsync() {
+        MapStreamerFactory.enforceAsync(true);
+        MapStreamer streamer = MapStreamerFactory.getInstance(map);
+        assertNotNull(streamer);
+        assertTrue(streamer instanceof AsyncMapStreamer);
+    }
+
+    @Test
+    public void testGetInstance_forceSync() {
+        MapStreamerFactory.enforceAsync(false);
+        MapStreamer streamer = MapStreamerFactory.getInstance(map);
+        assertNotNull(streamer);
+        assertTrue(streamer instanceof SyncMapStreamer);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/loadsupport/SyncMapStreamerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/loadsupport/SyncMapStreamerTest.java
@@ -1,0 +1,54 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.util.EmptyStatement;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class SyncMapStreamerTest {
+
+    @SuppressWarnings("unchecked")
+    private final IMap<Integer, String> map = mock(IMap.class);
+
+    private MapStreamer<Integer, String> streamer;
+
+    @Before
+    public void setUp() {
+        MapStreamerFactory.enforceAsync(false);
+        streamer = MapStreamerFactory.getInstance(map);
+    }
+
+    @Test
+    public void testPushEntry() {
+        streamer.pushEntry(15, "value");
+
+        verify(map).put(15, "value");
+        verifyNoMoreInteractions(map);
+    }
+
+    @Test(timeout = 1000)
+    public void testPushEntry_withException() {
+        when(map.put(anyInt(), anyString())).thenThrow(new IllegalArgumentException());
+
+        try {
+            streamer.pushEntry(1, "foobar");
+            fail("Expected exception directly thrown by pushEntry() method");
+        } catch (Exception ignored) {
+            EmptyStatement.ignore(ignored);
+        }
+
+        // this method should never block and never throw an exception
+        streamer.await();
+
+        verify(map).put(1, "foobar");
+        verifyNoMoreInteractions(map);
+    }
+}

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.MapStreamer;
+import com.hazelcast.simulator.worker.loadsupport.MapStreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -76,7 +77,7 @@ public class IntByteMapTest {
 
     @Warmup(global = false)
     public void warmup() throws InterruptedException {
-        MapStreamer<Integer, Object> streamer = new MapStreamer<Integer, Object>(map);
+        MapStreamer<Integer, Object> streamer = MapStreamerFactory.getInstance(map);
         Random random = new Random();
         for (int key : keys) {
             Object value = generateByteArray(random, valueSize);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.MapStreamer;
+import com.hazelcast.simulator.worker.loadsupport.MapStreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -88,7 +89,7 @@ public class IntIntMapTest {
     public void warmup() throws InterruptedException {
         waitClusterSize(LOGGER, testContext.getTargetInstance(), minNumberOfMembers);
         keys = generateIntKeys(keyCount, Integer.MAX_VALUE, keyLocality, testContext.getTargetInstance());
-        MapStreamer<Integer, Integer> streamer = new MapStreamer<Integer, Integer>(map);
+        MapStreamer<Integer, Integer> streamer = MapStreamerFactory.getInstance(map);
         Random random = new Random();
         for (int key : keys) {
             int value = random.nextInt(Integer.MAX_VALUE);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapLongPerformanceTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapLongPerformanceTest.java
@@ -12,6 +12,7 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.MapStreamer;
+import com.hazelcast.simulator.worker.loadsupport.MapStreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -38,7 +39,7 @@ public class MapLongPerformanceTest {
     private IMap<Integer, Long> map;
 
     @Setup
-    public void setUp(TestContext testContext, @Name("latencyProbe")IntervalProbe intervalProbe,
+    public void setUp(TestContext testContext, @Name("latencyProbe") IntervalProbe intervalProbe,
                       @Name("set") SimpleProbe setProbe, @Name("get") SimpleProbe getProbe) {
         this.intervalProbe = intervalProbe;
         this.setProbe = setProbe;
@@ -59,7 +60,7 @@ public class MapLongPerformanceTest {
 
     @Warmup(global = true)
     public void warmup() throws Exception {
-        MapStreamer<Integer, Long> streamer = new MapStreamer<Integer, Long>(map);
+        MapStreamer<Integer, Long> streamer = MapStreamerFactory.getInstance(map);
         for (int i = 0; i < keyCount; i++) {
             streamer.pushEntry(i, 0L);
         }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/MapPredicateTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/MapPredicateTest.java
@@ -19,6 +19,7 @@ import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.Employee;
 import com.hazelcast.simulator.tests.map.helpers.PredicateOperationCounter;
 import com.hazelcast.simulator.worker.loadsupport.MapStreamer;
+import com.hazelcast.simulator.worker.loadsupport.MapStreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -81,7 +82,7 @@ public class MapPredicateTest {
     }
 
     private void initMap() {
-        MapStreamer<Integer, Employee> streamer = new MapStreamer<Integer, Employee>(map);
+        MapStreamer<Integer, Employee> streamer = MapStreamerFactory.getInstance(map);
         for (int i = 0; i < keyCount; i++) {
             Employee employee = new Employee(i);
             streamer.pushEntry(employee.getId(), employee);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
@@ -14,6 +14,7 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.MapStreamer;
+import com.hazelcast.simulator.worker.loadsupport.MapStreamerFactory;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 import com.hazelcast.simulator.worker.metronome.SimpleMetronome;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -58,7 +59,7 @@ public class SqlPredicateTest {
     @Warmup(global = true)
     public void warmup() throws InterruptedException {
         Random random = new Random();
-        MapStreamer<String, DataSerializableEmployee> streamer = new MapStreamer<String, DataSerializableEmployee>(map);
+        MapStreamer<String, DataSerializableEmployee> streamer = MapStreamerFactory.getInstance(map);
         for (int k = 0; k < keyCount; k++) {
             String key = generateString(keyLength);
             DataSerializableEmployee value = generateRandomEmployee(random);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.MapStreamer;
+import com.hazelcast.simulator.worker.loadsupport.MapStreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -108,7 +109,7 @@ public class StringStringMapTest {
 
     private void loadInitialData() throws InterruptedException {
         Random random = new Random();
-        MapStreamer<String, String> streamer = new MapStreamer<String, String>(map);
+        MapStreamer<String, String> streamer = MapStreamerFactory.getInstance(map);
         for (String key : keys) {
             String value = values[random.nextInt(valueCount)];
             streamer.pushEntry(key, value);

--- a/utils/src/main/java/com/hazelcast/simulator/utils/VersionUtils.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/VersionUtils.java
@@ -1,0 +1,53 @@
+package com.hazelcast.simulator.utils;
+
+public final class VersionUtils {
+
+    private VersionUtils() {
+    }
+
+    public static boolean isMinVersion(String actualVersion, String minVersion) {
+        return (versionCompare(actualVersion, minVersion) <= 0);
+    }
+
+    /**
+     * Compares two version strings.
+     *
+     * Use this instead of String.compareTo() for a non-lexicographical comparison that works for version strings,
+     * e.g. versionCompare("1.10", "1.6").
+     *
+     * Warning:
+     * - It does not work if "1.10" is supposed to be equal to "1.10.0".
+     * - Everything after a "-" is ignored.
+     *
+     * @param firstVersionString  a string of ordinal numbers separated by decimal points.
+     * @param secondVersionString a string of ordinal numbers separated by decimal points.
+     * @return The result is a negative integer if str1 is _numerically_ less than str2.
+     * The result is a positive integer if str1 is _numerically_ greater than str2.
+     * The result is zero if the strings are _numerically_ equal.
+     */
+    public static Integer versionCompare(String firstVersionString, String secondVersionString) {
+        if (firstVersionString.indexOf('-') != -1) {
+            firstVersionString = firstVersionString.substring(0, firstVersionString.indexOf('-'));
+        }
+        if (secondVersionString.indexOf('-') != -1) {
+            secondVersionString = secondVersionString.substring(0, secondVersionString.indexOf('-'));
+        }
+        String[] firstVersion = firstVersionString.split("\\.");
+        String[] secondVersion = secondVersionString.split("\\.");
+
+        int i = 0;
+        // set index to first non-equal ordinal or length of shortest version string
+        while (i < firstVersion.length && i < secondVersion.length && firstVersion[i].equals(secondVersion[i])) {
+            i++;
+        }
+        if (i < firstVersion.length && i < secondVersion.length) {
+            // compare first non-equal ordinal number
+            int diff = Integer.valueOf(firstVersion[i]).compareTo(Integer.valueOf(secondVersion[i]));
+            return Integer.signum(diff);
+        } else {
+            // the strings are equal or one string is a substring of the other
+            // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+            return Integer.signum(firstVersion.length - secondVersion.length);
+        }
+    }
+}

--- a/utils/src/test/java/com/hazelcast/simulator/utils/VersionUtilsTest.java
+++ b/utils/src/test/java/com/hazelcast/simulator/utils/VersionUtilsTest.java
@@ -1,0 +1,72 @@
+package com.hazelcast.simulator.utils;
+
+import org.junit.Test;
+
+import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VersionUtilsTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        invokePrivateConstructor(VersionUtils.class);
+    }
+
+    @Test
+    public void testMinVersion() {
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5-EA"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5-RC"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5-RC1"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5-RC1-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5.1"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5.1-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5.1-EA"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5.1-RC"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5.1-RC1"));
+        assertTrue(VersionUtils.isMinVersion("3.4", "3.5.1-RC1-SNAPSHOT"));
+
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5-EA"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5-RC"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5-RC1"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5-RC1-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5.1"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5.1-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5.1-EA"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5.1-RC"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5.1-RC1"));
+        assertTrue(VersionUtils.isMinVersion("3.4.2", "3.5.1-RC1-SNAPSHOT"));
+
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5-EA"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5-RC"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5-RC1"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5-RC1-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5.1"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5.1-SNAPSHOT"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5.1-EA"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5.1-RC"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5.1-RC1"));
+        assertTrue(VersionUtils.isMinVersion("3.5", "3.5.1-RC1-SNAPSHOT"));
+
+        assertTrue(VersionUtils.isMinVersion("3.5-SNAPSHOT", "3.5"));
+
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5-SNAPSHOT"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5-EA"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5-RC"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5-RC1"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5-RC1-SNAPSHOT"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5.1"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5.1-SNAPSHOT"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5.1-EA"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5.1-RC"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5.1-RC1"));
+        assertFalse(VersionUtils.isMinVersion("3.6", "3.5.1-RC1-SNAPSHOT"));
+    }
+}


### PR DESCRIPTION
Fixes #630. Created a factory to get a sync or async `MapStreamer` implementation, depending on the Hazelcast version.

I didn't touch the `AsyncMapStreamer`, should work as before. The `SyncMapStreamer` is new but very simple. Started to write tests for both classes, but the async one is not at 100% coverage yet.

Please double-check if I did the version compare thing in the correct way, otherwise we'll have the async implementation in the old Hazelcast versions!