### PR TITLE
Fixed test failure in LockTest.

### DIFF
--- a/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
@@ -166,7 +166,6 @@ public class LockTest {
                     LOGGER.info(Thread.currentThread().getName() + " At iteration: " + iteration);
                 }
             }
-            totalMoney.addAndGet(iteration);
         }
 
         private long getRandomAccountKey() {


### PR DESCRIPTION
The totalMoney variable should not be updated inside the test as this is the initial value of money which is then used as an 'expected' value.
Tested on Hazelcast Simulator v0.6.