### PR TITLE
Probe configuration improvements

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/TestContainer.java
@@ -316,15 +316,6 @@ public class TestContainer<T extends TestContext> {
         if (parameterType.isAssignableFrom(TestContext.class)) {
             return testContext;
         }
-        String probeName = getValueFromNameAnnotations(parameterAnnotations, "Probe" + index);
-        if (IntervalProbe.class.equals(parameterType)) {
-            return getOrCreateConcurrentProbe(probeName, IntervalProbe.class);
-        }
-        if (SimpleProbe.class.equals(parameterType)) {
-            SimpleProbe probe = getOrCreateConcurrentProbe(probeName, SimpleProbe.class);
-            probeMap.put(probeName, probe);
-            return probe;
-        }
         throw new IllegalTestException(format("Unknown parameter type %s at index %s in setup method", parameterType, index));
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
@@ -173,7 +173,7 @@ class WorkerCommandRequestProcessor {
                 Object testInstance = InitCommand.class.getClassLoader().loadClass(testCase.getClassname()).newInstance();
                 bindProperties(testInstance, testCase, TestContainer.OPTIONAL_TEST_PROPERTIES);
                 TestContextImpl testContext = new TestContextImpl(testId, getHazelcastInstance());
-                ProbesConfiguration probesConfiguration = parseProbeConfiguration(testCase);
+                ProbesConfiguration probesConfiguration = parseProbeConfiguration(testInstance, testCase);
 
                 tests.put(testId, new TestContainer<TestContext>(testInstance, testContext, probesConfiguration, testCase));
                 testsPending.incrementAndGet();

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupportTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupportTest.java
@@ -1,9 +1,11 @@
 package com.hazelcast.simulator.utils;
 
+import com.hazelcast.simulator.probes.probes.IntervalProbe;
 import com.hazelcast.simulator.probes.probes.ProbesConfiguration;
 import com.hazelcast.simulator.test.TestCase;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,7 +28,6 @@ public class PropertyBindingSupportTest {
     @Test
     public void bindProperties_notFound_optional() {
         testCase.setProperty("class", "willBeIgnored");
-        testCase.setProperty("probe-getLatency", "willBeIgnored");
         testCase.setProperty("notExist", "isOptional");
 
         Set<String> optionalProperties = new HashSet<String>();
@@ -71,18 +72,31 @@ public class PropertyBindingSupportTest {
     @Test
     public void testParseProbesConfiguration() {
         testCase.setProperty("class", "foobar");
-        testCase.setProperty("probe-probe1", "latency");
-        testCase.setProperty("probe-probe2", "hdr");
+        testCase.setProperty("probe1", "latency");
+        testCase.setProperty("probe2", "hdr");
 
-        ProbesConfiguration config = parseProbeConfiguration(testCase);
+        TestClassWithProbes testInstance = new TestClassWithProbes();
+
+        ProbesConfiguration config = parseProbeConfiguration(testInstance, testCase);
         assertEquals("latency", config.getConfig("probe1"));
         assertEquals("hdr", config.getConfig("probe2"));
         assertEquals(null, config.getConfig("notConfigured"));
+    }
+
+    @Test(expected = BindException.class)
+    public void testFailFastWhenPropertyNotFound() {
+        testCase.setProperty("doesNotExist", "foobar");
+        bindProperties(bindPropertyTestClass, testCase, Collections.EMPTY_SET);
     }
 
     @SuppressWarnings("unused")
     private class BindPropertyTestClass {
 
         public String stringField;
+    }
+
+    private class TestClassWithProbes {
+        public IntervalProbe probe1;
+        public IntervalProbe probe2;
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/TestContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/TestContainerTest.java
@@ -321,7 +321,7 @@ public class TestContainerTest {
     private static class SetupWithValidArgumentsTest extends DummyTest {
 
         @Setup
-        public void setUp(TestContext testContext, SimpleProbe simpleProbe, IntervalProbe intervalProbe) {
+        public void setUp(TestContext testContext) {
         }
     }
 
@@ -347,24 +347,6 @@ public class TestContainerTest {
         testContainer.invoke(TestPhase.SETUP);
 
         assertNotNull(test.simpleProbe);
-    }
-
-    @Test
-    public void testProbeExplicitNameSetViaAnnotation() throws Exception {
-        ProbeTest test = new ProbeTest();
-        probesConfiguration.addConfig("explicitProbeName", ProbesType.THROUGHPUT.getName());
-        testContainer = createTestContainer(test);
-
-        assertTrue(testContainer.hasProbe("explicitProbeName"));
-    }
-
-    @Test
-    public void testProbeImplicitName() throws Exception {
-        ProbeTest test = new ProbeTest();
-        probesConfiguration.addConfig("Probe2", ProbesType.THROUGHPUT.getName());
-        testContainer = createTestContainer(test);
-
-        assertTrue(testContainer.hasProbe("Probe2"));
     }
 
     @Test
@@ -430,9 +412,8 @@ public class TestContainerTest {
         private IntervalProbe disabled;
 
         @Setup
-        public void setUp(TestContext context, @Name("explicitProbeName") SimpleProbe probe1, SimpleProbe probe2) {
+        public void setUp(TestContext context) {
             this.context = context;
-            this.simpleProbe = probe1;
         }
 
         @Run


### PR DESCRIPTION
1. Probe configuration via properties does not use the `probe-` prefix anymore.
2. Fail-fast behaviour re-introduced - there is a fast failure when unknown property is configured.
3. I did remove the option to inject probes via Setup method. It's not used in practice and it just adds complexity.