### PR TITLE
Fixed SonarQube complain in GitInfo

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/common/GitInfo.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/GitInfo.java
@@ -54,18 +54,17 @@ public final class GitInfo {
         InputStream gitPropsStream = null;
         try {
             gitPropsStream = GitInfo.class.getClassLoader().getResourceAsStream(fileName);
-            if (gitPropsStream == null) {
-                return new DummyProperties();
+            if (gitPropsStream != null) {
+                Properties properties = new Properties();
+                properties.load(gitPropsStream);
+                return properties;
             }
-            Properties properties = new Properties();
-            properties.load(gitPropsStream);
-            return properties;
         } catch (IOException e) {
             LOGGER.warn("Error while loading Git properties from " + fileName, e);
-            return new DummyProperties();
         } finally {
             closeQuietly(gitPropsStream);
         }
+        return new DummyProperties();
     }
 
     static class DummyProperties extends Properties {


### PR DESCRIPTION
Fixed new SonarQube complain in `GitInfo`:

> Dodgy - Load of known null value
>
>The variable referenced at this point is known to be null due to an earlier check against null. Although this is valid, it might be a mistake (perhaps you intended to refer to a different variable, or perhaps the earlier check to see if the variable is null should have been a check to see if it was nonnull).

Code should look a bit nicer now, tests are still green, SonarQube should be happy.