### PR TITLE
Added disable methods to probes

### DIFF
--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/SimpleProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/SimpleProbe.java
@@ -37,4 +37,18 @@ public interface SimpleProbe<R extends Result<R>, T extends SimpleProbe<R, T>> {
     void setValues(long durationMs, int invocations);
 
     R getResult();
+
+    /**
+     * Disable this probe during runtime, e.g. when just a single test instance should collect the results.
+     *
+     * Results from disabled probes are not collected, so {@link IllegalStateException} from uninitialized probes are ignored.
+     */
+    void disable();
+
+    /**
+     * Checks if a probe is disabled.
+     *
+     * @return <tt>true</tt> if probe is disabled, <tt>false</tt> otherwise.
+     */
+    boolean isDisabled();
 }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractIntervalProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractIntervalProbe.java
@@ -23,6 +23,8 @@ public abstract class AbstractIntervalProbe<R extends Result<R>, T extends Inter
     protected long started;
     protected int invocations;
 
+    private boolean disabled;
+
     @Override
     public void setValues(long durationMs, int invocations) {
         throw new UnsupportedOperationException("This method is just supported by IntervalProbe implementations");
@@ -52,5 +54,15 @@ public abstract class AbstractIntervalProbe<R extends Result<R>, T extends Inter
 
     @Override
     public void stopProbing(long timeStamp) {
+    }
+
+    @Override
+    public void disable() {
+        disabled = true;
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return disabled;
     }
 }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractSimpleProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/AbstractSimpleProbe.java
@@ -24,6 +24,8 @@ public abstract class AbstractSimpleProbe<R extends Result<R>, T extends Interva
     protected long durationMs;
     protected int invocations;
 
+    private boolean disabled;
+
     @Override
     public void started() {
     }
@@ -50,21 +52,27 @@ public abstract class AbstractSimpleProbe<R extends Result<R>, T extends Interva
 
     @Override
     public void stopProbing(long timeStamp) {
+        if (timeStamp < 0) {
+            throw new IllegalArgumentException("timeStamp must be zero or positive.");
+        }
         if (started == 0) {
             throw new IllegalStateException("Can't get result as probe has not been started yet.");
         }
 
         long stopOrNow = (timeStamp == 0 ? System.currentTimeMillis() : timeStamp);
         durationMs = stopOrNow - started;
+        if (durationMs < 1) {
+            throw new IllegalArgumentException("durationMs must be positive.");
+        }
     }
 
     @Override
     public void setValues(long durationMs, int invocations) {
         if (durationMs < 1) {
-            throw new IllegalArgumentException("durationMs must be positive!");
+            throw new IllegalArgumentException("durationMs must be positive.");
         }
         if (invocations < 1) {
-            throw new IllegalArgumentException("invocations must be positive!");
+            throw new IllegalArgumentException("invocations must be positive.");
         }
 
         this.durationMs = durationMs;
@@ -73,12 +81,18 @@ public abstract class AbstractSimpleProbe<R extends Result<R>, T extends Interva
 
     @Override
     public R getResult() {
-        if (durationMs == 0) {
-            throw new IllegalStateException("Can't get result as probe has no duration.");
-        }
-
         return getResult(durationMs);
     }
 
     protected abstract R getResult(long durationMs);
+
+    @Override
+    public void disable() {
+        disabled = true;
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return disabled;
+    }
 }

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/ConcurrentProbe.java
@@ -94,6 +94,16 @@ public class ConcurrentProbe<R extends Result<R>, T extends IntervalProbe<R, T>>
         return result;
     }
 
