### PR TITLE
Fallback for a binary incompatible change in Hazelcast Internals

### DIFF
--- a/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/synthetic/SyntheticTest.java
@@ -19,6 +19,7 @@ import com.hazelcast.simulator.test.annotations.Performance;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
+import com.hazelcast.simulator.tests.helpers.HazelcastTestUtils;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.utils.ExceptionReporter;
 import com.hazelcast.simulator.worker.tasks.IWorker;
@@ -125,7 +126,7 @@ public class SyntheticTest {
             } else {
                 Node node = getNode(targetInstance);
 
-                operationService = node.getNodeEngine().getOperationService();
+                operationService = HazelcastTestUtils.getOperationService(targetInstance);
                 clientInvocationService = null;
                 clientPartitionService = null;
             }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/SyntheticMapProxy.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/syntheticmap/SyntheticMapProxy.java
@@ -1,6 +1,7 @@
 package com.hazelcast.simulator.tests.syntheticmap;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.simulator.tests.helpers.HazelcastTestUtils;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
@@ -28,7 +29,7 @@ public class SyntheticMapProxy<K, V> extends AbstractDistributedObject<Synthetic
         GetOperation operation = new GetOperation(name, keyData);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
 
-        OperationService operationService = nodeEngine.getOperationService();
+        OperationService operationService = HazelcastTestUtils.getOperationService(nodeEngine.getHazelcastInstance());
         return operationService
                 .<V>invokeOnPartition(SyntheticMapService.SERVICE_NAME, operation, partitionId)
                 .getSafely();
@@ -42,7 +43,7 @@ public class SyntheticMapProxy<K, V> extends AbstractDistributedObject<Synthetic
         PutOperation operation = new PutOperation(name, keyData, valueData);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
 
-        OperationService operationService = nodeEngine.getOperationService();
+        OperationService operationService = HazelcastTestUtils.getOperationService(nodeEngine.getHazelcastInstance());
         operationService
                 .<V>invokeOnPartition(SyntheticMapService.SERVICE_NAME, operation, partitionId)
                 .getSafely();


### PR DESCRIPTION
Without this change Simulator is failing to run with Hazelcast 3.4 when compiled against Hazelcast 3.5