### PR TITLE
Field type should use interface instead of concrete class

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureContainer.java
@@ -50,7 +50,7 @@ public class FailureContainer {
     private final AtomicInteger failureCount = new AtomicInteger();
     private final ConcurrentMap<SimulatorAddress, FailureType> finishedWorkers
             = new ConcurrentHashMap<SimulatorAddress, FailureType>();
-    private final ConcurrentHashMap<FailureListener, Boolean> listenerMap = new ConcurrentHashMap<FailureListener, Boolean>();
+    private final ConcurrentMap<FailureListener, Boolean> listenerMap = new ConcurrentHashMap<FailureListener, Boolean>();
 
     private final AtomicBoolean hasCriticalFailure = new AtomicBoolean();
     private final ConcurrentMap<String, Boolean> hasCriticalFailuresMap = new ConcurrentHashMap<String, Boolean>();


### PR DESCRIPTION
This is a good practice anyway, but in this case it's a must.
Justification:
ConcurrentHashMap.keySet() returns KeySetView instead of Set in JKD8
 -> when you  use  JKD8 in compile-time, but JDK7- in runtime you
 get java.lang.NoSuchMethodError.

 Using  the ConcurrentMap interface instead of the ConcurrentHashMap class solves the problem.