### PR TITLE
fix attempt for #809 

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AbstractAsyncStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AbstractAsyncStreamer.java
@@ -46,7 +46,11 @@ abstract class AbstractAsyncStreamer<K, V> implements Streamer<K, V> {
     private final AtomicLong counter = new AtomicLong();
 
     AbstractAsyncStreamer() {
-        this.concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL;
+        this(DEFAULT_CONCURRENCY_LEVEL);
+    }
+
+    AbstractAsyncStreamer(int concurrencyLevel) {
+        this.concurrencyLevel = concurrencyLevel;
         this.semaphore = new Semaphore(DEFAULT_CONCURRENCY_LEVEL);
         this.callback = new StreamerExecutionCallback();
         this.throttlingLogger = ThrottlingLogger.newLogger(LOGGER, MAXIMUM_LOGGING_RATE_MS);

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AsyncCacheStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AsyncCacheStreamer.java
@@ -28,6 +28,11 @@ final class AsyncCacheStreamer<K, V> extends AbstractAsyncStreamer<K, V> {
 
     private final ICache<K, V> cache;
 
+    public AsyncCacheStreamer(int concurrencyLevel, ICache<K, V> cache) {
+        super(concurrencyLevel);
+        this.cache = cache;
+    }
+
     AsyncCacheStreamer(ICache<K, V> cache) {
         this.cache = cache;
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AsyncMapStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AsyncMapStreamer.java
@@ -28,6 +28,11 @@ final class AsyncMapStreamer<K, V> extends AbstractAsyncStreamer<K, V> {
 
     private final IMap<K, V> map;
 
+    public AsyncMapStreamer(int concurrencyLevel, IMap<K, V> map) {
+        super(concurrencyLevel);
+        this.map = map;
+    }
+
     AsyncMapStreamer(IMap<K, V> map) {
         this.map = map;
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
@@ -60,9 +60,23 @@ public final class StreamerFactory {
         return new SyncMapStreamer<K, V>(map);
     }
 
+    public static <K, V> Streamer<K, V> getInstance(IMap<K, V> map, int concurrencyLevel) {
+        if (CREATE_ASYNC.get()) {
+            return new AsyncMapStreamer<K, V>(concurrencyLevel,map);
+        }
+        return new SyncMapStreamer<K, V>(map);
+    }
+
     public static <K, V> Streamer<K, V> getInstance(Cache<K, V> cache) {
         if (CREATE_ASYNC.get() && cache instanceof ICache) {
             return new AsyncCacheStreamer<K, V>((ICache<K, V>) cache);
+        }
+        return new SyncCacheStreamer<K, V>(cache);
+    }
+
+    public static <K, V> Streamer<K, V> getInstance(Cache<K, V> cache ,int concurrencyLevel) {
+        if (CREATE_ASYNC.get() && cache instanceof ICache) {
+            return new AsyncCacheStreamer<K, V>(concurrencyLevel,(ICache<K, V>) cache);
         }
         return new SyncCacheStreamer<K, V>(cache);
     }


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-simulator/issues/809

- added new constructor which includes *concurrencyLevel* to AbstractAsyncStreamer 

- added new **getInstance** methods to StreamFactory so we can easily create streamer with defined concurrency level

easily change via **test.properties**
```
public int streamerConcurrencyLevel = 2500;
...
Streamer<String, String> streamer = StreamerFactory.getInstance(map,streamerConcurrencyLevel);
```