### PR TITLE
Start/stop Agents in Coordinator instead of Provisioner

### DIFF
--- a/dist/src/main/dist/bin/harakiri-monitor
+++ b/dist/src/main/dist/bin/harakiri-monitor
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "${SIMULATOR_HOME}" ] ; then
+    export SIMULATOR_HOME=$(cd $(dirname $(readlink -f $0 2> /dev/null || readlink $0 2> /dev/null || echo $0))/.. && pwd)
+fi
+
+export JAVA_OPTS="-server -Xms64m -Xmx64m -XX:+HeapDumpOnOutOfMemoryError ${JAVA_EXTRA_OPTS}"
+
+echo SIMULATOR_HOME = ${SIMULATOR_HOME}
+echo JAVA_OPTS = ${JAVA_OPTS}
+
+java -cp "${SIMULATOR_HOME}/lib/*" ${JAVA_OPTS} \
+    -DSIMULATOR_HOME=${SIMULATOR_HOME}  \
+    -Dlog4j.configuration=file:${SIMULATOR_HOME}/conf/agent-log4j.xml \
+    com.hazelcast.simulator.agent.HarakiriMonitor "$@"

--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -46,6 +46,20 @@ CLOUD_POLL_MAX_PERIOD=5000
 #
 CLOUD_BATCH_SIZE=20
 
+# =====================================================================
+# HarakiriMonitor
+# =====================================================================
+#
+# Defines if the HarakiriMonitor should be started for EC2 instances.
+# The HarakiriMonitor will kill the instance after a defined amount of time to save money.
+#
+HARAKIRI_MONITOR_ENABLED=true
+
+#
+# The number of seconds before the HarakiriMonitor will kill an EC2 instance.
+#
+HARAKIRI_MONITOR_WAIT_SECONDS=7200
+
 #
 # Just a prefix for the agent name. Different test clusters could be given different names. In GCE you need
 # to be very careful using multiple group-names, because for every port and every group-name a firewall rule is

--- a/dist/src/main/dist/simulator-tests/run.sh
+++ b/dist/src/main/dist/simulator-tests/run.sh
@@ -9,33 +9,33 @@ output=output
 gcArgs="-verbose:gc -Xloggc:verbosegc.log"
 gcArgs="$gcArgs -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime"
 
-memberHeapSZ=2G
+memberHeapSize=2G
 partitions=271
 monitorSec=30
 
 memberJvmArgs="-Dhazelcast.partition.count=$partitions"
 memberJvmArgs="$memberJvmArgs -Dhazelcast.health.monitoring.level=NOISY -Dhazelcast.health.monitoring.delay.seconds=$monitorSec"
-memberJvmArgs="$memberJvmArgs -Xmx$memberHeapSZ -XX:+HeapDumpOnOutOfMemoryError"
+memberJvmArgs="$memberJvmArgs -Xmx$memberHeapSize -XX:+HeapDumpOnOutOfMemoryError"
 memberJvmArgs="$memberJvmArgs $gcArgs"
 
-clientHeapSZ=1G
-clientJvmArgs="-Xmx$clientHeapSZ -XX:+HeapDumpOnOutOfMemoryError"
+clientHeapSize=1G
+clientJvmArgs="-Xmx$clientHeapSize -XX:+HeapDumpOnOutOfMemoryError"
 clientJvmArgs="$clientJvmArgs $gcArgs"
 
-if ! provisioner --scale ${boxCount} ; then
+if ! provisioner --scale ${boxCount}; then
   exit 1
 fi
 
 provisioner --clean
-provisioner --restart
+provisioner --install
 
 coordinator --memberWorkerCount ${members} \
-	        --clientWorkerCount ${clients} \
-	        --duration ${duration} \
-	        --workerVmOptions "$memberJvmArgs" \
-                --clientWorkerVmOptions "$clientJvmArgs" \
-	        --parallel \
-	        test.properties
+            --clientWorkerCount ${clients} \
+            --duration ${duration} \
+            --workerVmOptions "$memberJvmArgs" \
+            --clientWorkerVmOptions "$clientJvmArgs" \
+            --parallel \
+            test.properties
 
 provisioner --download ${output}
 
@@ -47,7 +47,7 @@ fi
 mv *.out ${output}/${runId}
 
 mv failures-* ${output} 2>/dev/null
