### PR TITLE
Added method setValues(durationMs, invocations) to SimpleProbe

### DIFF
--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/IntervalProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/IntervalProbe.java
@@ -22,7 +22,8 @@ public interface IntervalProbe<R extends Result<R>, T extends SimpleProbe<R, T>>
     /**
      * Adds a latency value in nanoseconds to the probe result.
      *
-     * Can be used if {@link #started()} and {@link #done()} are not directly related, e.g. in asynchronous tests.
+     * Can be used if {@link #started()} and {@link #done()} are not directly related, e.g. in asynchronous tests or are collected
+     * from an external source like a C++ client.
      *
      * @param latencyNanos latency value in nanoseconds
      */

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/SimpleProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/SimpleProbe.java
@@ -25,5 +25,16 @@ public interface SimpleProbe<R extends Result<R>, T extends SimpleProbe<R, T>> {
 
     void stopProbing(long timeStamp);
 
+    /**
+     * Sets the throughput result by passing invocations and duration in milliseconds.
+     *
+     * Can be used if {@link #startProbing(long)} and {@link #stopProbing(long)} are not directly related, e.g. in asynchronous
+     * tests or are collected from an external source like a C++ client.
+     *
+     * @param durationMs  duration of sampling in milliseconds
+     * @param invocations number of invocation during sampling period
+     */
+    void setValues(long durationMs, int invocations);
+
     R getResult();
 }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractIntervalProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractIntervalProbe.java
@@ -24,6 +24,11 @@ public abstract class AbstractIntervalProbe<R extends Result<R>, T extends Inter
     protected int invocations;
 
     @Override
+    public void setValues(long durationMs, int invocations) {
+        throw new UnsupportedOperationException("This method is just supported by IntervalProbe implementations");
+    }
+
+    @Override
     public void started() {
         started = System.nanoTime();
     }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbe.java
@@ -73,6 +73,11 @@ public class ConcurrentProbe<R extends Result<R>, T extends IntervalProbe<R, T>>
     }
 
     @Override
