### PR TITLE
Cleanup of CLOUD_PROVIDER detection

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -40,9 +40,9 @@ public class Agent {
 
     private static final Logger LOGGER = Logger.getLogger(Coordinator.class);
 
+    String cloudProvider;
     String cloudIdentity;
     String cloudCredential;
-    String cloudProvider;
 
     // internal state
     volatile long lastUsed = System.currentTimeMillis();

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/HarakiriMonitor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/HarakiriMonitor.java
@@ -4,6 +4,8 @@ import org.apache.log4j.Logger;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
+import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.NativeUtils.execute;
 import static java.lang.String.format;
 
@@ -11,7 +13,11 @@ import static java.lang.String.format;
  * Responsible for terminating ec2-instances if they are not used to prevent running into a big bill.
  */
 public class HarakiriMonitor extends Thread {
+
+    private static final long MAX_IDLE_TIME_MS = TimeUnit.HOURS.toMillis(2);
+
     private static final Logger LOGGER = Logger.getLogger(HarakiriMonitor.class);
+
     private final Agent agent;
 
     public HarakiriMonitor(Agent agent) {
@@ -20,25 +26,18 @@ public class HarakiriMonitor extends Thread {
     }
 
     public void run() {
-        if (!"aws-ec2".equals(agent.cloudProvider)) {
-            LOGGER.info("No Harakiri monitor is active: only on aws-ec2 unused machines will be terminated.");
+        if (!isEC2(agent.cloudProvider)) {
+            LOGGER.info("No Harakiri monitor is active: only on AWS-EC2 unused machines will be terminated.");
             return;
         }
 
         LOGGER.info("Harakiri monitor is active");
-
         for (; ; ) {
-            try {
-                Thread.sleep(TimeUnit.MINUTES.toMillis(1));
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            sleepSeconds((int) TimeUnit.MINUTES.toSeconds(1));
 
-            long maxIdleTimeMs = TimeUnit.HOURS.toMillis(2);
-
-            boolean harakiri = System.currentTimeMillis() - maxIdleTimeMs > agent.lastUsed;
-            if (harakiri) {
-                LOGGER.info("Trying to commit Harakiri (will only try once)");
+            boolean doHarakiri = (System.currentTimeMillis() - MAX_IDLE_TIME_MS > agent.lastUsed);
+            if (doHarakiri) {
+                LOGGER.info("Trying to commit Harakiri once!");
                 try {
                     String cmd = format("ec2-terminate-instances $(curl -s http://169.254.169.254/latest/meta-data/instance-id) "
                             + "--aws-access-key %s --aws-secret-key %s", agent.cloudIdentity, agent.cloudCredential);

--- a/simulator/src/main/java/com/hazelcast/simulator/common/SimulatorProperties.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/SimulatorProperties.java
@@ -86,10 +86,6 @@ public class SimulatorProperties {
         }
     }
 
-    public boolean isEC2() {
-        return "aws-ec2".equals(get("CLOUD_PROVIDER"));
-    }
-
     public String getUser() {
         return get("USER", "simulator");
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/TemplateBuilder.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/TemplateBuilder.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
+
 class TemplateBuilder {
 
     private static final Logger LOGGER = Logger.getLogger(Provisioner.class);
@@ -56,7 +58,7 @@ class TemplateBuilder {
             initSecurityGroup();
             template.getOptions().securityGroups(securityGroup);
         } else {
-            if (!props.isEC2()) {
+            if (!isEC2(props.get("CLOUD_PROVIDER"))) {
                 throw new IllegalStateException("SUBNET_ID can be used only when EC2 is configured as a cloud provider.");
             }
             LOGGER.info("Using VPC, Subnet ID = " + subnetId);
@@ -92,7 +94,7 @@ class TemplateBuilder {
     }
 
     private void initSecurityGroup() {
-        if (!props.isEC2()) {
+        if (!isEC2(props.get("CLOUD_PROVIDER"))) {
             return;
         }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/CloudProviderUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/CloudProviderUtils.java
@@ -1,0 +1,15 @@
+package com.hazelcast.simulator.utils;
+
+public final class CloudProviderUtils {
+
+    private CloudProviderUtils() {
+    }
+
+    public static boolean isStatic(String cloudProvider) {
+        return "static".equals(cloudProvider);
+    }
+
+    public static boolean isEC2(String cloudProvider) {
+        return "aws-ec2".equals(cloudProvider);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/common/SimulatorPropertiesTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/common/SimulatorPropertiesTest.java
@@ -139,11 +139,6 @@ public class SimulatorPropertiesTest {
     }
 
     @Test
-    public void testIsEC2() throws Exception {
-        assertTrue(simulatorProperties.isEC2());
-    }
-
-    @Test
     public void testGetUser() throws Exception {
         assertEquals("simulator", simulatorProperties.getUser());
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/CloudProviderUtilsTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/CloudProviderUtilsTest.java
@@ -1,0 +1,35 @@
+package com.hazelcast.simulator.utils;
+
+import org.junit.Test;
+
+import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CloudProviderUtilsTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        invokePrivateConstructor(CloudProviderUtils.class);
+    }
+
+    @Test
+    public void testIsStatic_true() throws Exception {
+        assertTrue(CloudProviderUtils.isStatic("static"));
+    }
+
+    @Test
+    public void testIsStatic_false() throws Exception {
+        assertFalse(CloudProviderUtils.isStatic("google-compute-engine"));
+    }
+
+    @Test
+    public void testIsEC2_true() throws Exception {
+        assertTrue(CloudProviderUtils.isEC2("aws-ec2"));
+    }
+
+    @Test
+    public void testisEC2_false() throws Exception {
+        assertFalse(CloudProviderUtils.isEC2("google-compute-engine"));
+    }
+}


### PR DESCRIPTION
* Added `CloudProviderUtils` to have all String comparisons of CLOUD_PROVIDER in a single place.
* Replaced `exitOnError()` with proper use of `CommandLineExitException`.
* Minimal cleanup of `HarakiriMonitor`.