-if [ -f ${output}/failures* ] ; then
-    echo "FAIL! ${output}"
-    exit 1
+if [ -f ${output}/failures* ]; then
+  echo "FAIL! ${output}"
+  exit 1
 fi

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -49,7 +49,6 @@ public class Agent {
 
     private final WorkerJvmManager workerJvmManager = new WorkerJvmManager(this);
     private final WorkerJvmFailureMonitor workerJvmFailureMonitor = new WorkerJvmFailureMonitor(this);
-    private final HarakiriMonitor harakiriMonitor = new HarakiriMonitor(this);
 
     private AgentRemoteService agentRemoteService;
 
@@ -99,7 +98,6 @@ public class Agent {
         startRestServer();
         workerJvmFailureMonitor.start();
         workerJvmManager.start();
-        harakiriMonitor.start();
 
         LOGGER.info("Simulator Agent is ready for action");
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/HarakiriMonitor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/HarakiriMonitor.java
@@ -1,53 +1,59 @@
 package com.hazelcast.simulator.agent;
 
+import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.apache.log4j.Logger;
 
-import java.util.concurrent.TimeUnit;
-
 import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.NativeUtils.execute;
 import static java.lang.String.format;
 
 /**
- * Responsible for terminating ec2-instances if they are not used to prevent running into a big bill.
+ * Responsible for terminating EC2 instances if they are not used to prevent running into a high bill.
  */
-public class HarakiriMonitor extends Thread {
-
-    private static final long MAX_IDLE_TIME_MS = TimeUnit.HOURS.toMillis(2);
+public class HarakiriMonitor {
 
     private static final Logger LOGGER = Logger.getLogger(HarakiriMonitor.class);
 
-    private final Agent agent;
+    private final String cloudProvider;
+    private final String cloudIdentity;
+    private final String cloudCredential;
+    private final int waitSeconds;
 
-    public HarakiriMonitor(Agent agent) {
-        super("HarakiriMonitor");
-        this.agent = agent;
+    public HarakiriMonitor(String cloudProvider, String cloudIdentity, String cloudCredential, int waitSeconds) {
+        this.cloudProvider = cloudProvider;
+        this.cloudIdentity = cloudIdentity;
+        this.cloudCredential = cloudCredential;
+        this.waitSeconds = waitSeconds;
     }
 
-    public void run() {
-        if (!isEC2(agent.cloudProvider)) {
+    void start() {
+        if (!isEC2(cloudProvider)) {
             LOGGER.info("No Harakiri monitor is active: only on AWS-EC2 unused machines will be terminated.");
             return;
         }
 
-        LOGGER.info("Harakiri monitor is active");
-        for (; ; ) {
-            sleepSeconds((int) TimeUnit.MINUTES.toSeconds(1));
+        LOGGER.info(format("Harakiri monitor is active and will wait %d seconds to kill this instance", waitSeconds));
+        sleepSeconds(waitSeconds);
 
-            boolean doHarakiri = (System.currentTimeMillis() - MAX_IDLE_TIME_MS > agent.lastUsed);
-            if (doHarakiri) {
-                LOGGER.info("Trying to commit Harakiri once!");
-                try {
-                    String cmd = format("ec2-terminate-instances $(curl -s http://169.254.169.254/latest/meta-data/instance-id) "
-                            + "--aws-access-key %s --aws-secret-key %s", agent.cloudIdentity, agent.cloudCredential);
-                    LOGGER.info("harakiri command: " + cmd);
-                    execute(cmd);
-                } catch (RuntimeException e) {
-                    LOGGER.info("Failed to execute Harakiri");
-                }
-                return;
-            }
+        LOGGER.info("Trying to commit Harakiri once!");
+        try {
+            String cmd = format("ec2-terminate-instances $(curl -s http://169.254.169.254/latest/meta-data/instance-id) "
+                    + "--aws-access-key %s --aws-secret-key %s", cloudIdentity, cloudCredential);
+            LOGGER.info("Harakiri command: " + cmd);
+            execute(cmd);
+        } catch (Exception e) {
+            throw new CommandLineExitException("Failed to execute Harakiri", e);
+        }
+    }
+
+    public static void main(String[] args) {
+        try {
+            HarakiriMonitor harakiriMonitor = HarakiriMonitorCli.createHarakiriMonitor(args);
+            harakiriMonitor.start();
+        } catch (Exception e) {
+            exitWithError(LOGGER, "Could not start HarakiriMonitor!", e);
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/HarakiriMonitorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/HarakiriMonitorCli.java
@@ -1,0 +1,54 @@
+package com.hazelcast.simulator.agent;
+
+import com.hazelcast.simulator.utils.CliUtils;
+import com.hazelcast.simulator.utils.CommandLineExitException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+
+import java.util.concurrent.TimeUnit;
+
+final class HarakiriMonitorCli {
+
+    private final OptionParser parser = new OptionParser();
+
+    private final OptionSpec<String> cloudProviderSpec = parser.accepts("cloudProvider",
+            "Cloud provider")
+            .withRequiredArg().ofType(String.class);
+
+    private final OptionSpec<String> cloudIdentitySpec = parser.accepts("cloudIdentity",
+            "Cloud identity")
+            .withRequiredArg().ofType(String.class);
+
+    private final OptionSpec<String> cloudCredentialSpec = parser.accepts("cloudCredential",
+            "Cloud credential")
+            .withRequiredArg().ofType(String.class);
+
+    private final OptionSpec<Integer> timeoutSpec = parser.accepts("waitSeconds",
+            "The number of seconds the HarakiriMonitor will wait until it kills the machine.")
+            .withRequiredArg().ofType(Integer.class).defaultsTo((int) TimeUnit.HOURS.toSeconds(2));
+
+    private HarakiriMonitorCli() {
+    }
+
+    static HarakiriMonitor createHarakiriMonitor(String[] args) {
+        HarakiriMonitorCli harakiriCli = new HarakiriMonitorCli();
+        OptionSet options = CliUtils.initOptionsWithHelp(harakiriCli.parser, args);
+
+        if (!options.has(harakiriCli.cloudProviderSpec)) {
+            throw new CommandLineExitException("You have to provide --cloudProvider");
+        }
+        if (!options.has(harakiriCli.cloudIdentitySpec)) {
+            throw new CommandLineExitException("You have to provide --cloudIdentity");
+        }
+        if (!options.has(harakiriCli.cloudCredentialSpec)) {
+            throw new CommandLineExitException("You have to provide --cloudCredential");
+        }
+
+        return new HarakiriMonitor(
+                options.valueOf(harakiriCli.cloudProviderSpec),
+                options.valueOf(harakiriCli.cloudIdentitySpec),
+                options.valueOf(harakiriCli.cloudCredentialSpec),
+                options.valueOf(harakiriCli.timeoutSpec));
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -44,6 +44,7 @@ import static com.hazelcast.simulator.coordinator.CoordinatorHelper.assignDedica
 import static com.hazelcast.simulator.coordinator.CoordinatorHelper.createAddressConfig;
 import static com.hazelcast.simulator.coordinator.CoordinatorHelper.findNextAgentLayout;
 import static com.hazelcast.simulator.coordinator.CoordinatorHelper.getMaxTestCaseIdLength;
+import static com.hazelcast.simulator.coordinator.CoordinatorHelper.getStartHarakiriMonitorCommand;
 import static com.hazelcast.simulator.coordinator.CoordinatorHelper.initAgentMemberLayouts;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
 import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
@@ -194,13 +195,16 @@ public final class Coordinator {
     }
 
     private void killAgents() {
-        echoLocal("Killing %s Agents", addresses.size());
+        String startHarakiriMonitorCommand = getStartHarakiriMonitorCommand(props);
 
+        echoLocal("Killing %s Agents", addresses.size());
         for (AgentAddress address : addresses) {
             echoLocal("Killing Agent, %s", address.publicAddress);
             bash.ssh(address.publicAddress, "killall -9 java || true");
+            if (startHarakiriMonitorCommand != null) {
+                bash.ssh(address.publicAddress, startHarakiriMonitorCommand);
+            }
         }
-
         echoLocal("Successfully killed %s Agents", addresses.size());
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -92,8 +92,8 @@ final class CoordinatorCli {
             "If defined tests are run in parallel.");
 
     private final OptionSpec<TestPhase> syncToTestPhaseSpec = parser.accepts("syncToTestPhase",
-            "Defines the last TestPhase which is synchronized between all parallel running tests."
-            ).withRequiredArg().ofType(TestPhase.class).defaultsTo(TestPhase.SETUP);
+            "Defines the last TestPhase which is synchronized between all parallel running tests.")
+            .withRequiredArg().ofType(TestPhase.class).defaultsTo(TestPhase.SETUP);
 
     private final OptionSpec<String> workerVmOptionsSpec = parser.accepts("workerVmOptions",
             "Worker JVM options (quotes can be used). These options will be applied to regular members and mixed members"

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorHelper.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorHelper.java
@@ -3,9 +3,11 @@ package com.hazelcast.simulator.coordinator;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.simulator.agent.workerjvm.WorkerJvmSettings;
+import com.hazelcast.simulator.common.SimulatorProperties;
 import com.hazelcast.simulator.coordinator.remoting.AgentsClient;
 import com.hazelcast.simulator.test.TestCase;
 import com.hazelcast.simulator.utils.CommandLineExitException;
+import org.apache.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
@@ -13,7 +15,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
+import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
+import static java.lang.String.format;
+
 final class CoordinatorHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(CoordinatorHelper.class);
 
     private CoordinatorHelper() {
     }
@@ -84,5 +92,22 @@ final class CoordinatorHelper {
             }
         }
         return (maxLength > 0) ? maxLength : 0;
+    }
+
+    static String getStartHarakiriMonitorCommand(SimulatorProperties props) {
+        if (!isEC2(props.get("CLOUD_PROVIDER")) || !"true".equals(props.get("HARAKIRI_MONITOR_ENABLED"))) {
+            LOGGER.info("HarakiriMonitor is not enabled or not running on EC2");
+            return null;
+        }
+        String waitSeconds = props.get("HARAKIRI_MONITOR_WAIT_SECONDS");
+        LOGGER.info(format("HarakiriMonitor will kill the EC2 instances in %s seconds", waitSeconds));
+        return format(
+                "nohup hazelcast-simulator-%s/bin/harakiri-monitor --cloudProvider %s --cloudIdentity %s --cloudCredential %s"
+                        + " --waitSeconds %s > harakiri.out 2> harakiri.err < /dev/null &",
+                getSimulatorVersion(),
+                props.get("CLOUD_PROVIDER"),
+                props.get("CLOUD_IDENTITY"),
+                props.get("CLOUD_CREDENTIAL"),
+                waitSeconds);
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
@@ -28,7 +28,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.isStatic;
 import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
@@ -85,39 +84,6 @@ public final class Provisioner {
         return new GitSupport(buildSupport, customGitRepositories, gitBuildDirectory);
     }
 
-    void startAgents() {
-        echoImportant("Starting %s Agents", addresses.size());
-
-        for (AgentAddress address : addresses) {
-            startAgent(address.publicAddress);
-        }
-
-        echoImportant("Successfully started agents on %s boxes", addresses.size());
-    }
-
-    void killAgents() {
-        echoImportant("Killing %s Agents", addresses.size());
-
-        for (AgentAddress address : addresses) {
-            echo("Killing Agent, %s", address.publicAddress);
-            bash.ssh(address.publicAddress, "killall -9 java || true");
-        }
-
-        echoImportant("Successfully killed %s Agents", addresses.size());
-    }
-
-    void restart(boolean enableEnterprise) {
-        echoImportant("Restarting %s Agents", addresses.size());
-
-        hazelcastJars.prepare(enableEnterprise);
-        for (AgentAddress address : addresses) {
-            echo("Installing agent: " + address.publicAddress);
-            installAgent(address.publicAddress);
-        }
-
-        echoImportant("Restarting %s Agents", addresses.size());
-    }
-
     void scale(int size, boolean enterpriseEnabled) {
         ensureNotStaticCloudProvider("scale");
 
@@ -133,22 +99,67 @@ public final class Provisioner {
         }
     }
 
+    void installSimulator(boolean enableEnterprise) {
+        echoImportant("Installing Simulator on %s machines", addresses.size());
+
+        hazelcastJars.prepare(enableEnterprise);
+        for (AgentAddress address : addresses) {
+            echo("Installing Simulator on " + address.publicAddress);
+            installSimulator(address.publicAddress);
+        }
+
+        echoImportant("Installing Simulator on %s machines", addresses.size());
+    }
+
+    void listMachines() {
+        echo("Provisioned machines (from " + AgentsFile.NAME + "):");
+        String machines = fileAsText(agentsFile);
+        echo("    " + machines);
+    }
+
+    void download(String dir) {
+        echoImportant("Download artifacts of %s machines", addresses.size());
+
+        bash.execute("mkdir -p " + dir);
+
+        for (AgentAddress address : addresses) {
+            echo("Downloading from %s", address.publicAddress);
+
+            String syncCommand = format("rsync --copy-links  -avv -e \"ssh %s\" %s@%s:hazelcast-simulator-%s/workers/* " + dir,
+                    props.get("SSH_OPTIONS", ""), props.getUser(), address.publicAddress, getSimulatorVersion());
+
+            bash.executeQuiet(syncCommand);
+        }
+
+        echoImportant("Finished downloading artifacts of %s machines", addresses.size());
+    }
+
+    void clean() {
+        echoImportant("Cleaning worker homes of %s machines", addresses.size());
+
+        for (AgentAddress address : addresses) {
+            echo("Cleaning %s", address.publicAddress);
+            bash.ssh(address.publicAddress, format("rm -fr hazelcast-simulator-%s/workers/*", getSimulatorVersion()));
+        }
+
+        echoImportant("Finished cleaning worker homes of %s machines", addresses.size());
+    }
+
+    void killJavaProcessed() {
+        echoImportant("Killing %s Java processes", addresses.size());
+
+        for (AgentAddress address : addresses) {
+            echo("Killing Java processes on %s", address.publicAddress);
+            bash.ssh(address.publicAddress, "killall -9 java || true");
+        }
+
+        echoImportant("Successfully killed %s Java processes", addresses.size());
+    }
+
     void terminate() {
         ensureNotStaticCloudProvider("terminate");
 
         scaleDown(Integer.MAX_VALUE);
-    }
-
-    void ensureNotStaticCloudProvider(String action) {
-        if (isStatic(props.get("CLOUD_PROVIDER"))) {
-            throw new CommandLineExitException(format("Cannot execute '%s' in static setup", action));
-        }
-    }
-
-    void listAgents() {
-        echo("Running Agents (from " + AgentsFile.NAME + "):");
-        String agents = fileAsText(agentsFile);
-        echo("    " + agents);
     }
 
     void shutdown() {
@@ -170,32 +181,10 @@ public final class Provisioner {
         echo("Done!");
     }
 
-    void download(String dir) {
-        echoImportant("Download artifacts of %s machines", addresses.size());
-
-        bash.execute("mkdir -p " + dir);
-
-        for (AgentAddress address : addresses) {
-            echo("Downloading from %s", address.publicAddress);
-
-            String syncCommand = format("rsync --copy-links  -avv -e \"ssh %s\" %s@%s:hazelcast-simulator-%s/workers/* " + dir,
-                    props.get("SSH_OPTIONS", ""), props.getUser(), address.publicAddress, getSimulatorVersion());
-
-            bash.executeQuiet(syncCommand);
+    private void ensureNotStaticCloudProvider(String action) {
+        if (isStatic(props.get("CLOUD_PROVIDER"))) {
+            throw new CommandLineExitException(format("Cannot execute '%s' in static setup", action));
         }
-
-        echoImportant("Finished Downloading Artifacts of %s machines", addresses.size());
-    }
-
-    void clean() {
-        echoImportant("Cleaning worker homes of %s machines", addresses.size());
-
-        for (AgentAddress address : addresses) {
-            echo("Cleaning %s", address.publicAddress);
-            bash.ssh(address.publicAddress, format("rm -fr hazelcast-simulator-%s/workers/*", getSimulatorVersion()));
-        }
-
-        echoImportant("Finished cleaning worker homes of %s machines", addresses.size());
     }
 
     private void scaleUp(int delta, boolean enterpriseEnabled) {
@@ -277,7 +266,7 @@ public final class Provisioner {
 
         int destroyedCount = 0;
         for (int batchSize : calcBatches(count)) {
-            final Map<String, AgentAddress> terminateMap = new HashMap<String, AgentAddress>();
+            Map<String, AgentAddress> terminateMap = new HashMap<String, AgentAddress>();
             for (AgentAddress address : addresses.subList(0, batchSize)) {
                 terminateMap.put(address.publicAddress, address);
             }
@@ -318,7 +307,7 @@ public final class Provisioner {
         return result;
     }
 
-    private void installAgent(String ip) {
+    private void installSimulator(String ip) {
         bash.ssh(ip, format("mkdir -p hazelcast-simulator-%s/lib/", getSimulatorVersion()));
 
         // first we delete the old lib files to prevent different versions of the same JAR to bite us
@@ -377,26 +366,6 @@ public final class Provisioner {
         return script;
     }
 
-    private void startAgent(String ip) {
-        echo("Killing Agent on: %s", ip);
-        bash.ssh(ip, "killall -9 java || true");
-
-        echo("Starting Agent on: %s", ip);
-        if (isEC2(props.get("CLOUD_PROVIDER"))) {
-            bash.ssh(ip, format(
-                    "nohup hazelcast-simulator-%s/bin/agent --cloudProvider %s --cloudIdentity %s --cloudCredential %s "
-                            + "> agent.out 2> agent.err < /dev/null &",
-                    getSimulatorVersion(),
-                    props.get("CLOUD_PROVIDER"),
-                    props.get("CLOUD_IDENTITY"),
-                    props.get("CLOUD_CREDENTIAL")));
-        } else {
-            bash.ssh(ip, format(
-                    "nohup hazelcast-simulator-%s/bin/agent > agent.out 2> agent.err < /dev/null &",
-                    getSimulatorVersion()));
-        }
-    }
-
     private int destroyNodes(ComputeService compute, final Map<String, AgentAddress> terminateMap) {
         Set destroyedSet = compute.destroyNodesMatching(new Predicate<NodeMetadata>() {
             @Override
@@ -443,11 +412,8 @@ public final class Provisioner {
                 echo("    " + ip + " JAVA INSTALLED");
             }
 
-            installAgent(ip);
+            installSimulator(ip);
             echo("    " + ip + " SIMULATOR AGENT INSTALLED");
-
-            startAgent(ip);
-            echo("    " + ip + " SIMULATOR AGENT STARTED");
         }
 
         private File getJavaInstallScript() {

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
@@ -413,7 +413,7 @@ public final class Provisioner {
             }
 
             installSimulator(ip);
-            echo("    " + ip + " SIMULATOR AGENT INSTALLED");
+            echo("    " + ip + " SIMULATOR INSTALLED");
         }
 
         private File getJavaInstallScript() {

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/ProvisionerCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/ProvisionerCli.java
@@ -1,11 +1,13 @@
 package com.hazelcast.simulator.provisioner;
 
+import com.hazelcast.simulator.common.AgentsFile;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
 import java.io.File;
 
+import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTIES_FILE_NAME;
 import static com.hazelcast.simulator.utils.CliUtils.initOptionsWithHelp;
 import static com.hazelcast.simulator.utils.CliUtils.printHelpAndExit;
 import static com.hazelcast.simulator.utils.FileUtils.newFile;
@@ -15,45 +17,45 @@ final class ProvisionerCli {
     private final OptionParser parser = new OptionParser();
 
     private final OptionSpec<String> gitSpec = parser.accepts("git",
-            "Overrides the HAZELCAST_VERSION_SPEC property and forces Provisioner to build Hazelcast JARs from a given GIT "
-                    + "version. This makes it easier to run a test with different versions of Hazelcast, e.g.\n"
+            "Overrides the HAZELCAST_VERSION_SPEC property and forces Provisioner to build Hazelcast JARs from a given GIT"
+                    + " version. This makes it easier to run a test with different versions of Hazelcast, e.g.\n"
                     + "     --git f0288f713                to use the Git revision f0288f713\n"
                     + "     --git myRepository/myBranch    to use branch myBranch from a repository myRepository.\n"
                     + "You can specify custom repositories in 'simulator.properties'.")
             .withRequiredArg().ofType(String.class);
 
-    private final OptionSpec restartSpec = parser.accepts("restart",
-            "Restarts all agents");
+    private final OptionSpec<Integer> scaleSpec = parser.accepts("scale",
+            "Number of Simulator machines to scale to. If the number of machines already exists, the call is ignored. If the"
+                    + " desired number of machines is smaller than the actual number of machines, machines are terminated.")
+            .withRequiredArg().ofType(Integer.class);
+
+    private final OptionSpec installSpec = parser.accepts("install",
+            "Installs Simulator on all provisioned machines.");
+
+    private final OptionSpec listAgentsSpec = parser.accepts("list",
+            "Lists the provisioned machines (from " + AgentsFile.NAME + " file).");
 
     private final OptionSpec<String> downloadSpec = parser.accepts("download",
-            "Download all the files from the workers directory. To delete all worker directories, run with --clean")
+            "Download all files from the remote Worker directories. Use --clean to delete all Worker directories.")
             .withOptionalArg().defaultsTo("workers").ofType(String.class);
 
     private final OptionSpec cleanSpec = parser.accepts("clean",
-            "Cleans the workers directories.");
-
-    private final OptionSpec<Integer> scaleSpec = parser.accepts("scale",
-            "Number of agent machines to scale to. If the number of machines already exists, the call is ignored. If the "
-                    + "desired number of machines is smaller than the actual number of machines, machines are terminated.")
-            .withRequiredArg().ofType(Integer.class);
-
-    private final OptionSpec terminateSpec = parser.accepts("terminate",
-            "Terminate all agent machines in the provisioner");
+            "Cleans the remote Worker directories on the provisioned machines.");
 
     private final OptionSpec killSpec = parser.accepts("kill",
-            "Kill all the agent processes (it will do a killall -9 java and kills all java processes)");
+            "Kills the Java processes on all provisioned machines (via killall -9 java).");
 
-    private final OptionSpec listAgentsSpec = parser.accepts("listAgents",
-            "Lists the running agents.");
+    private final OptionSpec terminateSpec = parser.accepts("terminate",
+            "Terminates all provisioned machines.");
 
     private final OptionSpec<String> propertiesFileSpec = parser.accepts("propertiesFile",
-            "The file containing the simulator properties. If no file is explicitly configured, first the working directory is "
-                    + "checked for a file 'simulator.properties'. All missing properties are always loaded from "
-                    + "'$SIMULATOR_HOME/conf/simulator.properties'.")
+            "The file containing the Simulator properties. If no file is explicitly configured, first the local working directory"
+                    + " is checked for a file '" + PROPERTIES_FILE_NAME + "'. All missing properties are always loaded from"
+                    + " '$SIMULATOR_HOME/conf/" + PROPERTIES_FILE_NAME + "'.")
             .withRequiredArg().ofType(String.class);
 
     private final OptionSpec<Boolean> enterpriseEnabledSpec = parser.accepts("enterpriseEnabled",
-            "Use hazelcast enterprise edition JARs.")
+            "Use JARs of Hazelcast Enterprise Edition.")
             .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
 
     private final Provisioner provisioner;
@@ -76,25 +78,24 @@ final class ProvisionerCli {
     void run() {
         try {
             provisioner.init();
-            if (options.has(restartSpec)) {
+            if (options.has(scaleSpec)) {
+                int size = options.valueOf(scaleSpec);
                 boolean enterpriseEnabled = options.valueOf(enterpriseEnabledSpec);
-                provisioner.restart(enterpriseEnabled);
-                provisioner.startAgents();
-            } else if (options.has(killSpec)) {
-                provisioner.killAgents();
+                provisioner.scale(size, enterpriseEnabled);
+            } else if (options.has(installSpec)) {
+                boolean enterpriseEnabled = options.valueOf(enterpriseEnabledSpec);
+                provisioner.installSimulator(enterpriseEnabled);
+            } else if (options.has(listAgentsSpec)) {
+                provisioner.listMachines();
             } else if (options.has(downloadSpec)) {
                 String dir = options.valueOf(downloadSpec);
                 provisioner.download(dir);
             } else if (options.has(cleanSpec)) {
                 provisioner.clean();
+            } else if (options.has(killSpec)) {
+                provisioner.killJavaProcessed();
             } else if (options.has(terminateSpec)) {
                 provisioner.terminate();
-            } else if (options.has(scaleSpec)) {
-                int size = options.valueOf(scaleSpec);
-                boolean enterpriseEnabled = options.valueOf(enterpriseEnabledSpec);
-                provisioner.scale(size, enterpriseEnabled);
-            } else if (options.has(listAgentsSpec)) {
-                provisioner.listAgents();
             } else {
                 printHelpAndExit(parser);
             }

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/CloudProviderUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/CloudProviderUtils.java
@@ -2,6 +2,8 @@ package com.hazelcast.simulator.utils;
 
 public final class CloudProviderUtils {
 
+    public static final String AWS_EC2 = "aws-ec2";
+
     private CloudProviderUtils() {
     }
 
@@ -10,6 +12,6 @@ public final class CloudProviderUtils {
     }
 
     public static boolean isEC2(String cloudProvider) {
-        return "aws-ec2".equals(cloudProvider);
+        return AWS_EC2.equals(cloudProvider);
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/HarakiriMonitorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/HarakiriMonitorTest.java
@@ -1,0 +1,145 @@
+package com.hazelcast.simulator.agent;
+
+import com.hazelcast.simulator.utils.CloudProviderUtils;
+import com.hazelcast.simulator.utils.CommandLineExitException;
+import com.hazelcast.simulator.utils.helper.ExitExceptionSecurityManager;
+import com.hazelcast.simulator.utils.helper.ExitStatusOneException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.simulator.utils.CloudProviderUtils.AWS_EC2;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class HarakiriMonitorTest {
+
+    private static final String CLOUD_PROVIDER = AWS_EC2;
+    private static final String CLOUD_IDENTITY = "someIdentity";
+    private static final String CLOUD_CREDENTIALS = "someCredentials";
+    private static final int WAIT_SECONDS = 1;
+
+    private static SecurityManager oldSecurityManager;
+
+    private List<String> args = new ArrayList<String>();
+    private HarakiriMonitor harakiriMonitor;
+
+    @BeforeClass
+    public static void setUp() {
+        oldSecurityManager = System.getSecurityManager();
+        System.setSecurityManager(new ExitExceptionSecurityManager());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        System.setSecurityManager(oldSecurityManager);
+    }
+
+    @Test
+    public void testCreateHarakiriMonitor() {
+        addCloudProviderArgs();
+        addCloudIdentityArgs();
+        addCloudCredentialArgs();
+
+        HarakiriMonitor harakiriMonitor = HarakiriMonitorCli.createHarakiriMonitor(getArgs());
+        assertNotNull(harakiriMonitor);
+    }
+
+    @Test(expected = CommandLineExitException.class)
+    public void testCreateHarakiriMonitor_noCloudProvider() {
+        addCloudIdentityArgs();
+        addCloudCredentialArgs();
+
+        HarakiriMonitorCli.createHarakiriMonitor(getArgs());
+    }
+
+    @Test(expected = CommandLineExitException.class)
+    public void testCreateHarakiriMonitor_noCloudIdentity() {
+        addCloudProviderArgs();
+        addCloudCredentialArgs();
+
+        HarakiriMonitorCli.createHarakiriMonitor(getArgs());
+    }
+
+    @Test(expected = CommandLineExitException.class)
+    public void testCreateHarakiriMonitor_noCloudCredential() {
+        addCloudProviderArgs();
+        addCloudIdentityArgs();
+
+        HarakiriMonitorCli.createHarakiriMonitor(getArgs());
+    }
+
+    @Test(timeout = 5000)
+    public void testHarakiriMonitor_noEC2() {
+        harakiriMonitor = new HarakiriMonitor("static", CLOUD_IDENTITY, CLOUD_PROVIDER, WAIT_SECONDS);
+        harakiriMonitor.start();
+    }
+
+    @Test
+    public void testHarakiriMonitor_isEC2() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                harakiriMonitor = new HarakiriMonitor(CloudProviderUtils.AWS_EC2, CLOUD_IDENTITY, CLOUD_PROVIDER, WAIT_SECONDS);
+                harakiriMonitor.start();
+                countDownLatch.countDown();
+            }
+        };
+        thread.start();
+        thread.join(TimeUnit.SECONDS.toMillis(1));
+
+        assertEquals(1, countDownLatch.getCount());
+    }
+
+    @Test
+    public void testMain() throws InterruptedException {
+        addCloudProviderArgs();
+        addCloudIdentityArgs();
+        addCloudCredentialArgs();
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                HarakiriMonitor.main(getArgs());
+                countDownLatch.countDown();
+            }
+        };
+        thread.start();
+        thread.join(TimeUnit.SECONDS.toMillis(1));
+
+        assertEquals(1, countDownLatch.getCount());
+    }
+
+    @Test(expected = ExitStatusOneException.class)
+    public void testMain_withException() {
+        HarakiriMonitor.main(getArgs());
+    }
+
+    private void addCloudProviderArgs() {
+        args.add("--cloudProvider");
+        args.add(CLOUD_PROVIDER);
+    }
+
+    private void addCloudIdentityArgs() {
+        args.add("--cloudIdentity");
+        args.add(CLOUD_IDENTITY);
+    }
+
+    private void addCloudCredentialArgs() {
+        args.add("--cloudCredential");
+        args.add(CLOUD_CREDENTIALS);
+    }
+
+    private String[] getArgs() {
+        String[] argsArray = new String[args.size()];
+        args.toArray(argsArray);
+        return argsArray;
+    }
+}

--- a/utils/src/main/java/com/hazelcast/simulator/utils/CliUtils.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/CliUtils.java
@@ -33,7 +33,7 @@ public final class CliUtils {
 
     public static OptionSet initOptionsWithHelp(OptionParser parser, String[] args) {
         try {
-            OptionSpec helpSpec = parser.accepts("help", "Show help").forHelp();
+            OptionSpec helpSpec = parser.accepts("help", "Shows the help.").forHelp();
             OptionSet options = parser.parse(args);
 
             if (options.has(helpSpec)) {


### PR DESCRIPTION
* Moved start/kill Agents functionality to Coordinator.
* Removed start Agents functionality from `--restart` and renamed the CLI command to `--install`.
* Renamed `--listAgents` to `--list`.
* General cleanup of Provisioner CLI commands texts.

```
user@system:~$ provisioner --help
INFO  12:14:01 Hazelcast Simulator Provisioner
INFO  12:14:01 Version: 0.6-SNAPSHOT, Commit: 0aaf2da, Build Time: 01.09.2015 @ 12:04:55 CEST
INFO  12:14:01 SIMULATOR_HOME: /home/donnerbart/bin/hazelcast-simulator
Option                         Description                                                                  
------                         -----------                                                                  
--clean                        Cleans the remote Worker directories on the provisioned machines.            
--download                     Download all files from the remote Worker directories. Use --clean to delete 
                                 all Worker directories. (default: workers)                                 
--enterpriseEnabled <Boolean>  Use JARs of Hazelcast Enterprise Edition. (default: false)                   
--git                          Overrides the HAZELCAST_VERSION_SPEC property and forces Provisioner to build
                                 Hazelcast JARs from a given GIT version. This makes it easier to run a test
                                 with different versions of Hazelcast, e.g.                                 
                                    --git f0288f713                to use the Git revision f0288f713        
                                    --git myRepository/myBranch    to use branch myBranch from a repository 
                                 myRepository.                                                              
                               You can specify custom repositories in 'simulator.properties'.               
--help                         Shows the help.                                                              
--kill                         Kills the Java processes on all provisioned machines (via killall -9 java).  
--list                         Lists the provisioned machines (from agents.txt file).                       
--propertiesFile               The file containing the Simulator properties. If no file is explicitly       
                                 configured, first the local working directory is checked for a file        
                                 'simulator.properties'. All missing properties are always loaded from      
                                 '$SIMULATOR_HOME/conf/simulator.properties'.                               
--install                      Installs Simulator on all provisioned machines.                            
--scale <Integer>              Number of Simulator machines to scale to. If the number of machines already  
                                 exists, the call is ignored. If the desired number of machines is smaller  
                                 than the actual number of machines, machines are terminated.               
--terminate                    Terminates all provisioned machines.
```

I replaced the term "Agent" with "provisioned machine" in some help texts to clarify the responsibility of the Provisioner. I also made clear that `--kill` kills all Java processes, not just the Agent.

I did a local run with and without `provisioner --install` and checked, that the Agents were stopped after each run. Worked without problems so far.