### PR TITLE
The probe.getIntervalCountAndReset is replaced by a get

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/probes/Probe.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/probes/Probe.java
@@ -59,10 +59,10 @@ public interface Probe {
     Histogram getIntervalHistogram();
 
     /**
-     * Get the count of entries of the last interval and reset.
+     * Get the number of iterations.
      *
-     * @return a count since the last interval count was taken
+     * @return the number of iterations.
      * @throws UnsupportedOperationException on non-lightweight implementations
      */
-    long getIntervalCountAndReset();
+    long get();
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
@@ -70,7 +70,7 @@ public class HdrProbe implements Probe {
     }
 
     @Override
-    public long getIntervalCountAndReset() {
+    public long get() {
         throw new UnsupportedOperationException();
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/probes/impl/ThroughputProbe.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/probes/impl/ThroughputProbe.java
@@ -58,7 +58,7 @@ public class ThroughputProbe implements Probe {
     }
 
     @Override
-    public long getIntervalCountAndReset() {
-        return counter.getAndSet(0);
+    public long get() {
+        return counter.get();
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrProbeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrProbeTest.java
@@ -69,7 +69,7 @@ public class HdrProbeTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testGetIntervalCountAndReset()  {
-        probe.getIntervalCountAndReset();
+    public void testGet()  {
+        probe.get();
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/probes/impl/ThroughputProbeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/probes/impl/ThroughputProbeTest.java
@@ -40,8 +40,7 @@ public class ThroughputProbeTest {
         sleepNanos(TimeUnit.MILLISECONDS.toNanos(expectedLatency));
         probe.done(started);
 
-        assertEquals(expectedCount, probe.getIntervalCountAndReset());
-        assertEquals(0, probe.getIntervalCountAndReset());
+        assertEquals(expectedCount, probe.get());
     }
 
     @Test
@@ -55,8 +54,7 @@ public class ThroughputProbeTest {
         probe.recordValue(TimeUnit.MILLISECONDS.toNanos(expectedMinValue));
         probe.recordValue(TimeUnit.MILLISECONDS.toNanos(expectedMaxValue));
 
-        assertEquals(expectedCount, probe.getIntervalCountAndReset());
-        assertEquals(0, probe.getIntervalCountAndReset());
+        assertEquals(expectedCount, probe.get());
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Resetting is not a concern of the probe. If a delta needs to be stored
compared to the previous run, it needs to be done somewhere else.

The driver behind this change is that we want to create thread unsafe
probes for higher performance. And resetting from an arbitrary thread
is undesirable.