### PR TITLE
Moved probe out of veryabstractworker

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractAsyncWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractAsyncWorker.java
@@ -18,6 +18,7 @@ package com.hazelcast.simulator.worker.tasks;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.utils.ExceptionReporter;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 import com.hazelcast.simulator.worker.selector.OperationSelector;
@@ -35,6 +36,8 @@ import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 public abstract class AbstractAsyncWorker<O extends Enum<O>, V> extends VeryAbstractWorker implements ExecutionCallback<V> {
 
     private final OperationSelector<O> selector;
+    @InjectProbe(name = IWorker.DEFAULT_WORKER_PROBE_NAME, useForThroughput = true)
+    private Probe workerProbe;
 
     public AbstractAsyncWorker(OperationSelectorBuilder<O> operationSelectorBuilder) {
         this.selector = operationSelectorBuilder.build();
@@ -44,7 +47,7 @@ public abstract class AbstractAsyncWorker<O extends Enum<O>, V> extends VeryAbst
     public final void run() throws Exception {
         final TestContext testContext = getTestContext();
         final Metronome metronome = getWorkerMetronome();
-        final Probe probe = getWorkerProbe();
+        final Probe probe = workerProbe;
         final OperationSelector<O> selector = this.selector;
 
         while ((!testContext.isStopped() && !isWorkerStopped)) {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorker.java
@@ -17,6 +17,7 @@ package com.hazelcast.simulator.worker.tasks;
 
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 
 /**
@@ -26,12 +27,14 @@ import com.hazelcast.simulator.worker.metronome.Metronome;
  * method without parameters.
  */
 public abstract class AbstractMonotonicWorker extends VeryAbstractWorker {
+    @InjectProbe(name = IWorker.DEFAULT_WORKER_PROBE_NAME, useForThroughput = true)
+    private Probe workerProbe;
 
     @Override
     public final void run() throws Exception {
         final TestContext testContext = getTestContext();
         final Metronome metronome = getWorkerMetronome();
-        final Probe probe = getWorkerProbe();
+        final Probe probe = workerProbe;
 
         while ((!testContext.isStopped() && !isWorkerStopped)) {
             metronome.waitForNext();

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorkerWithProbeControl.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorkerWithProbeControl.java
@@ -17,6 +17,7 @@ package com.hazelcast.simulator.worker.tasks;
 
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 
 /**
@@ -26,12 +27,14 @@ import com.hazelcast.simulator.worker.metronome.Metronome;
  * method with the built-in {@link Probe} as parameter. This can be used to make a finer selection of the measured code block.
  */
 public abstract class AbstractMonotonicWorkerWithProbeControl extends VeryAbstractWorker {
+    @InjectProbe(name = IWorker.DEFAULT_WORKER_PROBE_NAME, useForThroughput = true)
+    private Probe workerProbe;
 
     @Override
     public final void run() throws Exception {
         final TestContext testContext = getTestContext();
         final Metronome metronome = getWorkerMetronome();
-        final Probe probe = getWorkerProbe();
+        final Probe probe = workerProbe;
 
         while ((!testContext.isStopped() && !isWorkerStopped)) {
             metronome.waitForNext();

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractWorker.java
@@ -18,6 +18,7 @@ package com.hazelcast.simulator.worker.tasks;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.probes.impl.ThroughputProbe;
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.worker.metronome.EmptyMetronome;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 import com.hazelcast.simulator.worker.selector.OperationSelector;
@@ -33,6 +34,8 @@ import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
  * @param <O> Type of {@link Enum} used by the {@link com.hazelcast.simulator.worker.selector.OperationSelector}
  */
 public abstract class AbstractWorker<O extends Enum<O>> extends VeryAbstractWorker {
+    @InjectProbe(name = IWorker.DEFAULT_WORKER_PROBE_NAME, useForThroughput = true)
+    private Probe workerProbe;
 
     private final OperationSelector<O> selector;
 
@@ -44,7 +47,7 @@ public abstract class AbstractWorker<O extends Enum<O>> extends VeryAbstractWork
     public final void run() throws Exception {
         final TestContext testContext = getTestContext();
         final Metronome metronome = getWorkerMetronome();
-        final Probe probe = getWorkerProbe();
+        final Probe probe = workerProbe;
         final OperationSelector<O> selector = this.selector;
 
         if (metronome.getClass() == EmptyMetronome.class && probe.getClass() == ThroughputProbe.class) {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractWorkerWithProbeControl.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractWorkerWithProbeControl.java
@@ -17,6 +17,7 @@ package com.hazelcast.simulator.worker.tasks;
 
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 import com.hazelcast.simulator.worker.selector.OperationSelector;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -30,6 +31,8 @@ import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
  * @param <O> Type of {@link Enum} used by the {@link com.hazelcast.simulator.worker.selector.OperationSelector}
  */
 public abstract class AbstractWorkerWithProbeControl<O extends Enum<O>> extends VeryAbstractWorker {
+    @InjectProbe(name = IWorker.DEFAULT_WORKER_PROBE_NAME, useForThroughput = true)
+    private Probe workerProbe;
 
     private final OperationSelector<O> selector;
 
@@ -41,7 +44,7 @@ public abstract class AbstractWorkerWithProbeControl<O extends Enum<O>> extends 
     public final void run() throws Exception {
         final TestContext testContext = getTestContext();
         final Metronome metronome = getWorkerMetronome();
-        final Probe probe = getWorkerProbe();
+        final Probe probe = workerProbe;
         final OperationSelector<O> selector = this.selector;
 
         while ((!testContext.isStopped() && !isWorkerStopped)) {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/VeryAbstractWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/VeryAbstractWorker.java
@@ -17,10 +17,8 @@ package com.hazelcast.simulator.worker.tasks;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.InjectMetronome;
-import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.test.annotations.InjectTestContext;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 
@@ -35,8 +33,6 @@ public abstract class VeryAbstractWorker implements IWorker {
     private final Random random = new Random();
     @InjectTestContext
     private TestContext testContext;
-    @InjectProbe(name = IWorker.DEFAULT_WORKER_PROBE_NAME, useForThroughput = true)
-    private Probe workerProbe;
     @InjectMetronome
     private Metronome workerMetronome;
 
@@ -134,10 +130,6 @@ public abstract class VeryAbstractWorker implements IWorker {
 
     protected void increaseIteration() {
         iteration++;
-    }
-
-    Probe getWorkerProbe() {
-        return workerProbe;
     }
 
     protected Metronome getWorkerMetronome() {


### PR DESCRIPTION
The location was inappropriate because some worker classes take care of
their own probes.