### PR TITLE
Pulled out worker script

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -257,16 +257,6 @@ JDK_64_BITS=true
 JDK_VERSION=7
 
 #
-# Java Command.
-#
-# The command to start up Java. This could be as simple as a plain 'java' and use what is on the path; but it could also
-# be a the java command including the path, e.g. /java/jdk/jdk1.8/bin/java.
-#
-# It can also be used for numa control, Open Onload etc.
-#
-JAVA_CMD=java
-
-#
 # URL of Management Center
 #
 # If set to a valid URL the Management Center will be configured for member nodes.

--- a/dist/src/main/dist/conf/worker.sh
+++ b/dist/src/main/dist/conf/worker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# Script to start up a Simulator Worker.
+#
+# External variables have a @ symbol in front to distinguish them from regular bash variables.
+#
+
+# redirecting output/error to the right logfiles.
+exec > worker.out
+exec 2>worker.err
+
+JVM_ARGS="-XX:OnOutOfMemoryError=\"touch;-9;worker.oome\" \
+          -Dhazelcast.logging.type=log4j \
+          -Dlog4j.configuration=file:@LOG4J_FILE \
+          -DSIMULATOR_HOME=@SIMULATOR_HOME \
+          -DpublicAddress=@PUBLIC_ADDRESS \
+          -DagentIndex=@AGENT_INDEX \
+          -DworkerType=@WORKER_TYPE \
+          -DworkerId=@WORKER_ID \
+          -DworkerIndex=@WORKER_INDEX \
+          -DworkerPort=@WORKER_PORT \
+          -DworkerPerformanceMonitorIntervalSeconds=@WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS \
+          -DautoCreateHzInstance=@AUTO_CREATE_HZ_INSTANCE \
+          -DhzConfigFile=@HZ_CONFIG_FILE"
+
+# Include the member/client-worker jvm options
+JVM_ARGS="@JVM_OPTIONS ${JVM_ARGS}"
+
+CLASSPATH=@CLASSPATH
+
+MAIN=
+case "@WORKER_TYPE" in
+    CLIENT )        MAIN=com.hazelcast.simulator.worker.ClientWorker;;
+    MEMBER )        MAIN=com.hazelcast.simulator.worker.MemberWorker;;
+    INTEGRATION )   MAIN=com.hazelcast.simulator.worker.IntegrationTestWorker;;
+esac
+
+java -classpath ${CLASSPATH} ${JVM_ARGS} ${MAIN}

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerjvm/WorkerJvmSettings.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerjvm/WorkerJvmSettings.java
@@ -35,9 +35,9 @@ public class WorkerJvmSettings {
 
     private final boolean autoCreateHzInstance;
     private final int workerStartupTimeout;
-    private final int workerPerformanceMonitorIntervalSeconds;
+    private final int performanceMonitorIntervalSeconds;
 
-    private final String javaCmd;
+    private final String workerScript;
 
     public WorkerJvmSettings(int workerIndex, WorkerType workerType, WorkerParameters workerParameters) {
         this(workerIndex, workerType, workerParameters, workerParameters.getHazelcastVersionSpec(),
@@ -57,12 +57,12 @@ public class WorkerJvmSettings {
 
         this.autoCreateHzInstance = workerParameters.isAutoCreateHzInstance();
         this.workerStartupTimeout = workerParameters.getWorkerStartupTimeout();
-        this.workerPerformanceMonitorIntervalSeconds = initWorkerPerformanceMonitorIntervalSeconds(workerParameters);
+        this.performanceMonitorIntervalSeconds = initPerformanceMonitorIntervalSeconds(workerParameters);
 
-        this.javaCmd = workerParameters.getJavaCmd();
+        this.workerScript = workerParameters.getWorkerScript();
     }
 
-    private int initWorkerPerformanceMonitorIntervalSeconds(WorkerParameters workerParameters) {
+    private int initPerformanceMonitorIntervalSeconds(WorkerParameters workerParameters) {
         if (workerParameters.isMonitorPerformance()) {
             return workerParameters.getWorkerPerformanceMonitorIntervalSeconds();
         }
@@ -101,12 +101,12 @@ public class WorkerJvmSettings {
         return workerStartupTimeout;
     }
 
-    public int getWorkerPerformanceMonitorIntervalSeconds() {
-        return workerPerformanceMonitorIntervalSeconds;
+    public int getPerformanceMonitorIntervalSeconds() {
+        return performanceMonitorIntervalSeconds;
     }
 
-    public String getJavaCmd() {
-        return javaCmd;
+    public String getWorkerScript() {
+        return workerScript;
     }
 
     @Override
@@ -119,8 +119,8 @@ public class WorkerJvmSettings {
                 + ", log4jConfig='" + log4jConfig + '\''
                 + ", autoCreateHzInstance=" + autoCreateHzInstance
                 + ", workerStartupTimeout=" + workerStartupTimeout
-                + ", workerPerformanceMonitorIntervalSeconds=" + workerPerformanceMonitorIntervalSeconds
-                + ", javaCmd='" + javaCmd + '\''
+                + ", performanceMonitorIntervalSeconds=" + performanceMonitorIntervalSeconds
+                + ", workerScript='" + workerScript + '\''
                 + '}';
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/cluster/AgentWorkerLayout.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/cluster/AgentWorkerLayout.java
@@ -77,13 +77,22 @@ public final class AgentWorkerLayout {
     }
 
     void addWorker(WorkerType type, WorkerParameters parameters, WorkerConfiguration workerConfiguration) {
-        workerJvmSettingsList.add(new WorkerJvmSettings(currentWorkerIndex.incrementAndGet(), type, parameters,
-                workerConfiguration.getHzVersion(), workerConfiguration.getJvmOptions(),
-                workerConfiguration.getHzConfig()));
+        workerJvmSettingsList.add(
+                new WorkerJvmSettings(
+                        currentWorkerIndex.incrementAndGet(),
+                        type,
+                        parameters,
+                        workerConfiguration.getHzVersion(),
+                        workerConfiguration.getJvmOptions(),
+                        workerConfiguration.getHzConfig()));
     }
 
     void addWorker(WorkerType type, WorkerParameters parameters) {
-        workerJvmSettingsList.add(new WorkerJvmSettings(currentWorkerIndex.incrementAndGet(), type, parameters));
+        workerJvmSettingsList.add(
+                new WorkerJvmSettings(
+                        currentWorkerIndex.incrementAndGet(),
+                        type,
+                        parameters));
     }
 
     int getCount(WorkerType type) {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -161,6 +161,12 @@ final class CoordinatorCli {
                     PROPERTIES_FILE_NAME, PROPERTIES_FILE_NAME))
             .withRequiredArg().ofType(String.class);
 
+    private final OptionSpec<String> workerScriptFileSpec = parser.accepts("workerScript",
+            "The worker startup shell script. If no file is explicitly configured,"
+                    + " first the 'worker.sh' in the working directory is loaded."
+                    + " If that doesn't exist then SIMULATOR_HOME/conf/worker.sh is loaded.")
+            .withRequiredArg().ofType(String.class).defaultsTo(getDefaultConfigurationFile("worker.sh"));
+
     private final OptionSpec<String> memberHzConfigFileSpec = parser.accepts("hzFile",
             "The Hazelcast XML configuration file for the Worker. If no file is explicitly configured,"
                     + " first the 'hazelcast.xml' in the working directory is loaded."
@@ -252,6 +258,7 @@ final class CoordinatorCli {
                 initMemberHzConfig(memberHzConfig, componentRegistry, defaultHzPort, licenseKey, simulatorProperties),
                 initClientHzConfig(clientHzConfig, componentRegistry, defaultHzPort, licenseKey),
                 loadLog4jConfig(),
+                loadWorkerScript(options, cli),
                 options.has(cli.monitorPerformanceSpec)
         );
 
@@ -330,6 +337,12 @@ final class CoordinatorCli {
     private static String loadMemberHzConfig(OptionSet options, CoordinatorCli cli) {
         File file = getFile(cli.memberHzConfigFileSpec, options, "Hazelcast member configuration for Worker");
         LOGGER.info("Loading Hazelcast member configuration: " + file.getAbsolutePath());
+        return fileAsText(file);
+    }
+
+    private static String loadWorkerScript(OptionSet options, CoordinatorCli cli) {
+        File file = getFile(cli.workerScriptFileSpec, options, "Hazelcast worker.sh");
+        LOGGER.info("Loading Hazelcast worker script: " + file.getAbsolutePath());
         return fileAsText(file);
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/WorkerParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/WorkerParameters.java
@@ -44,11 +44,18 @@ public class WorkerParameters {
     private final boolean monitorPerformance;
     private final int workerPerformanceMonitorIntervalSeconds;
 
-    private final String javaCmd;
+    private final String workerScript;
 
-    public WorkerParameters(SimulatorProperties properties, boolean autoCreateHzInstance, int workerStartupTimeout,
-                            String memberJvmOptions, String clientJvmOptions, String memberHzConfig, String clientHzConfig,
-                            String log4jConfig, boolean monitorPerformance) {
+    public WorkerParameters(SimulatorProperties properties,
+                            boolean autoCreateHzInstance,
+                            int workerStartupTimeout,
+                            String memberJvmOptions,
+                            String clientJvmOptions,
+                            String memberHzConfig,
+                            String clientHzConfig,
+                            String log4jConfig,
+                            String workerScript,
+                            boolean monitorPerformance) {
         this.autoCreateHzInstance = autoCreateHzInstance;
         this.workerStartupTimeout = workerStartupTimeout;
 
@@ -63,8 +70,7 @@ public class WorkerParameters {
 
         this.monitorPerformance = monitorPerformance;
         this.workerPerformanceMonitorIntervalSeconds = initWorkerPerformanceMonitorIntervalSeconds(properties);
-
-        this.javaCmd = properties.get("JAVA_CMD", "java");
+        this.workerScript = workerScript;
     }
 
     private int initWorkerPerformanceMonitorIntervalSeconds(SimulatorProperties properties) {
@@ -122,8 +128,8 @@ public class WorkerParameters {
         return min(workerPerformanceMonitorIntervalSeconds, runPhaseLogIntervalSeconds);
     }
 
-    public String getJavaCmd() {
-        return javaCmd;
+    public String getWorkerScript() {
+        return workerScript;
     }
 
     public static String initMemberHzConfig(String memberHzConfig, ComponentRegistry componentRegistry, int port,

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerType.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/WorkerType.java
@@ -20,21 +20,14 @@ package com.hazelcast.simulator.worker;
  */
 public enum WorkerType {
 
-    INTEGRATION_TEST(IntegrationTestWorker.class.getName(), false),
+    INTEGRATION_TEST(false),
+    MEMBER(true),
+    CLIENT(false);
 
-    MEMBER(MemberWorker.class.getName(), true),
-    CLIENT(ClientWorker.class.getName(), false);
-
-    private final String className;
     private final boolean isMember;
 
-    WorkerType(String className, boolean isMember) {
-        this.className = className;
+    WorkerType(boolean isMember) {
         this.isMember = isMember;
-    }
-
-    public String getClassName() {
-        return className;
     }
 
     public boolean isMember() {

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -218,6 +218,7 @@ public class AgentSmokeTest implements FailureListener {
                 fileAsText("simulator/src/test/resources/hazelcast.xml"),
                 "",
                 fileAsText("dist/src/main/dist/conf/worker-log4j.xml"),
+                "worker.sh",
                 false
         );
         ClusterLayout clusterLayout = createSingleInstanceClusterLayout(AGENT_IP_ADDRESS, workerParameters);

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/WorkerParametersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/WorkerParametersTest.java
@@ -47,7 +47,7 @@ public class WorkerParametersTest {
     @Test
     public void testConstructor() {
         WorkerParameters workerParameters = new WorkerParameters(properties, true, 2342, "memberJvmOptions", "clientJvmOptions",
-                memberConfig, clientConfig, "log4jConfig", false);
+                memberConfig, clientConfig, "log4jConfig", "worker.sh",false);
 
         assertTrue(workerParameters.isAutoCreateHzInstance());
         assertEquals(2342, workerParameters.getWorkerStartupTimeout());
@@ -62,12 +62,12 @@ public class WorkerParametersTest {
         assertEquals("log4jConfig", workerParameters.getLog4jConfig());
         assertFalse(workerParameters.isMonitorPerformance());
 
-        assertEquals("java", workerParameters.getJavaCmd());
+        assertEquals("java", workerParameters.getWorkerScript());
     }
 
     @Test
     public void testGetRunPhaseLogIntervalSeconds_noPerformanceMonitor() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, false);
+        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, "worker.sh",false);
 
         int intervalSeconds = workerParameters.getRunPhaseLogIntervalSeconds(5);
         assertEquals(5, intervalSeconds);
@@ -75,7 +75,7 @@ public class WorkerParametersTest {
 
     @Test
     public void testGetRunPhaseLogIntervalSeconds_withPerformanceMonitor_overPerformanceMonitorInterval() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, true);
+        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, "worker.sh",true);
 
         int intervalSeconds = workerParameters.getRunPhaseLogIntervalSeconds(5000);
         assertEquals(1234, intervalSeconds);
@@ -83,7 +83,7 @@ public class WorkerParametersTest {
 
     @Test
     public void testGetRunPhaseLogIntervalSeconds_withPerformanceMonitor_belowPerformanceMonitorInterval() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, true);
+        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, "worker.sh",true);
 
         int intervalSeconds = workerParameters.getRunPhaseLogIntervalSeconds(30);
         assertEquals(30, intervalSeconds);

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/operation/OperationCodecTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/operation/OperationCodecTest.java
@@ -67,6 +67,7 @@ public class OperationCodecTest {
                         + "  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" />",
                 "",
                 "",
+                "",
                 false
         );
 
@@ -85,6 +86,6 @@ public class OperationCodecTest {
         assertEquals(workerJvmSettings.getJvmOptions(), decodedSettings.getJvmOptions());
         assertEquals(workerJvmSettings.isAutoCreateHzInstance(), decodedSettings.isAutoCreateHzInstance());
         assertEquals(workerJvmSettings.getWorkerStartupTimeout(), decodedSettings.getWorkerStartupTimeout());
-        assertEquals(workerJvmSettings.getJavaCmd(), decodedSettings.getJavaCmd());
+        assertEquals(workerJvmSettings.getWorkerScript(), decodedSettings.getWorkerScript());
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessorTest.java
@@ -182,7 +182,7 @@ public class AgentOperationProcessorTest {
         when(workerJvmSettings.getWorkerIndex()).thenReturn(1);
         when(workerJvmSettings.getHazelcastConfig()).thenReturn("");
         when(workerJvmSettings.getLog4jConfig()).thenReturn(fileAsText("dist/src/main/dist/conf/worker-log4j.xml"));
-        when(workerJvmSettings.getJavaCmd()).thenReturn(withStartupException ? null : "java");
+        when(workerJvmSettings.getWorkerScript()).thenReturn(withStartupException ? null : "java");
         when(workerJvmSettings.getHazelcastVersionSpec()).thenReturn(HazelcastJARs.BRING_MY_OWN);
         when(workerJvmSettings.getWorkerStartupTimeout()).thenReturn(startupTimeout);
         when(workerJvmSettings.getJvmOptions()).thenReturn("-verbose:gc");


### PR DESCRIPTION
The worker script that gets generated, is now pulled out as template. This gives one full control on e.g. the java command to execute, profilers, and all kinds of other things like checking e.g. the power governor.

Just copy the SIMULATOR_HOME/conf/worker.sh to the working directory and start modification.