### PR TITLE
Fixed infinite wait() in CommandFuture

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/CommandFuture.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/CommandFuture.java
@@ -11,6 +11,8 @@ import static java.lang.String.format;
 
 public final class CommandFuture<E> implements Future<E> {
 
+    private static final long ONE_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
+
     private static final Object NO_RESULT = new Object();
 
     private final Command command;
@@ -70,7 +72,7 @@ public final class CommandFuture<E> implements Future<E> {
 
         long remainingTimeoutNanos = timeUnit.toNanos(timeout);
         synchronized (this) {
-            while (NO_RESULT.equals(result) && remainingTimeoutNanos > 0) {
+            while (NO_RESULT.equals(result) && remainingTimeoutNanos > ONE_MILLISECOND) {
                 long started = System.nanoTime();
                 wait(TimeUnit.NANOSECONDS.toMillis(remainingTimeoutNanos));
                 remainingTimeoutNanos -= System.nanoTime() - started;

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/CommandFutureTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/CommandFutureTest.java
@@ -26,7 +26,7 @@ public class CommandFutureTest {
     private final CommandFuture<Object> exceptionFuture = new CommandFuture<Object>(command);
     private final FutureExceptionSetter futureExceptionSetter = new FutureExceptionSetter(exceptionFuture, DEFAULT_TIMEOUT_MS);
 
-    @Test()
+    @Test
     public void testGetCommand() throws Exception {
         assertEquals(command, future.getCommand());
     }
@@ -77,6 +77,11 @@ public class CommandFutureTest {
     @Test(timeout = 10000, expected = TimeoutException.class)
     public void testGet_withTimeout_noResult() throws Exception {
         future.get(50, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(timeout = 10000, expected = TimeoutException.class)
+    public void testGet_withTimeout_belowOneMilliSecond_noResult() throws Exception {
+        future.get(1, TimeUnit.NANOSECONDS);
     }
 
     @Test(timeout = 10000, expected = TimeoutException.class)


### PR DESCRIPTION
Fixed possible `wait(0)` if `CommandFuture` was used with timeout values under one millisecond.

Kudos to @jerrinot who found this issue in my Simulator Protocol PR.