### PR TITLE
Calculate Throughput on Workers instead on Coordinator

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -193,8 +193,7 @@ final class TestCaseRunner {
     }
 
     private void logPerformance() {
-        int duration = testSuite.durationSeconds > 0 ? testSuite.durationSeconds : runPhaseDuration;
-        performanceMonitor.logDetailedPerformanceInfo(duration);
+        performanceMonitor.logDetailedPerformanceInfo();
     }
 
     private void processProbeResults() {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessor.java
@@ -8,13 +8,14 @@ import com.hazelcast.simulator.test.TestCase;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.utils.ExceptionReporter;
+import com.hazelcast.simulator.worker.commands.PerformanceState;
 import com.hazelcast.simulator.worker.commands.Command;
 import com.hazelcast.simulator.worker.commands.CommandRequest;
 import com.hazelcast.simulator.worker.commands.CommandResponse;
 import com.hazelcast.simulator.worker.commands.GenericCommand;
 import com.hazelcast.simulator.worker.commands.GetBenchmarkResultsCommand;
-import com.hazelcast.simulator.worker.commands.GetOperationCountCommand;
 import com.hazelcast.simulator.worker.commands.GetStackTraceCommand;
+import com.hazelcast.simulator.worker.commands.GetPerformanceStateCommand;
 import com.hazelcast.simulator.worker.commands.InitCommand;
 import com.hazelcast.simulator.worker.commands.IsPhaseCompletedCommand;
 import com.hazelcast.simulator.worker.commands.MessageCommand;
@@ -124,8 +125,8 @@ class WorkerCommandRequestProcessor {
                     process((GenericCommand) command);
                 } else if (command instanceof MessageCommand) {
                     process((MessageCommand) command);
-                } else if (command instanceof GetOperationCountCommand) {
-                    result = process((GetOperationCountCommand) command);
+                } else if (command instanceof GetPerformanceStateCommand) {
+                    result = process((GetPerformanceStateCommand) command);
                 } else if (command instanceof GetBenchmarkResultsCommand) {
                     result = process((GetBenchmarkResultsCommand) command);
                 } else if (command instanceof GetStackTraceCommand) {
@@ -309,15 +310,13 @@ class WorkerCommandRequestProcessor {
         }
 
         @SuppressWarnings("unused")
-        private Long process(GetOperationCountCommand command) throws Exception {
-            long result = 0;
+        private PerformanceState process(GetPerformanceStateCommand command) throws Exception {
+            PerformanceState response = new PerformanceState();
             for (TestContainer testContainer : tests.values()) {
-                long operationCount = testContainer.getOperationCount();
-                if (operationCount > 0) {
-                    result += operationCount;
-                }
+                PerformanceState currentContainer = testContainer.getPerformance();
+                response.add(currentContainer);
             }
-            return result;
+            return response;
         }
 
         private Map<String, Result<?>> process(GetBenchmarkResultsCommand command) {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/commands/GetPerformanceStateCommand.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/commands/GetPerformanceStateCommand.java
@@ -1,6 +1,6 @@
 package com.hazelcast.simulator.worker.commands;
 
-public class GetOperationCountCommand extends Command {
+public class GetPerformanceStateCommand extends Command {
 
     @Override
     public boolean ignoreTimeout() {
@@ -9,6 +9,6 @@ public class GetOperationCountCommand extends Command {
 
     @Override
     public String toString() {
-        return "GetOperationCountCommand{}";
+        return "GetPerformanceStateCommand{}";
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/commands/PerformanceState.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/commands/PerformanceState.java
@@ -1,0 +1,61 @@
+package com.hazelcast.simulator.worker.commands;
+
+import java.io.Serializable;
+
+public class PerformanceState implements Serializable {
+    private static final long EMPTY_OPERATION_COUNT = -1;
+    private static final double EMPTY_THROUGHPUT = -1;
+
+    private long operationCount;
+    private double intervalThroughput;
+    private double totalThroughput;
+
+    public PerformanceState() {
+        this.operationCount = EMPTY_OPERATION_COUNT;
+        this.intervalThroughput = EMPTY_THROUGHPUT;
+    }
+
+    public PerformanceState(long operationCount, double intervalThroughput, double totalThroughput) {
+        this.operationCount = operationCount;
+        this.intervalThroughput = intervalThroughput;
+        this.totalThroughput = totalThroughput;
+    }
+
+    public void add(PerformanceState other) {
+        if (other.isEmpty()) {
+            return;
+        } else if (isEmpty()) {
+            operationCount = other.getOperationCount();
+            intervalThroughput = other.getIntervalThroughput();
+            totalThroughput = other.getTotalThroughput();
+        } else {
+            operationCount += other.getOperationCount();
+            intervalThroughput += other.getIntervalThroughput();
+            totalThroughput += other.getTotalThroughput();
+        }
+    }
+
+    public double getTotalThroughput() {
+        return totalThroughput;
+    }
+
+    public long getOperationCount() {
+        return operationCount;
+    }
+
+    public double getIntervalThroughput() {
+        return intervalThroughput;
+    }
+
+    public boolean isEmpty() {
+        return operationCount == EMPTY_OPERATION_COUNT && intervalThroughput == EMPTY_THROUGHPUT;
+    }
+
+    @Override
+    public String toString() {
+        return "PerformanceResponse{"
+                + "operationCount=" + operationCount
+                + ", intervalThroughput=" + intervalThroughput
+                + '}';
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceTracker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceTracker.java
@@ -1,0 +1,33 @@
+package com.hazelcast.simulator.worker.performance;
+
+import com.hazelcast.simulator.worker.commands.PerformanceState;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class PerformanceTracker {
+    private long lastOperationCount;
+    private long startedTimestamp;
+    private long lastTimestamp;
+
+    public void start() {
+        long now = System.currentTimeMillis();
+        startedTimestamp = now;
+        lastTimestamp = now;
+    }
+
+    public PerformanceState update(long currentOperationalCount) {
+        if (currentOperationalCount == -1) {
+            return new PerformanceState();
+        }
+        long now = System.currentTimeMillis();
+
+        long opDelta = currentOperationalCount - lastOperationCount;
+        long intervalTimeDelta = now - lastTimestamp;
+        long totalTimeDelta = now - startedTimestamp;
+        double intervalThroughput = (opDelta * SECONDS.toMillis(1)) / intervalTimeDelta;
+        double totalThroughput = (currentOperationalCount * SECONDS.toMillis(1) / totalTimeDelta);
+        lastOperationCount = currentOperationalCount;
+        lastTimestamp = now;
+        return new PerformanceState(currentOperationalCount, intervalThroughput, totalThroughput);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerCommandRequestProcessorTest.java
@@ -11,7 +11,6 @@ import com.hazelcast.simulator.worker.commands.CommandRequest;
 import com.hazelcast.simulator.worker.commands.CommandResponse;
 import com.hazelcast.simulator.worker.commands.GenericCommand;
 import com.hazelcast.simulator.worker.commands.GetBenchmarkResultsCommand;
-import com.hazelcast.simulator.worker.commands.GetOperationCountCommand;
 import com.hazelcast.simulator.worker.commands.GetStackTraceCommand;
 import com.hazelcast.simulator.worker.commands.InitCommand;
 import com.hazelcast.simulator.worker.commands.IsPhaseCompletedCommand;
@@ -249,18 +248,6 @@ public class WorkerCommandRequestProcessorTest {
     public void processMessageCommand() {
         MessageCommand command = new MessageCommand(null);
         addRequest(command);
-
-        assertNoException();
-    }
-
-    @Test
-    public void processGetOperationCountCommand() {
-        initTestCase(defaultTestCase);
-
-        GetOperationCountCommand command = new GetOperationCountCommand();
-        CommandResponse response = handleRequestAndAssertId(command);
-        assertNotNull(response);
-        assertEquals(0L, response.result);
 
         assertNoException();
     }


### PR DESCRIPTION
Fixes #724

Throughput is now calculated on workers instead of Coordinator.
Latency between "Obtaining stats on a worker" and "Processed on Coordinator" does not play a role anymore.