### PR TITLE
ICache from xml

### DIFF
--- a/dist/src/main/dist/conf/hazelcast.xml
+++ b/dist/src/main/dist/conf/hazelcast.xml
@@ -98,6 +98,9 @@
         </service>
     </services>
 
+    <cache name="*">
+    </cache>
+
     <cache name="maxCachSmall*">
         <eviction max-size-policy="ENTRY_COUNT" size="271" eviction-policy="LFU"/>
     </cache>

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -67,7 +66,6 @@ public class AddRemoveListenerICacheTest {
     public double getProb = 0.25;
 
     private final OperationSelectorBuilder<Operation> builder = new OperationSelectorBuilder<Operation>();
-    private final CacheConfig<Integer, Long> config = new CacheConfig<Integer, Long>();
     private final ICacheEntryListener<Integer, Long> listener = new ICacheEntryListener<Integer, Long>();
     private final ICacheEntryEventFilter<Integer, Long> filter = new ICacheEntryEventFilter<Integer, Long>();
 
@@ -83,8 +81,7 @@ public class AddRemoveListenerICacheTest {
 
         cacheManager = createCacheManager(hazelcastInstance);
 
-        config.setName(basename);
-        cacheManager.createCache(basename, config);
+        cacheManager.getCache(basename);
 
         builder.addOperation(Operation.REGISTER, registerProb)
                 .addOperation(Operation.DE_REGISTER, deRegisterProb)

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
@@ -16,7 +16,6 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
@@ -72,15 +71,7 @@ public class BatchingICacheTest {
         HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
         CacheManager cacheManager = createCacheManager(hazelcastInstance);
 
-        CacheConfig<Integer, Integer> config = new CacheConfig<Integer, Integer>();
-        config.setName(basename);
 
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException hack) {
-            // temp hack to deal with multiple nodes wanting to make the same cache
-            LOGGER.severe(hack);
-        }
         cache = (ICache<Object, Object>) cacheManager.getCache(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, writeProb).addDefaultOperation(Operation.GET);

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -63,14 +62,7 @@ public class CasICacheTest {
 
         CacheManager cacheManager = createCacheManager(hazelcastInstance);
 
-        CacheConfig<Integer, Long> config = new CacheConfig<Integer, Long>();
-        config.setName(basename);
 
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException e) {
-            LOGGER.severe(basename + ": createCache " + e);
-        }
         cache = cacheManager.getCache(basename);
     }
 

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -91,13 +90,8 @@ public class CreateDestroyICacheTest {
 
         private final ICacheCreateDestroyCounter counter = new ICacheCreateDestroyCounter();
 
-        private final CacheConfig config;
-
         private Worker() {
             super(builder);
-
-            config = new CacheConfig();
-            config.setName(basename);
         }
 
         @Override
@@ -105,7 +99,7 @@ public class CreateDestroyICacheTest {
             switch (operation) {
                 case CREATE_CACHE:
                     try {
-                        cacheManager.createCache(basename, config);
+                        cacheManager.getCache(basename);
                         counter.create++;
                     } catch (CacheException e) {
                         counter.createException++;

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -32,7 +31,6 @@ import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
 import javax.cache.Cache;
-import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.MutableEntry;
@@ -62,16 +60,6 @@ public class EntryProcessorICacheTest {
         HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
 
         CacheManager cacheManager = createCacheManager(hazelcastInstance);
-
-        CacheConfig<Integer, Long> config = new CacheConfig<Integer, Long>();
-        config.setName(basename);
-
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException hack) {
-            // temp hack to deal with multiple nodes wanting to make the same cache
-            LOGGER.severe(hack);
-        }
 
         cache = cacheManager.getCache(basename);
         resultsPerWorker = hazelcastInstance.getList(basename + ":ResultMap");

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
@@ -16,7 +16,6 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -26,9 +25,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
-import com.hazelcast.util.EmptyStatement;
 
-import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
@@ -55,14 +52,6 @@ public class ExpiryICacheTest {
         HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
         CacheManager cacheManager = createCacheManager(hazelcastInstance);
 
-        CacheConfig<Long, Long> config = new CacheConfig<Long, Long>();
-        config.setName(basename);
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException e) {
-            // ignore exception when multiple nodes created the same cache
-            EmptyStatement.ignore(e);
-        }
 
         cache = (ICache<Long, Long>) cacheManager.<Long, Long>getCache(basename);
     }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryTest.java
@@ -16,7 +16,6 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -74,7 +73,6 @@ public class ExpiryTest {
     private CacheManager cacheManager;
 
     private ExpiryPolicy expiryPolicy;
-    private CacheConfig<Integer, Long> config = new CacheConfig<Integer, Long>();
 
     @Setup
     public void setup(TestContext testContext) {
@@ -84,7 +82,6 @@ public class ExpiryTest {
         cacheManager = createCacheManager(hazelcastInstance);
         expiryPolicy = new CreatedExpiryPolicy(new Duration(TimeUnit.MILLISECONDS, expiryDuration));
 
-        config.setName(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb).addOperation(Operation.PUT_ASYNC, putAsyncProb)
                 .addOperation(Operation.GET, getProb).addOperation(Operation.GET_ASYNC, getAsyncProb);
@@ -92,7 +89,7 @@ public class ExpiryTest {
 
     @Warmup(global = true)
     public void warmup() {
-        cacheManager.createCache(basename, config);
+        cacheManager.getCache(basename);
     }
 
     @Verify(global = true)

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
@@ -16,7 +16,6 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -30,9 +29,7 @@ import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryEventFilter;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryListener;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
-import com.hazelcast.util.EmptyStatement;
 
-import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.FactoryBuilder;
@@ -98,15 +95,6 @@ public class ListenerICacheTest {
         listeners = hazelcastInstance.getList(basename + "listeners");
 
         cacheManager = createCacheManager(hazelcastInstance);
-
-        CacheConfig<Integer, Long> config = new CacheConfig<Integer, Long>();
-        config.setName(basename);
-
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException ignored) {
-            EmptyStatement.ignore(ignored);
-        }
 
         builder.addOperation(Operation.PUT, put)
                 .addOperation(Operation.PUT_EXPIRY, putExpiry)

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -103,7 +102,6 @@ public class MangleICacheTest {
 
     private class Worker extends AbstractWorker<Operation> {
 
-        private final CacheConfig config = new CacheConfig();
         private final ICacheOperationCounter counter = new ICacheOperationCounter();
 
         private CacheManager cacheManager;
@@ -111,7 +109,6 @@ public class MangleICacheTest {
         public Worker() {
             super(operationSelectorBuilder);
 
-            config.setName(basename);
             createNewCacheManager();
         }
 
@@ -128,7 +125,7 @@ public class MangleICacheTest {
                     closeCacheManager();
                     break;
                 case CREATE_CACHE:
-                    createCache();
+                    getCache();
                     break;
                 case CLOSE_CACHE:
                     closeCache();
@@ -174,10 +171,10 @@ public class MangleICacheTest {
             }
         }
 
-        private void createCache() {
+        private void getCache() {
             try {
                 int cacheNumber = randomInt(maxCaches);
-                cacheManager.createCache(basename + cacheNumber, config);
+                cacheManager.getCache(basename + cacheNumber);
                 counter.create++;
             } catch (CacheException e) {
                 counter.createException++;

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
@@ -15,10 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
@@ -31,7 +28,6 @@ import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
 import javax.cache.Cache;
-import javax.cache.CacheException;
 import javax.cache.CacheManager;
 
 import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCacheManager;
@@ -41,7 +37,6 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
  */
 public class PerformanceICacheTest {
 
-    private static final ILogger LOGGER = Logger.getLogger(PerformanceICacheTest.class);
 
     private enum Operation {
         PUT,
@@ -62,15 +57,6 @@ public class PerformanceICacheTest {
         HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
         CacheManager cacheManager = createCacheManager(hazelcastInstance);
 
-        CacheConfig<Integer, Integer> config = new CacheConfig<Integer, Integer>();
-        config.setName(basename);
-
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException hack) {
-            // temp hack to deal with multiple nodes wanting to make the same cache
-            LOGGER.severe(hack);
-        }
         cache = cacheManager.getCache(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/ReadWriteICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/ReadWriteICacheTest.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
+import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.logging.ILogger;
@@ -67,7 +68,7 @@ public class ReadWriteICacheTest {
     private final OperationSelectorBuilder<Operation> builder = new OperationSelectorBuilder<Operation>();
 
     private IList<ICacheReadWriteCounter> counters;
-    private MutableConfiguration<Integer, Integer> config;
+    private CacheConfig<Integer, Integer> config;
     private Cache<Integer, Integer> cache;
 
     @Setup
@@ -82,7 +83,7 @@ public class ReadWriteICacheTest {
         writer.writeDelayMs = putDelayMs;
         writer.deleteDelayMs = removeDelayMs;
 
-        config = new MutableConfiguration<Integer, Integer>();
+        config = new CacheConfig<Integer, Integer>();
         config.setReadThrough(true);
         config.setWriteThrough(true);
         config.setCacheLoaderFactory(FactoryBuilder.factoryOf(loader));

--- a/tests/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -33,7 +32,6 @@ import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
 import javax.cache.Cache;
-import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import java.util.Random;
 
@@ -77,20 +75,10 @@ public class StringICacheTest {
         hazelcastInstance = testContext.getTargetInstance();
 
         CacheManager cacheManager = createCacheManager(hazelcastInstance);
-
-        CacheConfig<String, String> config = new CacheConfig<String, String>();
-        config.setName(basename);
-
-        try {
-            cacheManager.createCache(basename, config);
-        } catch (CacheException hack) {
-            // temp hack to deal with multiple nodes wanting to make the same cache.
-            LOGGER.severe(hack);
-        }
         cache = cacheManager.getCache(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)
-                .addDefaultOperation(Operation.GET);
+                                .addDefaultOperation(Operation.GET);
     }
 
     @Teardown


### PR DESCRIPTION
fix for https://github.com/hazelcast/hazelcast-enterprise/issues/468

when you use `getCache`, it first tries to find cache config. If there is not created cache it gets cache config from xml and creates a proxy. If there is no config even in the xml, it throws exception. So in our case, if cache is not created yet, it pulls the config from xml with `NATIVE` in-memory format. But when you use `createCache`, it uses its own config by sending this config to whole cluster and then creates a proxy. So in our case, since default `CacheConfig` instance is created, `BINARY` in-memory format is used. So I mean, there may be inconsistent state in the cluster due to this behaviour.  Therefore, it may be better using `getCache` always since we have cache config in our xml and getting rid of all `createCache` in the tests.

using getCache 2 configure from the xml,  every time is a more consistent and flexible way to run our tests,  as now we have https://hazelcast-l337.ci.cloudbees.com/view/Simulator/job/Hazelcast-Simulator-nightly-enterprise/
using 

<cache name="*">
<backup-count>1</backup-count>
<async-backup-count>0</async-backup-count>
<in-memory-format>NATIVE</in-memory-format>
<eviction size="99" max-size-policy="USED_NATIVE_MEMORY_PERCENTAGE" eviction-policy="LRU"/>
</cache>



only way to make  https://github.com/hazelcast/hazelcast-enterprise/issues/468, happen is to have   createCache  and   getCache  used in the same test on same name

so https://github.com/hazelcast/hazelcast-simulator/blob/master/tests/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java#L99  has a mix of create and get caches


tested using

https://hazelcast-l337.ci.cloudbees.com/view/Simulator/job/Hazelcast-Simulator-nightly/303/console

and

https://hazelcast-l337.ci.cloudbees.com/view/Simulator/job/Hazelcast-Simulator-nightly-enterprise/228/console
