### PR TITLE
Initial migration of WorkerCommandRequestProcessor

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/WorkerConnector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/WorkerConnector.java
@@ -29,7 +29,7 @@ public class WorkerConnector {
      * @param port               the port for incoming connections
      */
     public WorkerConnector(int addressIndex, int parentAddressIndex, int port) {
-        OperationProcessor processor = new WorkerOperationProcessor();
+        OperationProcessor processor = new WorkerOperationProcessor(null, null);
         ConcurrentMap<String, ResponseFuture> futureMap = new ConcurrentHashMap<String, ResponseFuture>();
         SimulatorAddress localAddress = new SimulatorAddress(WORKER, parentAddressIndex, addressIndex, 0);
 

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/core/ResponseType.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/core/ResponseType.java
@@ -29,7 +29,13 @@ public enum ResponseType {
      * Is returned when an implementation of {@link com.hazelcast.simulator.protocol.processors.OperationProcessor}
      * does not implement the transmitted {@link com.hazelcast.simulator.protocol.operation.SimulatorOperation}.
      */
-    UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR(4);
+    UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR(4),
+
+    /**
+     * Is returned when an exception occurs during the execution of a
+     * {@link com.hazelcast.simulator.protocol.operation.SimulatorOperation}.
+     */
+    EXCEPTION_DURING_OPERATION_EXECUTION(5);
 
     private final int ordinal;
 

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/CreateTestOperation.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/CreateTestOperation.java
@@ -1,0 +1,25 @@
+package com.hazelcast.simulator.protocol.operation;
+
+import com.hazelcast.simulator.test.TestCase;
+
+import java.util.Map;
+
+public class CreateTestOperation implements SimulatorOperation {
+
+    private final String testId;
+    private final Map<String, String> properties;
+
+    public CreateTestOperation(TestCase testCase) {
+        this.testId = testCase.getId();
+        this.properties = testCase.getProperties();
+    }
+
+    @Override
+    public OperationType getOperationType() {
+        return OperationType.CREATE_TEST;
+    }
+
+    public TestCase getTestCase() {
+        return new TestCase(testId, properties);
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/IntegrationTestOperation.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/IntegrationTestOperation.java
@@ -12,7 +12,7 @@ public class IntegrationTestOperation implements SimulatorOperation {
 
     @Override
     public OperationType getOperationType() {
-        return OperationType.INTEGRATION_TEST_OPERATION;
+        return OperationType.INTEGRATION_TEST;
     }
 
     public String getTestData() {

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/OperationType.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/OperationType.java
@@ -1,8 +1,15 @@
 package com.hazelcast.simulator.protocol.operation;
 
+/**
+ * Defines the operation type for a {@link com.hazelcast.simulator.protocol.core.SimulatorMessage}.
+ */
 public enum OperationType {
 
-    INTEGRATION_TEST_OPERATION(IntegrationTestOperation.class, 0);
+    INTEGRATION_TEST(IntegrationTestOperation.class, 0),
+
+    CREATE_AGENT(IntegrationTestOperation.class, 1),
+    CREATE_WORKER(IntegrationTestOperation.class, 2),
+    CREATE_TEST(CreateTestOperation.class, 3);
 
     private final Class<? extends SimulatorOperation> classType;
     private final int classId;

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessor.java
@@ -1,29 +1,18 @@
 package com.hazelcast.simulator.protocol.processors;
 
 import com.hazelcast.simulator.protocol.core.ResponseType;
-import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
-import org.apache.log4j.Logger;
 
-import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
 import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
-import static org.junit.Assert.assertEquals;
 
 /**
- * An {@link OperationProcessor} to process {@link SimulatorOperation} instances on a Simulator Agent.
+ * An {@link OperationProcessor} implementation to process {@link SimulatorOperation} instances on a Simulator Agent.
  */
-public class AgentOperationProcessor implements OperationProcessor {
-
-    private static final Logger LOGGER = Logger.getLogger(AgentOperationProcessor.class);
+public class AgentOperationProcessor extends OperationProcessor {
 
     @Override
-    public ResponseType process(SimulatorOperation operation) {
-        LOGGER.debug("AgentOperationProcessor.process() " + operation.getClass().getSimpleName());
-
+    protected ResponseType processOperation(SimulatorOperation operation) throws Exception {
         switch (operation.getOperationType()) {
-            case INTEGRATION_TEST_OPERATION:
-                assertEquals(IntegrationTestOperation.TEST_DATA, ((IntegrationTestOperation) operation).getTestData());
-                return SUCCESS;
             default:
                 return UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessor.java
@@ -1,29 +1,18 @@
 package com.hazelcast.simulator.protocol.processors;
 
 import com.hazelcast.simulator.protocol.core.ResponseType;
-import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
-import org.apache.log4j.Logger;
 
-import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
 import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
-import static org.junit.Assert.assertEquals;
 
 /**
- * An {@link OperationProcessor} to process {@link SimulatorOperation} instances on a Simulator Coordinator.
+ * An {@link OperationProcessor} implementation to process {@link SimulatorOperation} instances on a Simulator Coordinator.
  */
-public class CoordinatorOperationProcessor implements OperationProcessor {
-
-    private static final Logger LOGGER = Logger.getLogger(CoordinatorOperationProcessor.class);
+public class CoordinatorOperationProcessor extends OperationProcessor {
 
     @Override
-    public ResponseType process(SimulatorOperation operation) {
-        LOGGER.info("CoordinatorOperationProcessor.process() " + operation.getClass().getSimpleName());
-
+    protected ResponseType processOperation(SimulatorOperation operation) throws Exception {
         switch (operation.getOperationType()) {
-            case INTEGRATION_TEST_OPERATION:
-                assertEquals(IntegrationTestOperation.TEST_DATA, ((IntegrationTestOperation) operation).getTestData());
-                return SUCCESS;
             default:
                 return UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/OperationProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/OperationProcessor.java
@@ -1,12 +1,39 @@
 package com.hazelcast.simulator.protocol.processors;
 
 import com.hazelcast.simulator.protocol.core.ResponseType;
+import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.protocol.operation.OperationType;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import org.apache.log4j.Logger;
+
+import static com.hazelcast.simulator.protocol.core.ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION;
+import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
 
 /**
  * Processes {@link SimulatorOperation} instances on a Simulator component.
  */
-public interface OperationProcessor {
+public abstract class OperationProcessor {
 
-    ResponseType process(SimulatorOperation operation);
+    private static final Logger LOGGER = Logger.getLogger(OperationProcessor.class);
+
+    public final ResponseType process(SimulatorOperation operation) {
+        OperationType operationType = operation.getOperationType();
+        LOGGER.info(getClass().getSimpleName() + ".process(" + operation.getClass().getSimpleName() + ")");
+        try {
+            switch (operationType) {
+                case INTEGRATION_TEST:
+                    if (!IntegrationTestOperation.TEST_DATA.equals(((IntegrationTestOperation) operation).getTestData())) {
+                        throw new IllegalStateException();
+                    }
+                    return SUCCESS;
+                default:
+                    return processOperation(operation);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error during processing an operation", e);
+            return EXCEPTION_DURING_OPERATION_EXECUTION;
+        }
+    }
+
+    protected abstract ResponseType processOperation(SimulatorOperation operation) throws Exception;
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/TestOperationProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/TestOperationProcessor.java
@@ -1,29 +1,18 @@
 package com.hazelcast.simulator.protocol.processors;
 
 import com.hazelcast.simulator.protocol.core.ResponseType;
-import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
-import org.apache.log4j.Logger;
 
-import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
 import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
-import static org.junit.Assert.assertEquals;
 
 /**
- * An {@link OperationProcessor} to process {@link SimulatorOperation} instances on a Simulator Test.
+ * An {@link OperationProcessor} implementation to process {@link SimulatorOperation} instances on a Simulator Test.
  */
-public class TestOperationProcessor implements OperationProcessor {
-
-    private static final Logger LOGGER = Logger.getLogger(TestOperationProcessor.class);
+public class TestOperationProcessor extends OperationProcessor {
 
     @Override
-    public ResponseType process(SimulatorOperation operation) {
-        LOGGER.info("TestOperationProcessor.process() " + operation.getClass().getSimpleName());
-
+    protected ResponseType processOperation(SimulatorOperation operation) throws Exception {
         switch (operation.getOperationType()) {
-            case INTEGRATION_TEST_OPERATION:
-                assertEquals(IntegrationTestOperation.TEST_DATA, ((IntegrationTestOperation) operation).getTestData());
-                return SUCCESS;
             default:
                 return UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/WorkerOperationProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/WorkerOperationProcessor.java
@@ -1,31 +1,95 @@
 package com.hazelcast.simulator.protocol.processors;
 
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.simulator.probes.probes.ProbesConfiguration;
 import com.hazelcast.simulator.protocol.core.ResponseType;
-import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.protocol.operation.CreateTestOperation;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import com.hazelcast.simulator.test.TestCase;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.worker.TestContainer;
+import com.hazelcast.simulator.worker.TestContextImpl;
 import org.apache.log4j.Logger;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
 import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
-import static org.junit.Assert.assertEquals;
+import static com.hazelcast.simulator.utils.FileUtils.isValidFileName;
+import static com.hazelcast.simulator.utils.PropertyBindingSupport.bindProperties;
+import static com.hazelcast.simulator.utils.PropertyBindingSupport.parseProbeConfiguration;
+import static com.hazelcast.simulator.utils.TestUtils.getUserContextKeyFromTestId;
+import static java.lang.String.format;
 
 /**
- * An {@link OperationProcessor} to process {@link SimulatorOperation} instances on a Simulator Worker.
+ * An {@link OperationProcessor} implementation to process {@link SimulatorOperation} instances on a Simulator Worker.
  */
-public class WorkerOperationProcessor implements OperationProcessor {
+public class WorkerOperationProcessor extends OperationProcessor {
 
+    private static final String DASHES = "---------------------------";
     private static final Logger LOGGER = Logger.getLogger(WorkerOperationProcessor.class);
 
-    @Override
-    public ResponseType process(SimulatorOperation operation) {
-        LOGGER.info("WorkerOperationProcessor.process() " + operation.getClass().getSimpleName());
+    private final AtomicInteger testsPending = new AtomicInteger(0);
+    //private final AtomicInteger testsCompleted = new AtomicInteger(0);
 
+    private final ConcurrentMap<String, TestContainer<TestContext>> tests
+            = new ConcurrentHashMap<String, TestContainer<TestContext>>();
+
+    //private final ConcurrentMap<String, TestPhase> testPhases = new ConcurrentHashMap<String, TestPhase>();
+
+    private final HazelcastInstance serverInstance;
+    private final HazelcastInstance clientInstance;
+
+    public WorkerOperationProcessor(HazelcastInstance serverInstance, HazelcastInstance clientInstance) {
+        this.serverInstance = serverInstance;
+        this.clientInstance = clientInstance;
+    }
+
+    @Override
+    protected ResponseType processOperation(SimulatorOperation operation) throws Exception {
         switch (operation.getOperationType()) {
-            case INTEGRATION_TEST_OPERATION:
-                assertEquals(IntegrationTestOperation.TEST_DATA, ((IntegrationTestOperation) operation).getTestData());
-                return SUCCESS;
+            case CREATE_TEST:
+                processCreateTest((CreateTestOperation) operation);
+                break;
             default:
                 return UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
         }
+        return SUCCESS;
+    }
+
+    private void processCreateTest(CreateTestOperation operation) throws Exception {
+        TestCase testCase = operation.getTestCase();
+        String testId = testCase.getId();
+        if (tests.containsKey(testId)) {
+            throw new IllegalStateException(
+                    format("Can't init TestCase: %s, another test with testId [%s] already exists", operation, testId));
+        }
+        if (!testId.isEmpty() && !isValidFileName(testId)) {
+            throw new IllegalArgumentException(
+                    format("Can't init TestCase: %s, testId [%s] is an invalid filename", operation, testId));
+        }
+
+        LOGGER.info(format("%s Initializing test %s %s%n%s", DASHES, testId, DASHES, testCase));
+
+        Object testInstance = CreateTestOperation.class.getClassLoader().loadClass(testCase.getClassname()).newInstance();
+        bindProperties(testInstance, testCase, TestContainer.OPTIONAL_TEST_PROPERTIES);
+        TestContextImpl testContext = new TestContextImpl(testId, getHazelcastInstance());
+        ProbesConfiguration probesConfiguration = parseProbeConfiguration(testInstance, testCase);
+
+        tests.put(testId, new TestContainer<TestContext>(testInstance, testContext, probesConfiguration, testCase));
+        testsPending.incrementAndGet();
+
+        if (serverInstance != null) {
+            serverInstance.getUserContext().put(getUserContextKeyFromTestId(testId), testInstance);
+        }
+    }
+
+    private HazelcastInstance getHazelcastInstance() {
+        if (clientInstance != null) {
+            return clientInstance;
+        }
+        return serverInstance;
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/TestContextImpl.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/TestContextImpl.java
@@ -3,13 +3,13 @@ package com.hazelcast.simulator.worker;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.simulator.test.TestContext;
 
-class TestContextImpl implements TestContext {
+public class TestContextImpl implements TestContext {
     private final String testId;
     private final HazelcastInstance hazelcastInstance;
 
     private volatile boolean stopped;
 
-    TestContextImpl(String testId, HazelcastInstance hazelcastInstance) {
+    public TestContextImpl(String testId, HazelcastInstance hazelcastInstance) {
         this.testId = testId;
         this.hazelcastInstance = hazelcastInstance;
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/ProtocolUtil.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/ProtocolUtil.java
@@ -161,7 +161,12 @@ public class ProtocolUtil {
     }
 
     static SimulatorMessage buildMessage(SimulatorAddress destination, SimulatorAddress source) {
-        return new SimulatorMessage(destination, source, MESSAGE_ID.incrementAndGet(), OPERATION_TYPE, OPERATION_JSON);
+        return buildMessage(destination, source, OPERATION_TYPE, OPERATION_JSON);
+    }
+
+    static SimulatorMessage buildMessage(SimulatorAddress destination, SimulatorAddress source,
+                                         OperationType operationType, String operationData) {
+        return new SimulatorMessage(destination, source, MESSAGE_ID.incrementAndGet(), operationType, operationData);
     }
 
     static Response sendFromCoordinator(SimulatorMessage message) throws Exception {

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/operation/OperationTypeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/operation/OperationTypeTest.java
@@ -9,7 +9,7 @@ public class OperationTypeTest {
 
     @Test
     public void testFromInt_OPERATION() {
-        assertEquals(OperationType.INTEGRATION_TEST_OPERATION, fromInt(OperationType.INTEGRATION_TEST_OPERATION.toInt()));
+        assertEquals(OperationType.INTEGRATION_TEST, fromInt(OperationType.INTEGRATION_TEST.toInt()));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessorTest.java
@@ -1,0 +1,28 @@
+package com.hazelcast.simulator.protocol.processors;
+
+import com.hazelcast.simulator.protocol.core.ResponseType;
+import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
+import static org.junit.Assert.assertEquals;
+
+public class AgentOperationProcessorTest {
+
+    private AgentOperationProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new AgentOperationProcessor();
+    }
+
+    @Test
+    public void testProcessOperation_UnsupportedOperation() throws Exception {
+        SimulatorOperation operation = new IntegrationTestOperation(IntegrationTestOperation.TEST_DATA);
+        ResponseType responseType = processor.processOperation(operation);
+
+        assertEquals(UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR, responseType);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
@@ -1,0 +1,28 @@
+package com.hazelcast.simulator.protocol.processors;
+
+import com.hazelcast.simulator.protocol.core.ResponseType;
+import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
+import static org.junit.Assert.assertEquals;
+
+public class CoordinatorOperationProcessorTest {
+
+    private CoordinatorOperationProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new CoordinatorOperationProcessor();
+    }
+
+    @Test
+    public void testProcessOperation_UnsupportedOperation() throws Exception {
+        SimulatorOperation operation = new IntegrationTestOperation(IntegrationTestOperation.TEST_DATA);
+        ResponseType responseType = processor.processOperation(operation);
+
+        assertEquals(UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR, responseType);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/TestOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/TestOperationProcessorTest.java
@@ -1,0 +1,28 @@
+package com.hazelcast.simulator.protocol.processors;
+
+import com.hazelcast.simulator.protocol.core.ResponseType;
+import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
+import static org.junit.Assert.assertEquals;
+
+public class TestOperationProcessorTest {
+
+    private TestOperationProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new TestOperationProcessor();
+    }
+
+    @Test
+    public void testProcessOperation_UnsupportedOperation() throws Exception {
+        SimulatorOperation operation = new IntegrationTestOperation(IntegrationTestOperation.TEST_DATA);
+        ResponseType responseType = processor.processOperation(operation);
+
+        assertEquals(UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR, responseType);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/WorkerOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/WorkerOperationProcessorTest.java
@@ -1,0 +1,112 @@
+package com.hazelcast.simulator.protocol.processors;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.simulator.protocol.core.ResponseType;
+import com.hazelcast.simulator.protocol.operation.CreateTestOperation;
+import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import com.hazelcast.simulator.test.TestCase;
+import com.hazelcast.simulator.tests.SuccessTest;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.hazelcast.simulator.protocol.core.ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION;
+import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
+import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
+import static com.hazelcast.simulator.protocol.operation.OperationHandler.encodeOperation;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WorkerOperationProcessorTest {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkerOperationProcessorTest.class);
+
+    private static final Class DEFAULT_TEST = SuccessTest.class;
+
+    private final Map<String, String> properties = new HashMap<String, String>();
+    private final TestCase defaultTestCase = mock(TestCase.class);
+
+    private final HazelcastInstance serverInstance = mock(HazelcastInstance.class);
+    private final HazelcastInstance clientInstance = mock(HazelcastInstance.class);
+
+    private WorkerOperationProcessor processor;
+
+    @Before
+    public void setUp() {
+        setTestCaseClass(DEFAULT_TEST.getName());
+
+        when(defaultTestCase.getId()).thenReturn(DEFAULT_TEST.getSimpleName());
+        when(defaultTestCase.getProperties()).thenReturn(properties);
+
+        when(serverInstance.getUserContext()).thenReturn(new ConcurrentHashMap<String, Object>());
+        when(clientInstance.getUserContext()).thenReturn(new ConcurrentHashMap<String, Object>());
+
+        processor = new WorkerOperationProcessor(serverInstance, clientInstance);
+    }
+
+    @Test
+    public void process_unsupportedCommand() throws Exception {
+        SimulatorOperation operation = new IntegrationTestOperation(IntegrationTestOperation.TEST_DATA);
+        ResponseType responseType = processor.processOperation(operation);
+
+        assertEquals(UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR, responseType);
+    }
+
+    @Test
+    public void process_CreateTestOperation() throws Exception {
+        ResponseType responseType = initTestCase(defaultTestCase);
+        assertEquals(SUCCESS, responseType);
+    }
+
+    @Test
+    public void process_CreateTestOperation_sameTestIdTwice() throws Exception {
+        ResponseType responseType = initTestCase(defaultTestCase);
+        assertEquals(SUCCESS, responseType);
+
+        responseType = initTestCase(defaultTestCase);
+        assertEquals(EXCEPTION_DURING_OPERATION_EXECUTION, responseType);
+    }
+
+    @Test
+    public void processInitCommand_invalidTestId() {
+        TestCase testCase = mock(TestCase.class);
+        when(testCase.getId()).thenReturn("%&/?!");
+        when(testCase.getProperties()).thenReturn(properties);
+
+        ResponseType responseType = initTestCase(testCase);
+        assertEquals(EXCEPTION_DURING_OPERATION_EXECUTION, responseType);
+    }
+
+    @Test
+    public void processInitCommand_invalidClassPath() {
+        setTestCaseClass("not.found.SuccessTest");
+
+        ResponseType responseType = initTestCase(defaultTestCase);
+        assertEquals(EXCEPTION_DURING_OPERATION_EXECUTION, responseType);
+    }
+
+    @Test
+    public void process_CreateTestOperation_withServerInstance() throws Exception {
+        processor = new WorkerOperationProcessor(serverInstance, null);
+
+        ResponseType responseType = initTestCase(defaultTestCase);
+        assertEquals(SUCCESS, responseType);
+    }
+
+    private void setTestCaseClass(String className) {
+        properties.put("class", className);
+    }
+
+    private ResponseType initTestCase(TestCase testCase) {
+        SimulatorOperation operation = new CreateTestOperation(testCase);
+        LOGGER.debug("Serialized operation: " + encodeOperation(operation));
+
+        return processor.process(operation);
+    }
+}


### PR DESCRIPTION
Initial migration of `WorkerCommandRequestProcessor` to `WorkerOperationProcessor` (`InitCommand` to `CreateTestOperation`).