### PR TITLE
Simplified exception handling

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractAsyncWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractAsyncWorker.java
@@ -19,8 +19,6 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.simulator.utils.ExceptionReporter;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 
-import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
-
 /**
  * Asynchronous version of {@link AbstractWorker}.
  *
@@ -37,13 +35,9 @@ public abstract class AbstractAsyncWorker<O extends Enum<O>, V> extends Abstract
     }
 
     @Override
-    public final void run() {
+    public final void doRun() throws Exception {
         while (!testContext.isStopped() && !isWorkerStopped) {
-            try {
-                timeStep(selector.select());
-            } catch (Exception e) {
-                throw rethrow(e);
-            }
+            timeStep(selector.select());
         }
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorker.java
@@ -15,8 +15,6 @@
  */
 package com.hazelcast.simulator.worker.tasks;
 
-import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
-
 /**
  * Monotonic version of {@link AbstractWorker}.
  *
@@ -26,16 +24,12 @@ import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
 public abstract class AbstractMonotonicWorker extends AbstractWorker {
 
     @Override
-    public final void run() {
+    public final void doRun() throws Exception {
         beforeRun();
 
         while (!testContext.isStopped() && !isWorkerStopped) {
             long started = System.nanoTime();
-            try {
-                timeStep();
-            } catch (Exception e) {
-                throw rethrow(e);
-            }
+            timeStep();
             workerProbe.recordValue(System.nanoTime() - started);
 
             increaseIteration();

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractWorker.java
@@ -71,16 +71,20 @@ public abstract class AbstractWorker<O extends Enum<O>> implements IWorker {
     }
 
     @Override
-    public void run() {
+    public final void run() {
+        try {
+            doRun();
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    protected void doRun() throws Exception {
         beforeRun();
 
         while (!testContext.isStopped() && !isWorkerStopped) {
             long started = System.nanoTime();
-            try {
-                timeStep(selector.select());
-            } catch (Exception e) {
-                throw rethrow(e);
-            }
+            timeStep(selector.select());
             workerProbe.recordValue(System.nanoTime() - started);
 
             increaseIteration();
@@ -110,7 +114,7 @@ public abstract class AbstractWorker<O extends Enum<O>> implements IWorker {
     /**
      * Override this method if you need to execute code on each worker before {@link #run()} is called.
      */
-    protected void beforeRun() {
+    protected void beforeRun() throws Exception {
     }
 
     /**
@@ -127,7 +131,7 @@ public abstract class AbstractWorker<O extends Enum<O>> implements IWorker {
      *
      * Won't be called if an error occurs in {@link #beforeRun()} or {@link #timeStep(Enum)}.
      */
-    protected void afterRun() {
+    protected void afterRun() throws Exception {
     }
 
     /**
@@ -135,7 +139,7 @@ public abstract class AbstractWorker<O extends Enum<O>> implements IWorker {
      *
      * @see IWorker
      */
-    public void afterCompletion() {
+    public void afterCompletion() throws Exception {
     }
 
     /**

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/IWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/IWorker.java
@@ -32,5 +32,5 @@ public interface IWorker extends Runnable {
      * Will always be called by the {@link com.hazelcast.simulator.test.TestContainer}, regardless of errors in the run phase.
      * Will be executed after {@link com.hazelcast.simulator.utils.ThreadSpawner#awaitCompletion()} on a single worker instance.
      */
-    void afterCompletion();
+    void afterCompletion() throws Exception;
 }

--- a/tests/src/main/java/com/hazelcast/simulator/tests/map/SerializationStrategyTest.java
+++ b/tests/src/main/java/com/hazelcast/simulator/tests/map/SerializationStrategyTest.java
@@ -136,7 +136,7 @@ public class SerializationStrategyTest {
         }
 
         @Override
-        protected void beforeRun() {
+        protected void beforeRun() throws Exception {
             localUniqueStrings = uniqueStrings.toArray(new String[uniqueStrings.size()]);
             super.beforeRun();
         }


### PR DESCRIPTION
All lifecycle methods like before/after etc are allowed to throw checked exceptions.

Exception handling is taken care of at a single place: AbstractWorker. Instead of repeated
on different places.