### PR TITLE
Fixed fail fast mechanism to abort testsuite after failure

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -324,10 +324,6 @@ public final class Coordinator {
                 public void run() {
                     try {
                         ((TestCaseRunner) testCaseRunner).run();
-                        if (failureContainer.hasCriticalFailure() && testSuite.isFailFast()) {
-                            LOGGER.info("Aborting testsuite due to failure (not implemented yet)");
-                            // FIXME: we should abort here as logged
-                        }
                     } catch (Exception e) {
                         throw rethrow(e);
                     }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -275,6 +275,10 @@ final class TestCaseRunner implements TestPhaseListener {
                     echo("Critical failure detected, aborting execution of test");
                     return;
                 }
+                if (failureContainer.hasCriticalFailure() && testSuite.isFailFast()) {
+                    echo("Aborting testsuite due to failure");
+                    return;
+                }
 
                 sleepSeconds(logRunPhaseIntervalSeconds);
                 logProgress(logRunPhaseIntervalSeconds * i, sleepSeconds);


### PR DESCRIPTION
Fixed broken fail fast mechanism by aborting the run phase of all tests after a single test failure.

**Note:** This will not prevent to start all other test phases, it will just abort the run phase. This should already shorten the testsuite execution massively if there is a test failure. If we want to skip all other test phases after a failure happened, we need more code changes :)