### PR TITLE
Cleanup of test phase handling

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/remoting/AgentsClient.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/remoting/AgentsClient.java
@@ -8,6 +8,7 @@ import com.hazelcast.simulator.common.messaging.Message;
 import com.hazelcast.simulator.common.messaging.MessageAddress;
 import com.hazelcast.simulator.coordinator.AgentMemberLayout;
 import com.hazelcast.simulator.test.Failure;
+import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.test.TestSuite;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import com.hazelcast.simulator.worker.commands.Command;
@@ -188,9 +189,9 @@ public class AgentsClient {
         executeOnAllWorkers(SERVICE_INIT_TESTSUITE, testSuite);
     }
 
-    public void waitForPhaseCompletion(String prefix, String testId, String phaseName) throws TimeoutException {
+    public void waitForPhaseCompletion(String prefix, String testId, TestPhase testPhase) throws TimeoutException {
         long start = System.nanoTime();
-        IsPhaseCompletedCommand command = new IsPhaseCompletedCommand(testId);
+        IsPhaseCompletedCommand command = new IsPhaseCompletedCommand(testId, testPhase);
         for (; ; ) {
             List<List<Boolean>> allResults = executeOnAllWorkers(command);
             boolean complete = true;
@@ -209,7 +210,7 @@ public class AgentsClient {
                 return;
             }
             long duration = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start);
-            LOGGER.info(prefix + "Waiting for " + phaseName + " completion: " + secondsToHuman(duration));
+            LOGGER.info(prefix + "Waiting for " + testPhase.name + " completion: " + secondsToHuman(duration));
             sleepSeconds(5);
         }
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestPhase.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestPhase.java
@@ -1,0 +1,18 @@
+package com.hazelcast.simulator.test;
+
+public enum TestPhase {
+    SETUP("setup"),
+    LOCAL_WARMUP("local warmup"),
+    GLOBAL_WARMUP("global warmup"),
+    RUN("run"),
+    GLOBAL_VERIFY("global verify"),
+    LOCAL_VERIFY("local verify"),
+    GLOBAL_TEARDOWN("global tear down"),
+    LOCAL_TEARDOWN("local tear down");
+
+    public final String name;
+
+    TestPhase(String name) {
+        this.name = name;
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestRunner.java
@@ -129,38 +129,21 @@ public class TestRunner<E> {
                 hazelcastInstance = Hazelcast.newHazelcastInstance();
             }
 
-            LOGGER.info("Starting setup");
-            testInvoker.setUp();
-            LOGGER.info("Finished setup");
+            runPhase(TestPhase.SETUP);
 
-            LOGGER.info("Starting local warmup");
-            testInvoker.localWarmup();
-            LOGGER.info("Finished local warmup");
-
-            LOGGER.info("Starting global warmup");
-            testInvoker.globalWarmup();
-            LOGGER.info("Finished global warmup");
+            runPhase(TestPhase.LOCAL_WARMUP);
+            runPhase(TestPhase.GLOBAL_WARMUP);
 
             LOGGER.info("Starting run");
             stopThread.start();
-            testInvoker.run();
+            testInvoker.invoke(TestPhase.RUN);
             LOGGER.info("Finished run");
 
-            LOGGER.info("Starting globalVerify");
-            testInvoker.globalVerify();
-            LOGGER.info("Finished globalVerify");
+            runPhase(TestPhase.GLOBAL_VERIFY);
+            runPhase(TestPhase.LOCAL_VERIFY);
 
-            LOGGER.info("Starting localVerify");
-            testInvoker.localVerify();
-            LOGGER.info("Finished localVerify");
-
-            LOGGER.info("Starting globalTearDown");
-            testInvoker.globalTeardown();
-            LOGGER.info("Finished globalTearDown");
-
-            LOGGER.info("Starting local teardown");
-            testInvoker.localTeardown();
-            LOGGER.info("Finished local teardown");
+            runPhase(TestPhase.GLOBAL_TEARDOWN);
+            runPhase(TestPhase.LOCAL_TEARDOWN);
         } finally {
             LOGGER.info("Shutdown...");
             hazelcastInstance.shutdown();
@@ -169,6 +152,12 @@ public class TestRunner<E> {
             stopThread.join();
             LOGGER.info("Finished");
         }
+    }
+
+    private void runPhase(TestPhase testPhase) throws Exception {
+        LOGGER.info("Starting " + testPhase.name);
+        testInvoker.invoke(testPhase);
+        LOGGER.info("Finished " + testPhase.name);
     }
 
     private final class StopThread extends Thread {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/commands/GenericCommand.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/commands/GenericCommand.java
@@ -15,23 +15,25 @@
  */
 package com.hazelcast.simulator.worker.commands;
 
+import com.hazelcast.simulator.test.TestPhase;
+
 public class GenericCommand extends Command {
 
     public static final long serialVersionUID = 0L;
 
     public String testId;
-    public String methodName;
+    public TestPhase testPhase;
 
-    public GenericCommand(String testId, String methodName) {
+    public GenericCommand(String testId, TestPhase testPhase) {
         this.testId = testId;
-        this.methodName = methodName;
+        this.testPhase = testPhase;
     }
 
     @Override
     public String toString() {
         return "GenericCommand{"
                 + "testId='" + testId + '\''
-                + ", methodName='" + methodName + '\''
+                + ", testPhase='" + testPhase + '\''
                 + '}';
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/commands/IsPhaseCompletedCommand.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/commands/IsPhaseCompletedCommand.java
@@ -1,23 +1,31 @@
 package com.hazelcast.simulator.worker.commands;
 
+import com.hazelcast.simulator.test.TestPhase;
+
 /**
  * Checks if a test-phase on a member has completed for a given test.
  */
 public class IsPhaseCompletedCommand extends Command {
 
     public final String testId;
+    public final TestPhase testPhase;
 
-    public IsPhaseCompletedCommand(String testId) {
+    public IsPhaseCompletedCommand(String testId, TestPhase testPhase) {
         if (testId == null) {
             throw new NullPointerException("testId can't be null");
         }
+        if (testPhase == null) {
+            throw new NullPointerException("testPhase can't be null");
+        }
         this.testId = testId;
+        this.testPhase = testPhase;
     }
 
     @Override
     public String toString() {
         return "IsPhaseCompletedCommand{"
                 + "testId='" + testId + '\''
+                + "testPhase=" + testPhase
                 + '}';
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/CommandFutureTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/CommandFutureTest.java
@@ -1,7 +1,7 @@
 package com.hazelcast.simulator.agent;
 
 import com.hazelcast.simulator.worker.commands.Command;
-import com.hazelcast.simulator.worker.commands.GenericCommand;
+import com.hazelcast.simulator.worker.commands.RunCommand;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -18,7 +18,7 @@ public class CommandFutureTest {
     private static final String DEFAULT_RESULT = "testResult";
     private static final int DEFAULT_TIMEOUT_MS = 500;
 
-    private final Command command = new GenericCommand("unitTest", "testMethod");
+    private final Command command = new RunCommand("unitTest");
 
     private final CommandFuture<String> future = new CommandFuture<String>(command);
     private final FutureSetter futureSetter = new FutureSetter(DEFAULT_RESULT, DEFAULT_TIMEOUT_MS);

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunTestSuiteTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunTestSuiteTest.java
@@ -3,6 +3,7 @@ package com.hazelcast.simulator.coordinator;
 import com.hazelcast.simulator.agent.workerjvm.WorkerJvmSettings;
 import com.hazelcast.simulator.coordinator.remoting.AgentsClient;
 import com.hazelcast.simulator.test.TestCase;
+import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.test.TestSuite;
 import com.hazelcast.simulator.worker.commands.Command;
 import org.junit.AfterClass;
@@ -99,8 +100,10 @@ public class CoordinatorRunTestSuiteTest {
         int phaseNumber = 8;
 
         verify(agentsClient, times(phaseNumber * numberOfTests)).executeOnAllWorkers(any(Command.class));
-        verify(agentsClient, times(phaseNumber)).waitForPhaseCompletion(anyString(), eq("CoordinatorTest1"), anyString());
-        verify(agentsClient, times(phaseNumber)).waitForPhaseCompletion(anyString(), eq("CoordinatorTest2"), anyString());
+        verify(agentsClient, times(phaseNumber))
+                .waitForPhaseCompletion(anyString(), eq("CoordinatorTest1"), any(TestPhase.class));
+        verify(agentsClient, times(phaseNumber))
+                .waitForPhaseCompletion(anyString(), eq("CoordinatorTest2"), any(TestPhase.class));
         verify(agentsClient, times(1)).terminateWorkers();
     }
 }


### PR DESCRIPTION
Introduced an `Enum` for the test phases instead of using Strings which invoke method via reflection on the worker side.

Also changes the behavior of the `IsPhaseCompletedCommand` to be more strict, e.g. when asking for complection of a phase, which is not running at the moment. Same is for the start of a new phase, if the old phase is not yet done.