### PR TITLE
Added recordValue(long latencyNanos) to probes

### DIFF
--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/IntervalProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/IntervalProbe.java
@@ -18,4 +18,13 @@ package com.hazelcast.simulator.probes.probes;
 public interface IntervalProbe<R extends Result<R>, T extends SimpleProbe<R, T>> extends SimpleProbe<R, T> {
 
     void started();
+
+    /**
+     * Adds a latency value in nanoseconds to the probe result.
+     *
+     * Can be used if {@link #started()} and {@link #done()} are not directly related, e.g. in asynchronous tests.
+     *
+     * @param latencyNanos latency value in nanoseconds
+     */
+    void recordValue(long latencyNanos);
 }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractIntervalProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractIntervalProbe.java
@@ -29,6 +29,14 @@ public abstract class AbstractIntervalProbe<R extends Result<R>, T extends Inter
     }
 
     @Override
+    public void done() {
+        if (started == 0) {
+            throw new IllegalStateException("You have to call started() before done()");
+        }
+        recordValue(System.nanoTime() - started);
+    }
+
+    @Override
     public long getInvocationCount() {
         return invocations;
     }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractSimpleProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractSimpleProbe.java
@@ -29,6 +29,11 @@ public abstract class AbstractSimpleProbe<R extends Result<R>, T extends Interva
     }
 
     @Override
+    public void recordValue(long latencyNanos) {
+        throw new UnsupportedOperationException("This method is just supported by IntervalProbe implementations");
+    }
+
+    @Override
     public long getInvocationCount() {
         return invocations;
     }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbe.java
@@ -41,6 +41,11 @@ public class ConcurrentProbe<R extends Result<R>, T extends IntervalProbe<R, T>>
     }
 
     @Override
+    public void recordValue(long latencyNanos) {
+        getProbe().recordValue(latencyNanos);
+    }
+
+    @Override
     public void done() {
         getProbe().done();
     }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbe.java
@@ -31,6 +31,10 @@ public final class DisabledProbe implements IntervalProbe<DisabledResult, Disabl
     }
 
     @Override
+    public void recordValue(long latencyNanos) {
+    }
+
+    @Override
     public void done() {
     }
 

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbe.java
@@ -27,11 +27,8 @@ public class HdrLatencyDistributionProbe
     private final Histogram histogram = new Histogram(MAXIMUM_LATENCY, 4);
 
     @Override
-    public void done() {
-        if (started == 0) {
-            throw new IllegalStateException("You have to call started() before done()");
-        }
-        histogram.recordValue((int) TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - started));
+    public void recordValue(long latencyNanos) {
+        histogram.recordValue((int) TimeUnit.NANOSECONDS.toMicros(latencyNanos));
     }
 
     @Override

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/LatencyDistributionProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/LatencyDistributionProbe.java
@@ -27,11 +27,8 @@ public class LatencyDistributionProbe extends AbstractIntervalProbe<LatencyDistr
     private final LinearHistogram histogram = new LinearHistogram(MAXIMUM_LATENCY, STEP);
 
     @Override
-    public void done() {
-        if (started == 0) {
-            throw new IllegalStateException("You have to call started() before done()");
-        }
-        histogram.addValue((int) TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - started));
+    public void recordValue(long latencyNanos) {
+        histogram.addValue((int) TimeUnit.NANOSECONDS.toMicros(latencyNanos));
         invocations++;
     }
 

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbe.java
@@ -22,12 +22,8 @@ public class MaxLatencyProbe extends AbstractIntervalProbe<MaxLatencyResult, Max
     private long maxLatency;
 
     @Override
