### PR TITLE
Added tests for external clients

### DIFF
--- a/dist/src/main/dist/tests/external/externalclientresponsetest.properties
+++ b/dist/src/main/dist/tests/external/externalclientresponsetest.properties
@@ -1,0 +1,2 @@
+class = com.hazelcast.simulator.tests.external.ExternalClientResponseTest
+delaySeconds = 60

--- a/dist/src/main/dist/tests/external/externalclienttest.properties
+++ b/dist/src/main/dist/tests/external/externalclienttest.properties
@@ -1,0 +1,3 @@
+class = com.hazelcast.simulator.tests.external.ExternalClientTest
+waitForClientsCount = 1
+waitIntervalSeconds = 10

--- a/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientResponseTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientResponseTest.java
@@ -1,0 +1,35 @@
+package com.hazelcast.simulator.tests.external;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.Setup;
+
+import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
+
+public class ExternalClientResponseTest {
+
+    private static final ILogger LOGGER = Logger.getLogger(ExternalClientResponseTest.class);
+
+    // properties
+    public String basename = "externalClientsFinished";
+    public int delaySeconds = 60;
+
+    private IAtomicLong clientsFinished;
+
+    @Setup
+    public void setUp(TestContext testContext) throws Exception {
+        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
+        this.clientsFinished = hazelcastInstance.getAtomicLong(basename);
+    }
+
+    @Run
+    public void run() {
+        sleepSeconds(delaySeconds);
+        clientsFinished.incrementAndGet();
+        LOGGER.info("Client response sent!");
+    }
+}

--- a/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
@@ -1,0 +1,39 @@
+package com.hazelcast.simulator.tests.external;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.Run;
+import com.hazelcast.simulator.test.annotations.Setup;
+
+import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
+
+public class ExternalClientTest {
+
+    private static final ILogger LOGGER = Logger.getLogger(ExternalClientTest.class);
+
+    // properties
+    public String basename = "externalClientsFinished";
+    public int waitForClientsCount = 1;
+    public int waitIntervalSeconds = 10;
+
+    private IAtomicLong clientsFinished;
+
+    @Setup
+    public void setUp(TestContext testContext) throws Exception {
+        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
+        this.clientsFinished = hazelcastInstance.getAtomicLong(basename);
+    }
+
+    @Run
+    public void run() {
+        long finishedClients;
+        do {
+            sleepSeconds(waitIntervalSeconds);
+            finishedClients = clientsFinished.get();
+        } while (finishedClients < waitForClientsCount);
+        LOGGER.info("Got response from " + finishedClients + " clients, stopping now!");
+    }
+}


### PR DESCRIPTION
I made a run with a simple testsuite and duration=0 to wait for all tests to finish:
```
ExternalClientTest@class = com.hazelcast.simulator.tests.external.ExternalClientTest
ExternalClientTest@waitForClientsCount = 2
ExternalClientTest@waitIntervalSeconds = 5

ExternalClient1@class = com.hazelcast.simulator.tests.external.ExternalClientResponseTest
ExternalClient1@delaySeconds = 15

ExternalClient2@class = com.hazelcast.simulator.tests.external.ExternalClientResponseTest
ExternalClient2@delaySeconds = 30
```

worker.log
```
INFO  2015-06-19 10:44:20,311 [Thread-11] com.hazelcast.simulator.tests.external.ExternalClientResponseTest: Client response sent!
INFO  2015-06-19 10:44:35,307 [Thread-12] com.hazelcast.simulator.tests.external.ExternalClientResponseTest: Client response sent!
INFO  2015-06-19 10:44:35,344 [Thread-10] com.hazelcast.simulator.tests.external.ExternalClientTest: Got response from 2 clients, stopping now!
```

Seems to work fine :)