+    public void setValues(long durationMs, int invocations) {
+        getProbe().setValues(durationMs, invocations);
+    }
+
+    @Override
     public R getResult() {
         Iterator<T> probeIterator = probeMap.values().iterator();
         if (!probeIterator.hasNext()) {

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbe.java
@@ -52,6 +52,10 @@ public final class DisabledProbe implements IntervalProbe<DisabledResult, Disabl
     }
 
     @Override
+    public void setValues(long durationMs, int invocations) {
+    }
+
+    @Override
     public DisabledResult getResult() {
         return RESULT;
     }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbe.java
@@ -18,11 +18,6 @@ package com.hazelcast.simulator.probes.probes.impl;
 public class OperationsPerSecProbe extends AbstractSimpleProbe<OperationsPerSecResult, OperationsPerSecProbe> {
 
     @Override
-    public void done() {
-        invocations++;
-    }
-
-    @Override
     public OperationsPerSecResult getResult(long durationMs) {
         return new OperationsPerSecResult(invocations, ((double) invocations / durationMs) * 1000);
     }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbe.java
@@ -29,6 +29,11 @@ public class WorkerProbe extends AbstractIntervalProbe<DisabledResult, WorkerPro
     }
 
     @Override
+    public void setValues(long durationMs, int invocations) {
+        this.invocations += invocations;
+    }
+
+    @Override
     public void done() {
         invocations++;
     }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbeTest.java
@@ -82,6 +82,20 @@ public class ConcurrentProbeTest {
     }
 
     @Test
+    public void testInvocationCountOnSimpleProbeWithSetValues() throws Exception {
+        ProbeSetValuesTester probeTester1 = new ProbeSetValuesTester(concurrentProbe);
+        ProbeSetValuesTester probeTester2 = new ProbeSetValuesTester(concurrentProbe);
+
+        probeTester1.start();
+        probeTester2.start();
+
+        probeTester1.join();
+        probeTester2.join();
+
+        assertEquals(10, concurrentProbe.getInvocationCount());
+    }
+
+    @Test
     public void testInvocationCountOnIntervalProbeWithRecordValue() throws Exception {
         concurrentProbe = (ConcurrentProbe) Probes.createConcurrentProbe("latency", IntervalProbe.class, config);
 
@@ -155,6 +169,20 @@ public class ConcurrentProbeTest {
             threadLocalProbe = probe.getProbe();
             probe.started();
             probe.done();
+        }
+    }
+
+    private static class ProbeSetValuesTester extends Thread {
+
+        private final ConcurrentProbe probe;
+
+        public ProbeSetValuesTester(ConcurrentProbe probe) {
+            this.probe = probe;
+        }
+
+        @Override
+        public void run() {
+            probe.setValues(1000, 5);
         }
     }
 

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbeTest.java
@@ -35,9 +35,16 @@ public class DisabledProbeTest {
     }
 
     @Test
-    public void testRecordValues() {
+    public void testRecordValue() {
         disabledProbe.recordValue(-1);
         disabledProbe.recordValue(500);
+
+        assertEquals(0, disabledProbe.getInvocationCount());
+    }
+
+    @Test
+    public void testSetValues() {
+        disabledProbe.setValues(123, 1254);
 
         assertEquals(0, disabledProbe.getInvocationCount());
     }
@@ -57,7 +64,7 @@ public class DisabledProbeTest {
     }
 
     @Test
-    public void testResult_withRecordValues() {
+    public void testResult_withRecordValue() {
         disabledProbe.recordValue(152);
 
         assertTrue(disabledProbe.getResult() != null);

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbeTest.java
@@ -32,8 +32,13 @@ public class HdrLatencyDistributionProbeTest {
         assertEquals(5, hdrLatencyDistributionProbe.getInvocationCount());
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetValues() {
+        hdrLatencyDistributionProbe.setValues(123, 125812);
+    }
+
     @Test
-    public void testRecordValues() {
+    public void testRecordValue() {
         hdrLatencyDistributionProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(500));
         hdrLatencyDistributionProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(200));
         hdrLatencyDistributionProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(1000));
@@ -67,7 +72,7 @@ public class HdrLatencyDistributionProbeTest {
     }
 
     @Test
-    public void testResult_withRecordValues() {
+    public void testResult_withRecordValue() {
         long sleepTime = TimeUnit.MILLISECONDS.toMicros(200);
         long tolerance = TimeUnit.MILLISECONDS.toMicros(801);
 

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/LatencyDistributionProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/LatencyDistributionProbeTest.java
@@ -31,8 +31,13 @@ public class LatencyDistributionProbeTest {
         assertEquals(5, latencyDistributionProbe.getInvocationCount());
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetValues() {
+        latencyDistributionProbe.setValues(123, 125812);
+    }
+
     @Test
-    public void testRecordValues() {
+    public void testRecordValue() {
         latencyDistributionProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(500));
         latencyDistributionProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(200));
         latencyDistributionProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(1000));
@@ -67,7 +72,7 @@ public class LatencyDistributionProbeTest {
     }
 
     @Test
-    public void testResult_withRecordValues() {
+    public void testResult_withRecordValue() {
         long minLatency = TimeUnit.MILLISECONDS.toMicros(200) / 10;
         long maxLatency = TimeUnit.MILLISECONDS.toMicros(1000) / 10;
 

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbeTest.java
@@ -30,8 +30,13 @@ public class MaxLatencyProbeTest {
         assertEquals(5, maxLatencyProbe.getInvocationCount());
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetValues() {
+        maxLatencyProbe.setValues(123, 125812);
+    }
+
     @Test
-    public void testRecordValues() {
+    public void testRecordValue() {
         maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(500));
         maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(200));
         maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(1000));
@@ -54,7 +59,7 @@ public class MaxLatencyProbeTest {
     }
 
     @Test
-    public void testResult_withRecordValues() {
+    public void testResult_withRecordValue() {
         maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(500));
         maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(200));
         maxLatencyProbe.recordValue(TimeUnit.MILLISECONDS.toNanos(1000));

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbeTest.java
@@ -28,13 +28,84 @@ public class OperationsPerSecProbeTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testRecordValues() {
+    public void testRecordValue() {
         operationsPerSecProbe.recordValue(500);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testResultWithInitialization() {
+    public void testStopProbingWithoutInitialization() {
+        operationsPerSecProbe.stopProbing(0);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testResultWithoutInitialization() {
         operationsPerSecProbe.getResult();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetValues_ZeroDuration() {
+        operationsPerSecProbe.setValues(0, 10000);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetValues_ZeroInvocations() {
+        operationsPerSecProbe.setValues(10000, 0);
+    }
+
+    @Test
+    public void testSetValues_10ops() {
+        operationsPerSecProbe.setValues(1000, 10);
+
+        OperationsPerSecResult result = operationsPerSecProbe.getResult();
+        assertTrue(result != null);
+
+        Long invocations = getObjectFromField(result, "invocations");
+        assertEqualsStringFormat("Expected %d invocations, but was %d", 10L, invocations);
+
+        Double operationsPerSecond = getObjectFromField(result, "operationsPerSecond");
+        assertEqualsStringFormat("Expected %.2f op/s, but was %.2f", 10.0, operationsPerSecond, 0.01);
+    }
+
+    @Test
+    public void testSetValues_20ops() {
+        operationsPerSecProbe.setValues(500, 10);
+
+        OperationsPerSecResult result = operationsPerSecProbe.getResult();
+        assertTrue(result != null);
+
+        Long invocations = getObjectFromField(result, "invocations");
+        assertEqualsStringFormat("Expected %d invocations, but was %d", 10L, invocations);
+
+        Double operationsPerSecond = getObjectFromField(result, "operationsPerSecond");
+        assertEqualsStringFormat("Expected %.2f op/s, but was %.2f", 20.0, operationsPerSecond, 0.01);
+    }
+
+    @Test
+    public void testSetValues_800ops() {
+        operationsPerSecProbe.setValues(5, 4);
+
+        OperationsPerSecResult result = operationsPerSecProbe.getResult();
+        assertTrue(result != null);
+
+        Long invocations = getObjectFromField(result, "invocations");
+        assertEqualsStringFormat("Expected %d invocations, but was %d", 4L, invocations);
+
+        Double operationsPerSecond = getObjectFromField(result, "operationsPerSecond");
+        assertEqualsStringFormat("Expected %.2f op/s, but was %.2f", 800.0, operationsPerSecond, 0.01);
+    }
+
+    @Test
+    public void testSetValues_8ops() {
+        operationsPerSecProbe.setValues(500, 4);
+
+        OperationsPerSecResult result = operationsPerSecProbe.getResult();
+        assertTrue(result != null);
+
+        Long invocations = getObjectFromField(result, "invocations");
+        assertEqualsStringFormat("Expected %d invocations, but was %d", 4L, invocations);
+
+        Double operationsPerSecond = getObjectFromField(result, "operationsPerSecond");
+        assertEqualsStringFormat("Expected %.2f op/s, but was %.2f", 8.0, operationsPerSecond, 0.01);
     }
 
     @Test

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbeTest.java
@@ -29,7 +29,7 @@ public class WorkerProbeTest {
     }
 
     @Test
-    public void testRecordValues() {
+    public void testRecordValue() {
         workerProbe.recordValue(-1);
         workerProbe.recordValue(5);
 
@@ -40,13 +40,23 @@ public class WorkerProbeTest {
     public void testResult() {
         workerProbe.done();
 
+        assertEquals(1, workerProbe.getInvocationCount());
         assertTrue(workerProbe.getResult() != null);
     }
 
     @Test
-    public void testResult_withRecordValues() {
+    public void testResult_withSetValues() {
+        workerProbe.setValues(123914, 12932);
+
+        assertEquals(12932, workerProbe.getInvocationCount());
+        assertTrue(workerProbe.getResult() != null);
+    }
+
+    @Test
+    public void testResult_withRecordValue() {
         workerProbe.recordValue(152);
 
+        assertEquals(1, workerProbe.getInvocationCount());
         assertTrue(workerProbe.getResult() != null);
     }
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
@@ -2,14 +2,19 @@ package com.hazelcast.simulator.tests.external;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
+import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.simulator.probes.probes.IntervalProbe;
+import com.hazelcast.simulator.probes.probes.SimpleProbe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
 
 public class ExternalClientTest {
 
@@ -20,11 +25,15 @@ public class ExternalClientTest {
     public int waitForClientsCount = 1;
     public int waitIntervalSeconds = 60;
 
+    IntervalProbe externalClientLatency;
+    SimpleProbe externalClientThroughput;
+
     private ICountDownLatch clientsRunning;
+    private HazelcastInstance hazelcastInstance;
 
     @Setup
     public void setUp(TestContext testContext) throws Exception {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
+        hazelcastInstance = testContext.getTargetInstance();
         this.clientsRunning = hazelcastInstance.getCountDownLatch(basename);
 
         clientsRunning.trySetCount(waitForClientsCount);
@@ -46,5 +55,29 @@ public class ExternalClientTest {
                 break;
             }
         }
+
+        IList<Long> latencyResults = hazelcastInstance.getList("externalClientsLatencyResults");
+        for (Long latency : latencyResults) {
+            externalClientLatency.recordValue(latency);
+        }
+
+        double totalDuration = 0;
+        int totalInvocations = 0;
+        IList<String> throughputResults = hazelcastInstance.getList("externalClientsThroughputResults");
+        for (String throughputString : throughputResults) {
+            String[] throughput = throughputString.split("\\|");
+            long operationCount = Long.valueOf(throughput[0]);
+            long duration = TimeUnit.NANOSECONDS.toMillis(Long.valueOf(throughput[1]));
+
+            LOGGER.info(format("External client executed %d operations in %d ms", operationCount, duration));
+
+            totalDuration += duration;
+            totalInvocations += operationCount;
+        }
+        long durationAvg = Math.round(totalDuration / throughputResults.size());
+
+        LOGGER.info(format("All external clients executed %d operations in %d ms", totalInvocations, durationAvg));
+
+        externalClientThroughput.setValues(durationAvg, totalInvocations);
     }
 }


### PR DESCRIPTION
Added method `setValues(durationMs, invocations)` to `SimpleProbe`.

This will be used to record throughput values from external clients, which measure the raw values by themselves, but have no probes implementation.