-    public void done() {
-        if (started == 0) {
-            throw new IllegalStateException("You have to call started() before done()");
-        }
-        long latency = System.nanoTime() - started;
-        maxLatency = Math.max(maxLatency, latency);
+    public void recordValue(long latencyNanos) {
+        maxLatency = Math.max(maxLatency, latencyNanos);
         invocations++;
     }
 

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbe.java
@@ -24,6 +24,11 @@ package com.hazelcast.simulator.probes.probes.impl;
 public class WorkerProbe extends AbstractIntervalProbe<DisabledResult, WorkerProbe> {
 
     @Override
+    public void recordValue(long latencyNanos) {
+        invocations++;
+    }
+
+    @Override
     public void done() {
         invocations++;
     }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbeTest.java
@@ -82,6 +82,22 @@ public class ConcurrentProbeTest {
     }
 
     @Test
+    public void testInvocationCountOnIntervalProbeWithRecordValue() throws Exception {
+        concurrentProbe = (ConcurrentProbe) Probes.createConcurrentProbe("latency", IntervalProbe.class, config);
+
+        ProbeRecordValueTester probeTester1 = new ProbeRecordValueTester(concurrentProbe);
+        ProbeRecordValueTester probeTester2 = new ProbeRecordValueTester(concurrentProbe);
+
+        probeTester1.start();
+        probeTester2.start();
+
+        probeTester1.join();
+        probeTester2.join();
+
+        assertEquals(2, concurrentProbe.getInvocationCount());
+    }
+
+    @Test
     public void testEmptyResult() {
         Result result = concurrentProbe.getResult();
         assertNull(result);
@@ -125,6 +141,7 @@ public class ConcurrentProbeTest {
     }
 
     private static class ProbeTester extends Thread {
+
         private final ConcurrentProbe probe;
 
         private SimpleProbe threadLocalProbe;
@@ -138,6 +155,20 @@ public class ConcurrentProbeTest {
             threadLocalProbe = probe.getProbe();
             probe.started();
             probe.done();
+        }
+    }
+
+    private static class ProbeRecordValueTester extends Thread {
+
+        private final ConcurrentProbe probe;
+
+        public ProbeRecordValueTester(ConcurrentProbe probe) {
+            this.probe = probe;
+        }
+
+        @Override
+        public void run() {
+            probe.recordValue(TimeUnit.MICROSECONDS.toNanos(40));
         }
     }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbeTest.java
@@ -35,6 +35,14 @@ public class DisabledProbeTest {
     }
 
     @Test
+    public void testRecordValues() {
+        disabledProbe.recordValue(-1);
+        disabledProbe.recordValue(500);
+
+        assertEquals(0, disabledProbe.getInvocationCount());
+    }
+
+    @Test
     public void testResultToHumanString() {
         DisabledResult result = disabledProbe.getResult();
         assertTrue(result != null);
@@ -44,6 +52,13 @@ public class DisabledProbeTest {
     @Test
     public void testResult() {
         disabledProbe.done();
+
+        assertTrue(disabledProbe.getResult() != null);
+    }
+
+    @Test
+    public void testResult_withRecordValues() {
+        disabledProbe.recordValue(152);
 
         assertTrue(disabledProbe.getResult() != null);
     }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbeTest.java
@@ -31,6 +31,15 @@ public class MaxLatencyProbeTest {
     }
 
     @Test
+    public void testRecordValues() {
+        maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(500));
+        maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(200));
+        maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(1000));
+
+        assertEquals(3, maxLatencyProbe.getInvocationCount());
+    }
+
+    @Test
     public void testResult() {
         maxLatencyProbe.started();
         sleepNanos(TimeUnit.MILLISECONDS.toNanos(150));
@@ -42,6 +51,19 @@ public class MaxLatencyProbeTest {
         Long maxLatencyMs = getObjectFromField(result, "maxLatencyMs");
         assertTrue(maxLatencyMs >= 150);
         assertTrue(maxLatencyMs < 1000);
+    }
+
+    @Test
+    public void testResult_withRecordValues() {
+        maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(500));
+        maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(200));
+        maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(1000));
+
+        MaxLatencyResult result = maxLatencyProbe.getResult();
+        assertTrue(result != null);
+
+        Long maxLatencyMs = getObjectFromField(result, "maxLatencyMs");
+        assertEquals(1000, maxLatencyMs.longValue());
     }
 
     @Test

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbeTest.java
@@ -27,6 +27,11 @@ public class OperationsPerSecProbeTest {
         assertEquals(3, operationsPerSecProbe.getInvocationCount());
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRecordValues() {
+        operationsPerSecProbe.recordValue(500);
+    }
+
     @Test(expected = IllegalStateException.class)
     public void testResultWithInitialization() {
         operationsPerSecProbe.getResult();

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbeTest.java
@@ -29,8 +29,23 @@ public class WorkerProbeTest {
     }
 
     @Test
+    public void testRecordValues() {
+        workerProbe.recordValue(-1);
+        workerProbe.recordValue(5);
+
+        assertEquals(2, workerProbe.getInvocationCount());
+    }
+
+    @Test
     public void testResult() {
         workerProbe.done();
+
+        assertTrue(workerProbe.getResult() != null);
+    }
+
+    @Test
+    public void testResult_withRecordValues() {
+        workerProbe.recordValue(152);
 
         assertTrue(workerProbe.getResult() != null);
     }


### PR DESCRIPTION
Added `recordValue(long latencyNanos)` to probes to ease latency measurements in asynchronous setups.