### PR TITLE
Fixed ProbesResultXmlReader

### DIFF
--- a/visualiser/src/main/java/com/hazelcast/simulator/visualiser/utils/DataSetUtils.java
+++ b/visualiser/src/main/java/com/hazelcast/simulator/visualiser/utils/DataSetUtils.java
@@ -37,7 +37,6 @@ public final class DataSetUtils {
         if (probeData instanceof LatencyDistributionResult) {
             return calcSingleProbeDataSet((LatencyDistributionResult) probeData, accuracy, scalingPercentile);
         }
-        System.err.println("Skipping unsupported probe result type: " + probeData.getClass().getSimpleName());
         return null;
     }
 


### PR DESCRIPTION
* Fixed reading of multiple probes in a single file in `ProbesResultXmlReader`.
* Removed debug message of unsupported probe types.