### PR TITLE
Configurable startup delay workers

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.simulator.agent.workerjvm.WorkerJvmLauncher.WORKERS_HOME_NAME;
 import static com.hazelcast.simulator.common.GitInfo.getBuildTime;
@@ -62,6 +61,7 @@ import static com.hazelcast.simulator.utils.FormatUtils.secondsToHuman;
 import static com.hazelcast.simulator.utils.NativeUtils.execute;
 import static com.hazelcast.simulator.utils.jars.HazelcastJARs.OUT_OF_THE_BOX;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class Coordinator {
 
@@ -244,10 +244,16 @@ public final class Coordinator {
     }
 
     private void startRemoteClient() {
-        int workerPingIntervalMillis = (int) TimeUnit.SECONDS.toMillis(simulatorProperties.getWorkerPingIntervalSeconds());
+        int workerPingIntervalMillis = (int) SECONDS.toMillis(simulatorProperties.getWorkerPingIntervalSeconds());
         int shutdownDelaySeconds = simulatorProperties.getMemberWorkerShutdownDelaySeconds();
 
-        remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, workerPingIntervalMillis, shutdownDelaySeconds);
+        remoteClient = new RemoteClient(
+                coordinatorConnector,
+                componentRegistry,
+                workerPingIntervalMillis,
+                shutdownDelaySeconds,
+                coordinatorParameters.getWorkerVmStartupDelayMs()
+        );
         remoteClient.initTestSuite(testSuite);
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -58,6 +58,11 @@ final class CoordinatorCli {
 
     private final OptionParser parser = new OptionParser();
 
+    private final OptionSpec<Integer> workerVmStartupDelayMsSpec = parser.accepts("workerVmStartupDelayMs",
+            "Amount of time in milliseconds to wait between starting up the next member. This is useful to prevent" +
+                    "duplicate connection issues.")
+            .withRequiredArg().ofType(Integer.class).defaultsTo(0);
+
     private final OptionSpec<String> durationSpec = parser.accepts("duration",
             "Amount of time to execute the RUN phase per test, e.g. 10s, 1m, 2h or 3d.")
             .withRequiredArg().ofType(String.class).defaultsTo(format("%ds", DEFAULT_DURATION_SECONDS));
@@ -229,7 +234,8 @@ final class CoordinatorCli {
                 options.valueOf(cli.workerRefreshSpec),
                 options.valueOf(cli.targetTypeSpec),
                 options.valueOf(cli.targetCountSpec),
-                options.valueOf(cli.syncToTestPhaseSpec)
+                options.valueOf(cli.syncToTestPhaseSpec),
+                options.valueOf(cli.workerVmStartupDelayMsSpec)
         );
 
         String memberHzConfig = loadMemberHzConfig(options, cli);

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
@@ -37,10 +37,12 @@ class CoordinatorParameters {
     private final int targetCount;
 
     private final TestPhase lastTestPhaseToSync;
+    private final int workerVmStartupDelayMs;
 
+    @SuppressWarnings("checkstyle:parameternumber")
     CoordinatorParameters(SimulatorProperties properties, String workerClassPath, boolean uploadHazelcastJARs,
                           boolean enterpriseEnabled, boolean verifyEnabled, boolean parallel, boolean refreshJvm,
-                          TargetType targetType, int targetCount, TestPhase lastTestPhaseToSync) {
+                          TargetType targetType, int targetCount, TestPhase lastTestPhaseToSync, int workerVmStartupDelayMs) {
         this.simulatorProperties = properties;
         this.workerClassPath = workerClassPath;
 
@@ -54,6 +56,11 @@ class CoordinatorParameters {
         this.targetCount = targetCount;
 
         this.lastTestPhaseToSync = lastTestPhaseToSync;
+        this.workerVmStartupDelayMs = workerVmStartupDelayMs;
+    }
+
+    public int getWorkerVmStartupDelayMs() {
+        return workerVmStartupDelayMs;
     }
 
     SimulatorProperties getSimulatorProperties() {

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/AbstractServerConnector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/AbstractServerConnector.java
@@ -39,8 +39,8 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -53,7 +53,7 @@ import static com.hazelcast.simulator.protocol.operation.OperationType.getOperat
 import static com.hazelcast.simulator.utils.CommonUtils.awaitTermination;
 import static com.hazelcast.simulator.utils.CommonUtils.joinThread;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepMillis;
-import static com.hazelcast.simulator.utils.ExecutorFactory.createFixedThreadPool;
+import static com.hazelcast.simulator.utils.ExecutorFactory.createScheduledThreadPool;
 import static java.lang.String.format;
 
 /**
@@ -75,22 +75,21 @@ abstract class AbstractServerConnector implements ServerConnector {
     private final int port;
 
     private final EventLoopGroup group;
-    private final ExecutorService executorService;
+    private final ScheduledExecutorService executorService;
 
     private Channel channel;
 
     AbstractServerConnector(ConcurrentMap<String, ResponseFuture> futureMap, SimulatorAddress localAddress, int port,
                             int threadPoolSize) {
-        this(futureMap, localAddress, port, threadPoolSize, createFixedThreadPool(threadPoolSize, "AbstractServerConnector"));
+        this(futureMap, localAddress, port, threadPoolSize, createScheduledThreadPool(threadPoolSize, "AbstractServerConnector"));
     }
 
     AbstractServerConnector(ConcurrentMap<String, ResponseFuture> futureMap, SimulatorAddress localAddress, int port,
-                            int threadPoolSize, ExecutorService executorService) {
+                            int threadPoolSize, ScheduledExecutorService executorService) {
         this.futureMap = futureMap;
         this.localAddress = localAddress;
         this.addressIndex = localAddress.getAddressIndex();
         this.port = port;
-
         this.group = new NioEventLoopGroup(threadPoolSize);
         this.executorService = executorService;
     }
@@ -183,7 +182,7 @@ abstract class AbstractServerConnector implements ServerConnector {
         return group;
     }
 
-    ExecutorService getExecutorService() {
+    ScheduledExecutorService getScheduledExecutor() {
         return executorService;
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/AgentConnector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/AgentConnector.java
@@ -72,7 +72,7 @@ public class AgentConnector extends AbstractServerConnector implements ClientPip
         super(futureMap, localAddress, port, threadPoolSize);
 
         RemoteExceptionLogger exceptionLogger = new RemoteExceptionLogger(localAddress, AGENT_EXCEPTION, this);
-        this.processor = new AgentOperationProcessor(exceptionLogger, agent, workerJvmManager, getExecutorService());
+        this.processor = new AgentOperationProcessor(exceptionLogger, agent, workerJvmManager, getScheduledExecutor());
 
         this.futureMap = futureMap;
 
@@ -112,7 +112,7 @@ public class AgentConnector extends AbstractServerConnector implements ClientPip
         pipeline.addLast("forwardToCoordinatorHandler", new ForwardToCoordinatorHandler(localAddress, connectionManager,
                 workerJvmManager));
         pipeline.addLast("responseHandler", new ResponseHandler(localAddress, remoteAddress, getFutureMap()));
-        pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getExecutorService()));
+        pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getScheduledExecutor()));
         pipeline.addLast("exceptionHandler", new ExceptionHandler(this));
     }
 
@@ -125,8 +125,8 @@ public class AgentConnector extends AbstractServerConnector implements ClientPip
         pipeline.addLast("frameDecoder", new SimulatorFrameDecoder());
         pipeline.addLast("protocolDecoder", new SimulatorProtocolDecoder(localAddress));
         pipeline.addLast("forwardToWorkerHandler", new ForwardToWorkerHandler(localAddress, clientConnectorManager,
-                getExecutorService()));
-        pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getExecutorService()));
+                getScheduledExecutor()));
+        pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getScheduledExecutor()));
         pipeline.addLast("responseHandler", new ResponseHandler(localAddress, COORDINATOR, futureMap, addressIndex));
         pipeline.addLast("exceptionHandler", new ExceptionHandler(this));
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/WorkerConnector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/WorkerConnector.java
@@ -89,10 +89,10 @@ public class WorkerConnector extends AbstractServerConnector {
         pipeline.addLast("messageEncoder", new MessageEncoder(localAddress, localAddress.getParent()));
         pipeline.addLast("frameDecoder", new SimulatorFrameDecoder());
         pipeline.addLast("protocolDecoder", new SimulatorProtocolDecoder(localAddress));
-        pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getExecutorService()));
+        pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getScheduledExecutor()));
         pipeline.addLast("testProtocolDecoder", new SimulatorProtocolDecoder(localAddress.getChild(0)));
         pipeline.addLast("testMessageConsumeHandler", new MessageTestConsumeHandler(testProcessorManager, localAddress,
-                getExecutorService()));
+                getScheduledExecutor()));
         pipeline.addLast("responseHandler", new ResponseHandler(localAddress, localAddress.getParent(), futureMap, addressIndex));
         pipeline.addLast("exceptionHandler", new ExceptionHandler(serverConnector));
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/CreateWorkerOperation.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/CreateWorkerOperation.java
@@ -28,9 +28,15 @@ public class CreateWorkerOperation implements SimulatorOperation {
      * Defines a list of {@link WorkerJvmSettings} to create Simulator Workers.
      */
     private final List<WorkerJvmSettings> settingsList;
+    private int delayMs;
 
-    public CreateWorkerOperation(List<WorkerJvmSettings> settingsList) {
+    public CreateWorkerOperation(List<WorkerJvmSettings> settingsList, int delayMs) {
         this.settingsList = settingsList;
+        this.delayMs = delayMs;
+    }
+
+    public int getDelayMs() {
+        return delayMs;
     }
 
     public List<WorkerJvmSettings> getWorkerJvmSettings() {

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -97,7 +97,7 @@ public class AgentSmokeTest implements FailureListener {
                 testHistogramContainer);
         coordinatorConnector.addAgent(1, AGENT_IP_ADDRESS, AGENT_PORT);
 
-        remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, (int) TimeUnit.SECONDS.toMillis(10), 0);
+        remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, (int) TimeUnit.SECONDS.toMillis(10), 0,0);
     }
 
     @AfterClass

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorParametersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorParametersTest.java
@@ -17,7 +17,7 @@ public class CoordinatorParametersTest {
         SimulatorProperties properties = mock(SimulatorProperties.class);
 
         CoordinatorParameters coordinatorParameters = new CoordinatorParameters(properties, "workerClassPath", false, true, false,
-                true, false, TargetType.PREFER_CLIENT, 5, LOCAL_TEARDOWN);
+                true, false, TargetType.PREFER_CLIENT, 5, LOCAL_TEARDOWN,0);
 
         assertEquals(properties, coordinatorParameters.getSimulatorProperties());
         assertEquals("workerClassPath", coordinatorParameters.getWorkerClassPath());

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RemoteClientTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RemoteClientTest.java
@@ -79,7 +79,7 @@ public class RemoteClientTest {
     @Test
     public void testLogOnAllAgents() {
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.logOnAllAgents("test");
 
         verify(coordinatorConnector).write(eq(ALL_AGENTS), any(LogOperation.class));
@@ -89,7 +89,7 @@ public class RemoteClientTest {
     @Test
     public void testLogOnAllWorkers() {
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.logOnAllWorkers("test");
 
         verify(coordinatorConnector).write(eq(ALL_WORKERS), any(LogOperation.class));
@@ -102,7 +102,7 @@ public class RemoteClientTest {
         ClusterLayout clusterLayout = getClusterLayout(0, 6, 3);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.createWorkers(clusterLayout, false);
     }
 
@@ -112,7 +112,7 @@ public class RemoteClientTest {
         ClusterLayout clusterLayout = getClusterLayout(0, 6, 0);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.createWorkers(clusterLayout, false);
     }
 
@@ -122,7 +122,7 @@ public class RemoteClientTest {
         ClusterLayout clusterLayout = getClusterLayout(0, 6, 0);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.createWorkers(clusterLayout, false);
     }
 
@@ -132,7 +132,7 @@ public class RemoteClientTest {
         ClusterLayout clusterLayout = getClusterLayout(0, 6, 0);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.createWorkers(clusterLayout, false);
     }
 
@@ -142,7 +142,7 @@ public class RemoteClientTest {
         ClusterLayout clusterLayout = getClusterLayout(0, 6, 0);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.createWorkers(clusterLayout, true);
 
         sleepSeconds(1);
@@ -154,7 +154,7 @@ public class RemoteClientTest {
     public void testInitTestSuite() {
         initMock(ResponseType.SUCCESS);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         TestSuite testSuite = new TestSuite();
         remoteClient.initTestSuite(testSuite);
@@ -167,7 +167,7 @@ public class RemoteClientTest {
     public void testSendToAllAgents() {
         initMock(ResponseType.SUCCESS);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         remoteClient.sendToAllAgents(DEFAULT_OPERATION);
 
@@ -179,7 +179,7 @@ public class RemoteClientTest {
     public void testSendToAllAgents_withFailureResponse() {
         initMock(ResponseType.UNBLOCKED_BY_FAILURE);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         remoteClient.sendToAllAgents(DEFAULT_OPERATION);
 
@@ -191,7 +191,7 @@ public class RemoteClientTest {
     public void testSendToAllAgents_withErrorResponse() {
         initMock(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         try {
             remoteClient.sendToAllAgents(DEFAULT_OPERATION);
@@ -205,7 +205,7 @@ public class RemoteClientTest {
     public void testSendToAllWorkers() {
         initMock(ResponseType.SUCCESS);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         remoteClient.sendToAllWorkers(DEFAULT_OPERATION);
 
@@ -217,7 +217,7 @@ public class RemoteClientTest {
     public void testSendToAllWorkers_withFailureResponse() {
         initMock(ResponseType.UNBLOCKED_BY_FAILURE);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         remoteClient.sendToAllWorkers(DEFAULT_OPERATION);
 
@@ -229,7 +229,7 @@ public class RemoteClientTest {
     public void testSendToAllWorkers_withErrorResponse() {
         initMock(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         try {
             remoteClient.sendToAllWorkers(DEFAULT_OPERATION);
@@ -243,7 +243,7 @@ public class RemoteClientTest {
     public void testSendToFirstWorker() {
         initMock(ResponseType.SUCCESS);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         SimulatorAddress firstWorkerAddress = componentRegistry.getFirstWorker().getAddress();
 
         remoteClient.sendToFirstWorker(DEFAULT_OPERATION);
@@ -256,7 +256,7 @@ public class RemoteClientTest {
     public void testSendToFirstWorker_withFailureResponse() {
         initMock(ResponseType.UNBLOCKED_BY_FAILURE);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         SimulatorAddress firstWorkerAddress = componentRegistry.getFirstWorker().getAddress();
 
         remoteClient.sendToFirstWorker(DEFAULT_OPERATION);
@@ -269,7 +269,7 @@ public class RemoteClientTest {
     public void testSendToFirstWorker_withErrorResponse() {
         initMock(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         SimulatorAddress firstWorkerAddress = componentRegistry.getFirstWorker().getAddress();
 
         try {
@@ -284,7 +284,7 @@ public class RemoteClientTest {
     public void testSendToTestOnAllWorkers() {
         initMock(ResponseType.SUCCESS);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         remoteClient.sendToTestOnAllWorkers(DEFAULT_TEST_ID, DEFAULT_OPERATION);
 
@@ -296,7 +296,7 @@ public class RemoteClientTest {
     public void testSendToTestOnAllWorkers_withFailureResponse() {
         initMock(ResponseType.UNBLOCKED_BY_FAILURE);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         remoteClient.sendToTestOnAllWorkers(DEFAULT_TEST_ID, DEFAULT_OPERATION);
 
@@ -308,7 +308,7 @@ public class RemoteClientTest {
     public void testSendToTestOnAllWorkers_withErrorResponse() {
         initMock(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
 
         try {
             remoteClient.sendToTestOnAllWorkers(DEFAULT_TEST_ID, DEFAULT_OPERATION);
@@ -322,7 +322,7 @@ public class RemoteClientTest {
     public void testSendToTestOnFirstWorker() {
         initMock(ResponseType.SUCCESS);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         SimulatorAddress testOnFirstWorkerAddress = componentRegistry.getFirstWorker().getAddress().getChild(1);
 
         remoteClient.sendToTestOnFirstWorker(DEFAULT_TEST_ID, DEFAULT_OPERATION);
@@ -335,7 +335,7 @@ public class RemoteClientTest {
     public void testSendToTestOnFirstWorker_withFailureResponse() {
         initMock(ResponseType.UNBLOCKED_BY_FAILURE);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         SimulatorAddress testOnFirstWorkerAddress = componentRegistry.getFirstWorker().getAddress().getChild(1);
 
         remoteClient.sendToTestOnFirstWorker(DEFAULT_TEST_ID, DEFAULT_OPERATION);
@@ -348,7 +348,7 @@ public class RemoteClientTest {
     public void testSendToTestOnFirstWorker_withErrorResponse() {
         initMock(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         SimulatorAddress testOnFirstWorkerAddress = componentRegistry.getFirstWorker().getAddress().getChild(1);
 
         try {
@@ -369,7 +369,7 @@ public class RemoteClientTest {
                 .thenReturn(response);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, 50,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.startWorkerPingThread();
 
         sleepMillis(300);
@@ -390,7 +390,7 @@ public class RemoteClientTest {
                 .thenReturn(response);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, 50,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.startWorkerPingThread();
 
         sleepMillis(300);
@@ -404,7 +404,7 @@ public class RemoteClientTest {
     @Test
     public void testPingWorkerThread_shouldDoNothingIfDisabled() {
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, -1,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS,0);
         remoteClient.startWorkerPingThread();
 
         sleepMillis(300);

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/connector/AbstractServerConnectorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/connector/AbstractServerConnectorTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.simulator.TestEnvironmentUtils.resetLogLevel;
@@ -46,7 +46,7 @@ public class AbstractServerConnectorTest {
 
     private SimulatorAddress connectorAddress;
     private ConcurrentMap<String, ResponseFuture> futureMap;
-    private ExecutorService executorService;
+    private ScheduledExecutorService executorService;
     private ChannelGroup channelGroup;
 
     private TestServerConnector testServerConnector;
@@ -57,7 +57,7 @@ public class AbstractServerConnectorTest {
 
         futureMap = new ConcurrentHashMap<String, ResponseFuture>();
         connectorAddress = new SimulatorAddress(AddressLevel.WORKER, 1, 1, 0);
-        executorService = mock(ExecutorService.class);
+        executorService = mock(ScheduledExecutorService.class);
         channelGroup = mock(ChannelGroup.class);
 
         testServerConnector = new TestServerConnector(futureMap, connectorAddress, PORT, THREAD_POOL_SIZE, executorService,
@@ -136,7 +136,7 @@ public class AbstractServerConnectorTest {
     public void testGetExecutorService() {
         testServerConnector.start();
 
-        assertEquals(executorService, testServerConnector.getExecutorService());
+        assertEquals(executorService, testServerConnector.getScheduledExecutor());
     }
 
     @Test
@@ -196,7 +196,7 @@ public class AbstractServerConnectorTest {
         private final ChannelGroup channelGroup;
 
         TestServerConnector(ConcurrentMap<String, ResponseFuture> futureMap, SimulatorAddress localAddress, int port,
-                            int threadPoolSize, ExecutorService executorService, ChannelGroup channelGroup) {
+                            int threadPoolSize, ScheduledExecutorService executorService, ChannelGroup channelGroup) {
             super(futureMap, localAddress, port, threadPoolSize, executorService);
 
             this.channelGroup = channelGroup;

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/operation/OperationCodecTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/operation/OperationCodecTest.java
@@ -72,7 +72,7 @@ public class OperationCodecTest {
 
         WorkerJvmSettings workerJvmSettings = new WorkerJvmSettings(1, WorkerType.MEMBER, workerParameters);
 
-        CreateWorkerOperation operation = new CreateWorkerOperation(Collections.singletonList(workerJvmSettings));
+        CreateWorkerOperation operation = new CreateWorkerOperation(Collections.singletonList(workerJvmSettings),0);
         String json = toJson(operation);
         assertNotNull(json);
         LOGGER.info(json);

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/TestOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/TestOperationProcessorTest.java
@@ -52,7 +52,7 @@ public class TestOperationProcessorTest {
     public void testProcessOperation_unsupportedOperation() throws Exception {
         createTestOperationProcessor();
 
-        SimulatorOperation operation = new CreateWorkerOperation(Collections.<WorkerJvmSettings>emptyList());
+        SimulatorOperation operation = new CreateWorkerOperation(Collections.<WorkerJvmSettings>emptyList(),0);
         ResponseType responseType = processor.processOperation(getOperationType(operation), operation, COORDINATOR);
 
         assertEquals(UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR, responseType);

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/WorkerOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/WorkerOperationProcessorTest.java
@@ -79,7 +79,7 @@ public class WorkerOperationProcessorTest {
 
     @Test
     public void process_unsupportedOperation() throws Exception {
-        SimulatorOperation operation = new CreateWorkerOperation(Collections.<WorkerJvmSettings>emptyList());
+        SimulatorOperation operation = new CreateWorkerOperation(Collections.<WorkerJvmSettings>emptyList(),0);
         ResponseType responseType = processor.processOperation(getOperationType(operation), operation, COORDINATOR);
 
         assertEquals(UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR, responseType);


### PR DESCRIPTION
This will prevent duplicate connections being created. Normally the io balancer will take care of it; but I'm chasing a performance variation and I want to exclude certain causes.