### PR TITLE
Optional synchronization for test phases

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -3,6 +3,7 @@ package com.hazelcast.simulator.coordinator;
 import com.hazelcast.simulator.agent.workerjvm.WorkerJvmSettings;
 import com.hazelcast.simulator.common.AgentsFile;
 import com.hazelcast.simulator.test.Failure;
+import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.test.TestSuite;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import joptsimple.OptionParser;
@@ -89,6 +90,10 @@ final class CoordinatorCli {
     private final OptionSpec parallelSpec = parser.accepts("parallel",
             "If defined tests are run in parallel.");
 
+    private final OptionSpec<TestPhase> syncToTestPhaseSpec = parser.accepts("syncToTestPhase",
+            "Defines the last TestPhase which is synchronized between all parallel running tests."
+            ).withRequiredArg().ofType(TestPhase.class).defaultsTo(TestPhase.SETUP);
+
     private final OptionSpec<String> workerVmOptionsSpec = parser.accepts("workerVmOptions",
             "Worker JVM options (quotes can be used). These options will be applied to regular members and mixed members"
                     + " (so with client + member in the same JVM).")
@@ -168,6 +173,7 @@ final class CoordinatorCli {
         coordinator.testStopTimeoutMs = options.valueOf(testStopTimeoutMsSpec);
         coordinator.agentsFile = getFile(agentsFileSpec, options, "Agents file");
         coordinator.parallel = options.has(parallelSpec);
+        coordinator.lastTestPhaseToSync = options.valueOf(syncToTestPhaseSpec);
 
         TestSuite testSuite = loadTestSuite(getTestSuiteFile(), options.valueOf(overridesSpec));
         testSuite.durationSeconds = getDurationSeconds();

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.simulator.coordinator;
 
+import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -216,6 +217,46 @@ public class CoordinatorCliTest {
 
         CoordinatorCli cli = new CoordinatorCli(coordinator, getArgs(false));
         cli.init();
+    }
+
+    @Test(expected = Exception.class)
+    public void testInit_syncToTestPhase_invalid() {
+        args.add("--waitForTestCaseCompletion");
+        args.add("--syncToTestPhase");
+        args.add("INVALID");
+
+        coordinatorCliInit();
+    }
+
+    @Test
+    public void testInit_syncToTestPhase_default() {
+        args.add("--waitForTestCaseCompletion");
+
+        coordinatorCliInit();
+
+        assertEquals(TestPhase.SETUP, coordinator.lastTestPhaseToSync);
+    }
+
+    @Test
+    public void testInit_syncToTestPhase_globalWarmup() {
+        args.add("--waitForTestCaseCompletion");
+        args.add("--syncToTestPhase");
+        args.add("GLOBAL_WARMUP");
+
+        coordinatorCliInit();
+
+        assertEquals(TestPhase.GLOBAL_WARMUP, coordinator.lastTestPhaseToSync);
+    }
+
+    @Test
+    public void testInit_syncToTestPhase_localVerify() {
+        args.add("--waitForTestCaseCompletion");
+        args.add("--syncToTestPhase");
+        args.add("LOCAL_VERIFY");
+
+        coordinatorCliInit();
+
+        assertEquals(TestPhase.LOCAL_VERIFY, coordinator.lastTestPhaseToSync);
     }
 
     private void coordinatorCliInit() {

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunTestSuiteTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunTestSuiteTest.java
@@ -90,11 +90,14 @@ public class CoordinatorRunTestSuiteTest {
         coordinator.testSuite = testSuite;
         coordinator.cooldownSeconds = 0;
         coordinator.testCaseRunnerSleepPeriod = 3;
+        coordinator.lastTestPhaseToSync = TestPhase.SETUP;
 
         when(agentsClient.getPublicAddresses()).thenReturn(privateAddressList);
         when(agentsClient.getAgentCount()).thenReturn(1);
 
         when(failureMonitor.getFailureCount()).thenReturn(0);
+
+        when(performanceMonitor.getPerformanceNumbers()).thenReturn(" (PerformanceMonitor is mocked)");
     }
 
     @After


### PR DESCRIPTION
Added an optional synchronization for test phases between parallel running tests. This is very useful if you have to coordinate actions between tests, which is e.g. needed when using external clients. The actual workaround is to manually sync the tests via `ICountDownLatch` or `IAtomicLong`, which is a lot of work and still racy.

The default behavior should not be changed, despite the setup phase, which will be the only phase which is synchronized by default. This should not significantly influence any of our test runs, since the setup phase should not run for a long time (we have the warmup phases for long running operations).

TLDR: All parallel running tests will now wait until all setup phases are done. Other phases can be synced optionally.