+    @Override
+    public void disable() {
+        getProbe().disable();
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return getProbe().isDisabled();
+    }
+
     T getProbe() {
         T probe = threadLocalProbe.get();
         if (probe != null) {

--- a/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbe.java
+++ b/probes/src/main/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbe.java
@@ -59,4 +59,13 @@ public final class DisabledProbe implements IntervalProbe<DisabledResult, Disabl
     public DisabledResult getResult() {
         return RESULT;
     }
+
+    @Override
+    public void disable() {
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return true;
+    }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/DisabledProbeTest.java
@@ -85,13 +85,22 @@ public class DisabledProbeTest {
         result.writeTo(null);
     }
 
-    @Test()
+    @Test
     public void testResultHashCode() {
         assertEquals(1, disabledProbe.getResult().hashCode());
     }
 
-    @Test()
+    @Test
     public void testResultEquals() {
         assertTrue(disabledProbe.getResult().equals(DisabledProbe.INSTANCE.getResult()));
+    }
+
+    @Test
+    public void testDisable() {
+        assertTrue(disabledProbe.isDisabled());
+
+        disabledProbe.disable();
+
+        assertTrue(disabledProbe.isDisabled());
     }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/HdrLatencyDistributionProbeTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepNanos;
 import static com.hazelcast.simulator.utils.TestUtils.assertEqualsStringFormat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -130,6 +131,8 @@ public class HdrLatencyDistributionProbeTest {
         assertTrue(result2 != null);
         assertEqualsStringFormat("Expected %d records, but was %d", 1L, result2.getHistogram().getTotalCount());
 
+        assertNotEquals(result1.hashCode(), result2.hashCode());
+
         HdrLatencyDistributionResult combined = result1.combine(result2);
         assertTrue(combined != null);
 
@@ -151,5 +154,14 @@ public class HdrLatencyDistributionProbeTest {
         double latency = histogram.getMean();
         assertTrue("latency should be >= " + sleepTime1 + ", but was " + latency, latency >= sleepTime1);
         assertTrue("latency should be < " + sleepTime2 + tolerance + ", but was " + latency, latency < sleepTime2 + tolerance);
+    }
+
+    @Test
+    public void testDisable() {
+        assertFalse(hdrLatencyDistributionProbe.isDisabled());
+
+        hdrLatencyDistributionProbe.disable();
+
+        assertTrue(hdrLatencyDistributionProbe.isDisabled());
     }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/LatencyDistributionProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/LatencyDistributionProbeTest.java
@@ -8,6 +8,8 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepNanos;
 import static com.hazelcast.simulator.utils.TestUtils.assertEqualsStringFormat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class LatencyDistributionProbeTest {
@@ -122,12 +124,15 @@ public class LatencyDistributionProbeTest {
         LatencyDistributionResult result1 = latencyDistributionProbe.getResult();
         assertTrue(result1 != null);
 
+        latencyDistributionProbe = new LatencyDistributionProbe();
         latencyDistributionProbe.started();
         sleepNanos(TimeUnit.MILLISECONDS.toNanos(sleepTime2));
         latencyDistributionProbe.done();
 
         LatencyDistributionResult result2 = latencyDistributionProbe.getResult();
         assertTrue(result2 != null);
+
+        assertNotEquals(result1.hashCode(), result2.hashCode());
 
         LatencyDistributionResult combined = result1.combine(result2);
         assertTrue(combined != null);
@@ -143,5 +148,14 @@ public class LatencyDistributionProbeTest {
             }
         }
         assertEqualsStringFormat("Expected to find %d buckets with latency info, but found %d", 2, foundBuckets);
+    }
+
+    @Test
+    public void testDisable() {
+        assertFalse(latencyDistributionProbe.isDisabled());
+
+        latencyDistributionProbe.disable();
+
+        assertTrue(latencyDistributionProbe.isDisabled());
     }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/MaxLatencyProbeTest.java
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepNanos;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getObjectFromField;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MaxLatencyProbeTest {
@@ -98,11 +100,22 @@ public class MaxLatencyProbeTest {
         MaxLatencyResult result2 = maxLatencyProbe.getResult();
         assertTrue(result2 != null);
 
+        assertNotEquals(result1.hashCode(), result2.hashCode());
+
         MaxLatencyResult combined = result1.combine(result2);
         assertTrue(combined != null);
 
         Long maxLatencyMs = getObjectFromField(combined, "maxLatencyMs");
         assertTrue(maxLatencyMs >= 300);
         assertTrue(maxLatencyMs < 1000);
+    }
+
+    @Test
+    public void testDisable() {
+        assertFalse(maxLatencyProbe.isDisabled());
+
+        maxLatencyProbe.disable();
+
+        assertTrue(maxLatencyProbe.isDisabled());
     }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/OperationsPerSecProbeTest.java
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getObjectFromField;
 import static com.hazelcast.simulator.utils.TestUtils.assertEqualsStringFormat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class OperationsPerSecProbeTest {
@@ -37,9 +39,15 @@ public class OperationsPerSecProbeTest {
         operationsPerSecProbe.stopProbing(0);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testResultWithoutInitialization() {
-        operationsPerSecProbe.getResult();
+    @Test(expected = IllegalArgumentException.class)
+    public void testStopProbingNegativeTimeStamp() {
+        operationsPerSecProbe.stopProbing(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStopProbingNegativeDuration() {
+        operationsPerSecProbe.startProbing(1000);
+        operationsPerSecProbe.stopProbing(999);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -159,6 +167,8 @@ public class OperationsPerSecProbeTest {
         OperationsPerSecResult result2 = operationsPerSecProbe.getResult();
         assertTrue(result2 != null);
 
+        assertNotEquals(result1.hashCode(), result2.hashCode());
+
         OperationsPerSecResult combined = result1.combine(result2);
         assertTrue(combined != null);
 
@@ -167,5 +177,14 @@ public class OperationsPerSecProbeTest {
 
         Double operationsPerSecond = getObjectFromField(combined, "operationsPerSecond");
         assertEqualsStringFormat("Expected %.2f op/s, but was %.2f", 1.2, operationsPerSecond, 0.01);
+    }
+
+    @Test
+    public void testDisable() {
+        assertFalse(operationsPerSecProbe.isDisabled());
+
+        operationsPerSecProbe.disable();
+
+        assertTrue(operationsPerSecProbe.isDisabled());
     }
 }

--- a/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbeTest.java
+++ b/probes/src/test/java/com/hazelcast/simulator/probes/probes/impl/WorkerProbeTest.java
@@ -3,6 +3,7 @@ package com.hazelcast.simulator.probes.probes.impl;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class WorkerProbeTest {
@@ -58,5 +59,14 @@ public class WorkerProbeTest {
 
         assertEquals(1, workerProbe.getInvocationCount());
         assertTrue(workerProbe.getResult() != null);
+    }
+
+    @Test
+    public void testDisable() {
+        assertFalse(workerProbe.isDisabled());
+
+        workerProbe.disable();
+
+        assertTrue(workerProbe.isDisabled());
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
@@ -7,7 +7,6 @@ import com.hazelcast.simulator.probes.probes.ProbesConfiguration;
 import com.hazelcast.simulator.probes.probes.ProbesType;
 import com.hazelcast.simulator.probes.probes.Result;
 import com.hazelcast.simulator.probes.probes.SimpleProbe;
-import com.hazelcast.simulator.probes.probes.impl.DisabledResult;
 import com.hazelcast.simulator.test.TestCase;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestPhase;
@@ -140,8 +139,8 @@ public class TestContainer<T extends TestContext> {
         for (Map.Entry<String, SimpleProbe<?, ?>> entry : probeMap.entrySet()) {
             String probeName = entry.getKey();
             SimpleProbe<?, ?> probe = entry.getValue();
-            Result<?> result = probe.getResult();
-            if (!(result instanceof DisabledResult)) {
+            if (!probe.isDisabled()) {
+                Result<?> result = probe.getResult();
                 results.put(probeName, result);
             }
         }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
@@ -69,6 +69,10 @@ public class ExternalClientTest {
 
         // just a single instance will collect the results from all external clients
         if (!isExternalResultsCollectorInstance) {
+            // disable probes
+            externalClientLatency.disable();
+            externalClientThroughput.disable();
+
             LOGGER.info("Stopping non result collecting ExternalClientTest");
             testContext.stop();
             return;


### PR DESCRIPTION
Added disable methods to probes to enable collection of probes from a single test instance in the cluster. Before the `getResult()` may have thrown an exception if there is no data in the probes of all other instances.