### PR TITLE
Made passive member mode configurable.

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerjvm/WorkerJvmSettings.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerjvm/WorkerJvmSettings.java
@@ -18,6 +18,7 @@ package com.hazelcast.simulator.agent.workerjvm;
 import java.io.Serializable;
 
 public class WorkerJvmSettings implements Serializable {
+
     public String vmOptions;
     public String clientVmOptions;
     public String hzConfig;
@@ -27,6 +28,7 @@ public class WorkerJvmSettings implements Serializable {
     public int memberWorkerCount;
     public int clientWorkerCount;
     public boolean autoCreateHZInstances = true;
+    public boolean passiveMembers = true;
 
     public int workerStartupTimeout;
     public boolean refreshJvm;
@@ -49,9 +51,12 @@ public class WorkerJvmSettings implements Serializable {
         this.hzConfig = settings.hzConfig;
         this.clientHzConfig = settings.clientHzConfig;
         this.log4jConfig = settings.log4jConfig;
+
         this.memberWorkerCount = settings.memberWorkerCount;
         this.clientWorkerCount = settings.clientWorkerCount;
         this.autoCreateHZInstances = settings.autoCreateHZInstances;
+        this.passiveMembers = settings.passiveMembers;
+
         this.workerStartupTimeout = settings.workerStartupTimeout;
         this.refreshJvm = settings.refreshJvm;
         this.javaVendor = settings.javaVendor;

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -23,6 +23,7 @@ import static com.hazelcast.simulator.utils.FileUtils.fileAsText;
 import static com.hazelcast.simulator.utils.FileUtils.getFile;
 import static com.hazelcast.simulator.utils.FileUtils.getFileAsTextFromWorkingDirOrBaseDir;
 import static com.hazelcast.simulator.utils.FileUtils.newFile;
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 
 final class CoordinatorCli {
@@ -192,6 +193,7 @@ final class CoordinatorCli {
         workerJvmSettings.memberWorkerCount = options.valueOf(memberWorkerCountSpec);
         workerJvmSettings.clientWorkerCount = options.valueOf(clientWorkerCountSpec);
         workerJvmSettings.autoCreateHZInstances = options.valueOf(autoCreateHZInstancesSpec);
+        workerJvmSettings.passiveMembers = parseBoolean(coordinator.props.get("PASSIVE_MEMBERS", "true"));
 
         workerJvmSettings.workerStartupTimeout = options.valueOf(workerStartupTimeoutSpec);
         workerJvmSettings.hzConfig = loadHzConfig();

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -157,10 +157,12 @@ final class TestCaseRunner {
     }
 
     private void startTestCase() throws TimeoutException {
-        echo("Starting Test start");
         WorkerJvmSettings workerJvmSettings = coordinator.workerJvmSettings;
+        boolean isPassiveMembers = (workerJvmSettings.passiveMembers && workerJvmSettings.clientWorkerCount > 0);
+
+        echo(format("Starting Test start (%s members)", (isPassiveMembers) ? "passive" : "active"));
         RunCommand runCommand = new RunCommand(testCaseId);
-        runCommand.clientOnly = workerJvmSettings.clientWorkerCount > 0;
+        runCommand.passiveMembers = isPassiveMembers;
         agentsClient.executeOnAllWorkers(runCommand);
         echo("Completed Test start");
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
@@ -204,8 +204,7 @@ class WorkerCommandRequestProcessor {
                     return;
                 }
 
-                boolean passive = (command.clientOnly && clientInstance == null);
-                if (passive) {
+                if (command.passiveMembers && clientInstance == null) {
                     LOGGER.info(format("%s Skipping run of %s (member is passive) %s", DASHES, testName, DASHES));
                     return;
                 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/commands/RunCommand.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/commands/RunCommand.java
@@ -5,7 +5,7 @@ public class RunCommand extends Command {
     public static final long serialVersionUID = 0L;
 
     public String testId;
-    public boolean clientOnly;
+    public boolean passiveMembers;
 
     public RunCommand(String testId) {
         this.testId = testId;
@@ -15,7 +15,7 @@ public class RunCommand extends Command {
     public String toString() {
         return "RunCommand{"
                 + "testId='" + testId + '\''
-                + ", clientOnly=" + clientOnly
+                + ", passiveMembers=" + passiveMembers
                 + '}';
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -126,7 +126,7 @@ public class AgentSmokeTest {
 
         LOGGER.info("Starting run phase...");
         RunCommand runCommand = new RunCommand(testCase.getId());
-        runCommand.clientOnly = false;
+        runCommand.passiveMembers = false;
         agentsClient.executeOnAllWorkers(runCommand);
 
         LOGGER.info("Running for " + TEST_RUNTIME_SECONDS + " seconds");

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessorTest.java
@@ -190,7 +190,7 @@ public class WorkerCommandRequestProcessorTest {
 
         initTestCase(defaultTestCase);
         RunCommand command = new RunCommand(DEFAULT_TEST_ID);
-        command.clientOnly = true;
+        command.passiveMembers = true;
         handleRequestAndAssertId(command);
 
         waitForPhaseCompletion(DEFAULT_TEST_ID, TestPhase.RUN);


### PR DESCRIPTION
Made passive mode for members configurable via `simulator.properties`. Per default it is still enabled, but you can switch it off now to have a run phase on the member side, even if there are clients on the same node!