### PR TITLE
Introduced AbstractTest to reduce duplication

### DIFF
--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/AbstractTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/AbstractTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.tests;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+/**
+ * An Abstract Test that provides basic behavior so it doesn't need to be repeated for every test.
+ * <p>
+ * Coordinator will not impose the AbstractTest to be the part of any test class.
+ */
+public abstract class AbstractTest {
+
+    protected final ILogger logger = Logger.getLogger(getClass());
+
+}

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/ExampleTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/ExampleTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -32,14 +30,12 @@ import com.hazelcast.simulator.worker.tasks.AbstractWorkerWithMultipleProbes;
 
 import static org.junit.Assert.assertEquals;
 
-public class ExampleTest {
+public class ExampleTest extends AbstractTest {
 
     private enum Operation {
         PUT,
         GET
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(ExampleTest.class);
 
     // properties
     public int maxKeys = 1000;
@@ -51,11 +47,11 @@ public class ExampleTest {
 
     @Setup
     public void setUp(TestContext testContext) {
-        LOGGER.info("======== SETUP =========");
+        logger.info("======== SETUP =========");
         HazelcastInstance targetInstance = testContext.getTargetInstance();
         map = targetInstance.getMap("exampleMap");
 
-        LOGGER.info("Map name is: " + map.getName());
+        logger.info("Map name is: " + map.getName());
 
         operationSelectorBuilder
                 .addOperation(Operation.PUT, putProb)
@@ -64,21 +60,21 @@ public class ExampleTest {
 
     @Teardown
     public void tearDown() {
-        LOGGER.info("======== TEAR DOWN =========");
+        logger.info("======== TEAR DOWN =========");
         map.destroy();
-        LOGGER.info("======== THE END =========");
+        logger.info("======== THE END =========");
     }
 
     @Warmup
     public void warmup() {
-        LOGGER.info("======== WARMUP =========");
-        LOGGER.info("Map size is: " + map.size());
+        logger.info("======== WARMUP =========");
+        logger.info("Map size is: " + map.size());
     }
 
     @Verify
     public void verify() {
-        LOGGER.info("======== VERIFYING =========");
-        LOGGER.info("Map size is: " + map.size());
+        logger.info("======== VERIFYING =========");
+        logger.info("Map size is: " + map.size());
 
         for (int i = 0; i < maxKeys; i++) {
             String actualValue = map.get(i);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/GenericOperationTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/GenericOperationTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -45,9 +43,7 @@ import java.util.concurrent.locks.LockSupport;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperationService;
 
-public class GenericOperationTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(GenericOperationTest.class);
+public class GenericOperationTest extends AbstractTest {
 
     private enum PrioritySelector {
         PRIORITY,
@@ -89,7 +85,7 @@ public class GenericOperationTest {
 
     @Teardown
     public void tearDown() {
-        LOGGER.info(getOperationCountInformation(instance));
+        logger.info(getOperationCountInformation(instance));
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
@@ -20,14 +20,13 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.worker.metronome.Metronome;
@@ -49,9 +48,7 @@ import static com.hazelcast.simulator.utils.TestUtils.assertTrueEventually;
 import static com.hazelcast.simulator.worker.metronome.MetronomeFactory.withFixedIntervalMs;
 import static org.junit.Assert.assertEquals;
 
-public class AsyncAtomicLongTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(AsyncAtomicLongTest.class);
+public class AsyncAtomicLongTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -101,7 +98,7 @@ public class AsyncAtomicLongTest {
             }
         }
         totalCounter.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Verify

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
@@ -18,8 +18,6 @@ package com.hazelcast.simulator.tests.concurrent.atomiclong;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
@@ -27,6 +25,7 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
@@ -38,9 +37,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getPartit
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static org.junit.Assert.assertEquals;
 
-public class AtomicLongTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(AtomicLongTest.class);
+public class AtomicLongTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -85,9 +82,9 @@ public class AtomicLongTest {
         }
         totalCounter.destroy();
 
-        LOGGER.info("Operations: " + operationsCounter);
-        LOGGER.info(getOperationCountInformation(targetInstance));
-        LOGGER.info(getPartitionDistributionInformation(targetInstance));
+        logger.info("Operations: " + operationsCounter);
+        logger.info(getOperationCountInformation(targetInstance));
+        logger.info(getPartitionDistributionInformation(targetInstance));
     }
 
     @Warmup

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomicreference/AtomicReferenceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomicreference/AtomicReferenceTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.concurrent.atomicreference;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicReference;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
@@ -35,9 +34,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateByteArray;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateString;
 
-public class AtomicReferenceTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(AtomicReferenceTest.class);
+public class AtomicReferenceTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -95,7 +92,7 @@ public class AtomicReferenceTest {
         for (IAtomicReference counter : counters) {
             counter.destroy();
         }
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LeaseLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LeaseLockTest.java
@@ -17,12 +17,11 @@ package com.hazelcast.simulator.tests.concurrent.lock;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
 import java.util.concurrent.TimeUnit;
@@ -31,9 +30,7 @@ import static com.hazelcast.simulator.utils.CommonUtils.sleepMillis;
 import static java.lang.String.format;
 import static org.junit.Assert.fail;
 
-public class LeaseLockTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(LeaseLockTest.class);
+public class LeaseLockTest extends AbstractTest {
 
     public String basename = LeaseLockTest.class.getSimpleName();
     public int lockCount = 500;
@@ -58,7 +55,7 @@ public class LeaseLockTest {
             if (isLocked) {
                 String message = format("%s is locked with remainingLeaseTime: %d ms", lock, remainingLeaseTime);
                 if (allowZeroMillisRemainingLeaseLockTime && remainingLeaseTime == 0) {
-                    LOGGER.warning(message);
+                    logger.warning(message);
                 } else {
                     fail(message);
                 }
@@ -89,7 +86,7 @@ public class LeaseLockTest {
                 try {
                     lock.tryLock(tryTime, TimeUnit.MILLISECONDS, leaseTime, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
-                    LOGGER.info("tryLock() got exception: " + e.getMessage());
+                    logger.info("tryLock() got exception: " + e.getMessage());
                 }
             }
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockConflictTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockConflictTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.concurrent.lock;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ILock;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyIncrementPair;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
@@ -38,9 +37,7 @@ import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static org.junit.Assert.assertEquals;
 
 // TODO: We need to deal with exception logging; they are logged but not visible to Simulator
-public class LockConflictTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(LockConflictTest.class);
+public class LockConflictTest extends AbstractTest {
 
     // properties
     public String basename = LockConflictTest.class.getSimpleName();
@@ -77,7 +74,7 @@ public class LockConflictTest {
         for (LockCounter counter : globalCounter) {
             total.add(counter);
         }
-        LOGGER.info(basename + ": " + total + " from " + globalCounter.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + globalCounter.size() + " worker threads");
 
         long[] expected = new long[keyCount];
         for (long[] increments : globalIncrements) {
@@ -90,7 +87,7 @@ public class LockConflictTest {
         for (int key = 0; key < keyCount; key++) {
             if (expected[key] != list.get(key)) {
                 failures++;
-                LOGGER.info(basename + ": key=" + key + " expected " + expected[key] + " != " + "actual " + list.get(key));
+                logger.info(basename + ": key=" + key + " expected " + expected[key] + " != " + "actual " + list.get(key));
             }
         }
         assertEquals(basename + ": " + failures + " key=>values have been incremented unexpected", 0, failures);
@@ -133,13 +130,13 @@ public class LockConflictTest {
                             localCounter.locked++;
                         }
                     } catch (Exception e) {
-                        LOGGER.severe(basename + ": trying lock=" + keyIncrementPair.key, e);
+                        logger.severe(basename + ": trying lock=" + keyIncrementPair.key, e);
                         if (throwException) {
                             throw rethrow(e);
                         }
                     }
                 } catch (Exception e) {
-                    LOGGER.severe(basename + ": getting lock for locking=" + keyIncrementPair.key, e);
+                    logger.severe(basename + ": getting lock for locking=" + keyIncrementPair.key, e);
                     if (throwException) {
                         throw rethrow(e);
                     }
@@ -157,7 +154,7 @@ public class LockConflictTest {
                     localIncrements[keyIncrementPair.key] += keyIncrementPair.increment;
                     localCounter.increased++;
                 } catch (Exception e) {
-                    LOGGER.severe(basename + ": updating account=" + keyIncrementPair, e);
+                    logger.severe(basename + ": updating account=" + keyIncrementPair, e);
                     if (throwException) {
                         throw rethrow(e);
                     }
@@ -178,13 +175,13 @@ public class LockConflictTest {
                             localCounter.unlocked++;
                             iterator.remove();
                         } catch (Exception e) {
-                            LOGGER.severe(basename + ": unlocking lock =" + keyIncrementPair.key, e);
+                            logger.severe(basename + ": unlocking lock =" + keyIncrementPair.key, e);
                             if (throwException) {
                                 throw rethrow(e);
                             }
                         }
                     } catch (Exception e) {
-                        LOGGER.severe(basename + ": getting lock for unlocking=" + keyIncrementPair.key, e);
+                        logger.severe(basename + ": getting lock for unlocking=" + keyIncrementPair.key, e);
                         if (throwException) {
                             throw rethrow(e);
                         }
@@ -193,7 +190,7 @@ public class LockConflictTest {
                 sleepSeconds(1);
 
                 if (++unlockAttempts > 5) {
-                    LOGGER.info(basename + ": Cant unlock=" + locked + " unlockAttempts=" + unlockAttempts);
+                    logger.info(basename + ": Cant unlock=" + locked + " unlockAttempts=" + unlockAttempts);
                     break;
                 }
             }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/SimpleLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/SimpleLockTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.concurrent.lock;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ILock;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.util.Random;
@@ -34,11 +33,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class SimpleLockTest {
+public class SimpleLockTest extends AbstractTest {
 
     private static final int INITIAL_VALUE = 1000;
-
-    private static final ILogger LOGGER = Logger.getLogger(SimpleLockTest.class);
 
     public String basename = SimpleLockTest.class.getSimpleName();
     public int maxAccounts = 7;
@@ -110,7 +107,7 @@ public class SimpleLockTest {
             ILock lock = targetInstance.getLock(basename + i);
             IAtomicLong account = targetInstance.getAtomicLong(basename + i);
 
-            LOGGER.info(format("%s %d", account, account.get()));
+            logger.info(format("%s %d", account, account.get()));
 
             assertFalse(basename + ": Lock should be unlocked", lock.isLocked());
             assertTrue(basename + ": Amount is < 0 ", account.get() >= 0);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/TryLockTimeOutTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/TryLockTimeOutTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.concurrent.lock;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ILock;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.io.Serializable;
@@ -39,9 +38,7 @@ import static org.junit.Assert.assertFalse;
  * We are using tryLock() with a configurable time out: tryLockTimeOutMs.
  * We verify that the total value of accounts is the same at the end of the test.
  */
-public class TryLockTimeOutTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(TryLockTimeOutTest.class);
+public class TryLockTimeOutTest extends AbstractTest {
 
     public String basename = TryLockTimeOutTest.class.getSimpleName();
     public int threadCount = 3;
@@ -66,7 +63,7 @@ public class TryLockTimeOutTest {
             accounts.add(initialAccountValue);
         }
         totalInitialValue = initialAccountValue * maxAccounts;
-        LOGGER.info("totalInitialValue=" + totalInitialValue);
+        logger.info("totalInitialValue=" + totalInitialValue);
     }
 
     @Verify(global = true)
@@ -82,7 +79,7 @@ public class TryLockTimeOutTest {
         for (long value : accounts) {
             totalValue += value;
         }
-        LOGGER.info(": totalValue=" + totalValue);
+        logger.info(": totalValue=" + totalValue);
         assertEquals(basename + ": totalInitialValue != totalValue ", totalInitialValue, totalValue);
 
         Counter total = new Counter();
@@ -90,7 +87,7 @@ public class TryLockTimeOutTest {
         for (Counter count : totals) {
             total.add(count);
         }
-        LOGGER.info("total count " + total);
+        logger.info("total count " + total);
     }
 
     @Run
@@ -123,7 +120,7 @@ public class TryLockTimeOutTest {
                         }
                     }
                 } catch (InterruptedException e) {
-                    LOGGER.severe("outerLock " + e.getMessage(), e);
+                    logger.severe("outerLock " + e.getMessage(), e);
                     counter.interruptedException++;
                 }
             }
@@ -148,7 +145,7 @@ public class TryLockTimeOutTest {
                     }
                 }
             } catch (InterruptedException e) {
-                LOGGER.severe("innerLock " + e.getMessage(), e);
+                logger.severe("innerLock " + e.getMessage(), e);
                 counter.interruptedException++;
             }
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/executor/ExecutorTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/executor/ExecutorTest.java
@@ -19,14 +19,13 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IExecutorService;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.io.Serializable;
@@ -40,9 +39,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.rethrow;
 import static com.hazelcast.simulator.utils.TestUtils.getUserContextKeyFromTestId;
 import static org.junit.Assert.assertEquals;
 
-public class ExecutorTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ExecutorTest.class);
+public class ExecutorTest extends AbstractTest {
 
     // properties
     public String basename = ExecutorTest.class.getSimpleName();
@@ -78,7 +75,7 @@ public class ExecutorTest {
         for (IExecutorService executor : executors) {
             executor.shutdownNow();
             if (!executor.awaitTermination(120, TimeUnit.SECONDS)) {
-                LOGGER.severe("Time out while waiting for shutdown of executor: " + executor.getName());
+                logger.severe("Time out while waiting for shutdown of executor: " + executor.getName());
             }
             executor.destroy();
         }
@@ -128,7 +125,7 @@ public class ExecutorTest {
                 }
 
                 if (iteration % 10000 == 0) {
-                    LOGGER.info(Thread.currentThread().getName() + " At iteration: " + iteration);
+                    logger.info(Thread.currentThread().getName() + " At iteration: " + iteration);
                 }
             }
             expectedExecutedCounter.addAndGet(iteration);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientResponseTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientResponseTest.java
@@ -17,18 +17,15 @@ package com.hazelcast.simulator.tests.external;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.tests.AbstractTest;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 
-public class ExternalClientResponseTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ExternalClientResponseTest.class);
+public class ExternalClientResponseTest extends AbstractTest {
 
     // properties
     public String basename = "externalClientsFinished";
@@ -51,6 +48,6 @@ public class ExternalClientResponseTest {
 
         sleepSeconds(delaySeconds);
         clientsFinished.countDown();
-        LOGGER.info("Client response sent!");
+        logger.info("Client response sent!");
     }
 }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientStarterTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientStarterTest.java
@@ -16,12 +16,11 @@
 package com.hazelcast.simulator.tests.external;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.common.SimulatorProperties;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.Bash;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isClient;
@@ -30,9 +29,7 @@ import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
 import static com.hazelcast.simulator.utils.UuidUtil.newSecureUuidString;
 import static java.lang.String.format;
 
-public class ExternalClientStarterTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ExternalClientStarterTest.class);
+public class ExternalClientStarterTest extends AbstractTest {
 
     // properties
     public String binaryName = "binaryName";
@@ -72,7 +69,7 @@ public class ExternalClientStarterTest {
 
             String tmpLogFileName = logFileName + '_' + i;
 
-            LOGGER.info(format("Starting external client: %s %s &>> %s.log", binaryName, tmpArguments, tmpLogFileName));
+            logger.info(format("Starting external client: %s %s &>> %s.log", binaryName, tmpArguments, tmpLogFileName));
             bash.execute(format("../upload/%s %s &>> %s.log &", binaryName, tmpArguments, tmpLogFileName));
         }
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.external;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.ExecutionException;
@@ -35,9 +34,7 @@ import static com.hazelcast.simulator.tests.external.ExternalClientUtils.setCoun
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static java.lang.String.format;
 
-public class ExternalClientTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ExternalClientTest.class);
+public class ExternalClientTest extends AbstractTest {
 
     // properties
     public String basename = "externalClientsRunning";
@@ -67,9 +64,9 @@ public class ExternalClientTest {
         // determine one instance per cluster
         if (hazelcastInstance.getMap(basename).putIfAbsent(basename, true) == null) {
             isExternalResultsCollectorInstance = true;
-            LOGGER.info("This instance will collect all probe results from external clients");
+            logger.info("This instance will collect all probe results from external clients");
         } else {
-            LOGGER.info("This instance will not collect probe results");
+            logger.info("This instance will not collect probe results");
         }
     }
 
@@ -89,23 +86,23 @@ public class ExternalClientTest {
             long clientsRunningCount = clientsRunning.getCount();
             if (clientsRunningCount > 0) {
                 long responseReceivedCount = waitForClientsCount - clientsRunningCount;
-                LOGGER.info(format("Got response from %d/%d clients, waiting...", responseReceivedCount, waitForClientsCount));
+                logger.info(format("Got response from %d/%d clients, waiting...", responseReceivedCount, waitForClientsCount));
             } else {
-                LOGGER.info(format("Got response from all %d clients, stopping now!", waitForClientsCount));
+                logger.info(format("Got response from all %d clients, stopping now!", waitForClientsCount));
                 break;
             }
         }
 
         // just a single instance will collect the results from all external clients
         if (!isExternalResultsCollectorInstance) {
-            LOGGER.info("Stopping non result collecting ExternalClientTest");
+            logger.info("Stopping non result collecting ExternalClientTest");
             return;
         }
 
         // get probe results
-        LOGGER.info("Collecting results from external clients...");
+        logger.info("Collecting results from external clients...");
         getThroughputResults(hazelcastInstance, expectedResultSize);
         getLatencyResults(hazelcastInstance, externalClientProbe, expectedResultSize);
-        LOGGER.info("Result collecting ExternalClientTest done!");
+        logger.info("Result collecting ExternalClientTest done!");
     }
 }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/helpers/KeyLocality.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/helpers/KeyLocality.java
@@ -29,37 +29,37 @@ public enum KeyLocality {
 
     /**
      * Generates random generated local keys (keys that point to locally owned partitions).
-     *
+     * <p>
      * The keys will be perfectly balanced over the partitions.
      */
     LOCAL,
 
     /**
      * Generates random generated remote keys.
-     *
+     * <p>
      * Each worker will generate it own random set of keys, so it is very unlikely they are going to be shared.
-     *
+     * <p>
      * The keys will be perfectly balanced over remote partitions.
      */
     REMOTE,
 
     /**
      * Generates random generated keys.
-     *
+     * <p>
      * Each worker will generate it own random set of keys, so it is very unlikely they are going to be shared. Also becase
      * each worker generates its own keys, the total size of key domain is 'load-generating-worker * keycount'.
-     *
+     * <p>
      * If you want to pound the same keys by all members, use {@link #SHARED}.
-     *
+     * <p>
      * The keys will be perfectly balanced over the partitions.
      */
     RANDOM,
 
     /**
      * Generates random generated keys (same sequence on all Workers).
-     *
+     * <p>
      * In doubt, this is the keyLocality you want to use. All keys will be shared by all members.
-     *
+     * <p>
      * Since all keys are shared, the total size of the key domain is equal to the keyCount configured on the member.
      */
     SHARED,

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/helpers/KeyUtils.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/helpers/KeyUtils.java
@@ -89,7 +89,7 @@ public final class KeyUtils {
 
     /**
      * Generates an array of int keys with a configurable keyLocality.
-     *
+     * <p>
      * If the instance is a client, keyLocality is ignored.
      *
      * @param keyCount    the number of keys in the array
@@ -109,7 +109,7 @@ public final class KeyUtils {
 
     /**
      * Generates an array of int keys with a configurable keyLocality.
-     *
+     * <p>
      * If the instance is a client, keyLocality is ignored.
      *
      * @param keyCount    the number of keys in the array
@@ -142,7 +142,7 @@ public final class KeyUtils {
 
     /**
      * Generates an array of string keys with a configurable keyLocality.
-     *
+     * <p>
      * If the instance is a client, keyLocality is ignored.
      *
      * @param keyCount    the number of keys in the array
@@ -157,7 +157,7 @@ public final class KeyUtils {
 
     /**
      * Generates an array of string keys with a configurable keyLocality.
-     *
+     * <p>
      * If the hz is a client, keyLocality is ignored.
      *
      * @param prefix      prefix for the generated keys
@@ -173,7 +173,7 @@ public final class KeyUtils {
 
     /**
      * Generates an array of string keys with a configurable keyLocality.
-     *
+     * <p>
      * If the hz is a client, keyLocality is ignored.
      *
      * @param prefix      prefix for the generated keys

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/helpers/TxnCounter.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/helpers/TxnCounter.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 
 public class TxnCounter implements Serializable {
 
-    public long committed ;
+    public long committed;
     public long rolled;
     public long failedRollbacks;
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
@@ -17,14 +17,13 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryEventFilter;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryListener;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheListenerOperationCounter;
@@ -40,12 +39,12 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
 
 /**
  * In this test we concurrently add remove cache listeners while putting and getting from the cache.
- *
+ * <p>
  * This test is out side of normal usage, however has found problems where put operations hang.
  * This type of test could uncover memory leaks in the process of adding and removing listeners.
  * The max size of the cache used in this test is keyCount int key/value pairs.
  */
-public class AddRemoveListenerICacheTest {
+public class AddRemoveListenerICacheTest extends AbstractTest {
 
     private enum Operation {
         REGISTER,
@@ -53,8 +52,6 @@ public class AddRemoveListenerICacheTest {
         PUT,
         GET
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(AddRemoveListenerICacheTest.class);
 
     public String basename = AddRemoveListenerICacheTest.class.getSimpleName();
     public int keyCount = 1000;
@@ -104,7 +101,7 @@ public class AddRemoveListenerICacheTest {
         for (ICacheListenerOperationCounter i : results) {
             total.add(i);
         }
-        LOGGER.info(basename + ": " + total + " from " + results.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + results.size() + " worker threads");
     }
 
     @RunWithWorker
@@ -150,7 +147,7 @@ public class AddRemoveListenerICacheTest {
 
         @Override
         public void afterRun() {
-            LOGGER.info(basename + ": " + operationCounter);
+            logger.info(basename + ": " + operationCounter);
             results.add(operationCounter);
         }
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
@@ -37,10 +37,10 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
 
 /**
  * Demonstrates the effect of batching.
- *
+ * <p>
  * It uses async methods to invoke operation and wait for future to complete every {@code batchSize} invocations.
  * Hence setting {@link #batchSize} to 1 is effectively the same as using sync operations.
- *
+ * <p>
  * Setting {@link #batchSize} to values greater than 1 causes the batch-effect to kick-in, pipe-lines are utilized better
  * and overall throughput goes up.
  */

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CacheLoaderTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CacheLoaderTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.icache.helpers.RecordingCacheLoader;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
@@ -41,17 +40,15 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * This tests concurrent load all calls to {@link javax.cache.integration.CacheLoader}.
- *
+ * <p>
  * We can configure a delay in {@link javax.cache.integration.CacheLoader#loadAll(Iterable)} or to wait for completion.
- *
+ * <p>
  * A large delay and high concurrent calls to {@link javax.cache.integration.CacheLoader#loadAll(Iterable)} could overflow some
  * internal queues. The same can happen if {@link #waitForLoadAllFutureCompletion} is false.
- *
+ * <p>
  * We verify that the cache contains all keys and that the keys have been loaded through a the cache instance.
  */
-public class CacheLoaderTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(CacheLoaderTest.class);
+public class CacheLoaderTest extends AbstractTest {
 
     public String basename = CacheLoaderTest.class.getSimpleName();
     public int keyCount = 10;
@@ -91,7 +88,7 @@ public class CacheLoaderTest {
     @Verify(global = false)
     public void verify() {
         RecordingCacheLoader<Integer> loader = (RecordingCacheLoader<Integer>) config.getCacheLoaderFactory().create();
-        LOGGER.info(basename + ": " + loader);
+        logger.info(basename + ": " + loader);
     }
 
     @Verify(global = true)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
@@ -36,10 +36,10 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the cas method {@link Cache#replace(Object, Object, Object)} for optimistic concurrency control.
- *
+ * <p>
  * With a collection of predefined keys we concurrently increment the value.
  * We protect ourselves against lost updates using the cas method {@link Cache#replace(Object, Object, Object)}.
- *
+ * <p>
  * Locally we keep track of all increments. We verify if the sum of these local increments matches the global increment.
  */
 public class CasICacheTest {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ConcurrentCreateICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ConcurrentCreateICacheTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.simulator.tests.icache;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
@@ -37,9 +36,7 @@ import static org.junit.Assert.assertEquals;
  * in the setup phase of this test. We count the number of {@link CacheException} thrown when creating the cache
  * from multi members and clients, and at verification we assert that no exceptions where thrown.
  */
-public class ConcurrentCreateICacheTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ConcurrentCreateICacheTest.class);
+public class ConcurrentCreateICacheTest extends AbstractTest {
 
     // properties
     public String baseName = ConcurrentCreateICacheTest.class.getSimpleName();
@@ -60,19 +57,19 @@ public class ConcurrentCreateICacheTest {
             cacheManager.createCache(baseName, config);
             counter.create++;
         } catch (CacheException e) {
-            LOGGER.severe(baseName + ": createCache exception " + e, e);
+            logger.severe(baseName + ": createCache exception " + e, e);
             counter.createException++;
         }
         counterList.add(counter);
     }
 
-    @Verify(global = true)
-    public void verify() {
+    @Verify
+    public void globalVerify() {
         Counter total = new Counter();
         for (Counter counter : counterList) {
             total.add(counter);
         }
-        LOGGER.info(baseName + ": " + total + " from " + counterList.size() + " worker threads");
+        logger.info(baseName + ": " + total + " from " + counterList.size() + " worker threads");
 
         assertEquals(baseName + ": We expect 0 CacheException from multi node create cache calls", 0, total.createException);
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java
@@ -17,12 +17,11 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheCreateDestroyCounter;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
@@ -36,9 +35,7 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
  * In this test we are concurrently creating, deleting, destroying and putting to a cache.
  * However this test is a sub set of {@link MangleICacheTest}, so could be deleted.
  */
-public class CreateDestroyICacheTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(CreateDestroyICacheTest.class);
+public class CreateDestroyICacheTest extends AbstractTest {
 
     private enum Operation {
         CREATE_CACHE,
@@ -78,7 +75,7 @@ public class CreateDestroyICacheTest {
         for (ICacheCreateDestroyCounter counter : counters) {
             total.add(counter);
         }
-        LOGGER.info(basename + ": " + total + " from " + counters.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + counters.size() + " worker threads");
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/EvictionICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/EvictionICacheTest.java
@@ -19,12 +19,11 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -48,15 +47,13 @@ import static org.junit.Assert.fail;
  * of the cache size. The test also logs the global max size of the ICache observed from all test
  * participants, providing no assertion errors were throw.
  */
-public class EvictionICacheTest {
+public class EvictionICacheTest extends AbstractTest {
 
     enum Operation {
         PUT,
         PUT_ASYNC,
         PUT_ALL,
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(EvictionICacheTest.class);
 
     public String basename = EvictionICacheTest.class.getSimpleName();
     public int threadCount = 3;
@@ -95,7 +92,7 @@ public class EvictionICacheTest {
         cache = (ICache<Object, Object>) cacheManager.getCache(basename);
 
         CacheConfig config = cache.getConfiguration(CacheConfig.class);
-        LOGGER.info(basename + ": " + cache.getName() + " config=" + config);
+        logger.info(basename + ": " + cache.getName() + " config=" + config);
 
         configuredMaxSize = config.getEvictionConfig().getSize();
 
@@ -175,7 +172,7 @@ public class EvictionICacheTest {
                 observedMaxSize = m;
             }
         }
-        LOGGER.info(basename + ": cache " + cache.getName() + " size=" + cache.size() + " configuredMaxSize=" + configuredMaxSize
+        logger.info(basename + ": cache " + cache.getName() + " size=" + cache.size() + " configuredMaxSize=" + configuredMaxSize
                 + " observedMaxSize=" + observedMaxSize + " estimatedMaxSize=" + estimatedMaxSize);
 
         IList<Counter> counters = hazelcastInstance.getList(basename + "counter");
@@ -183,8 +180,8 @@ public class EvictionICacheTest {
         for (Counter c : counters) {
             total.add(c);
         }
-        LOGGER.info(basename + ": " + total);
-        LOGGER.info(basename + ": putAllMap size=" + putAllMap.size());
+        logger.info(basename + ": " + total);
+        logger.info(basename + ": putAllMap size=" + putAllMap.size());
     }
 
     private static class Counter implements Serializable {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
@@ -36,9 +35,7 @@ import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.TestUtils.assertTrueEventually;
 import static org.junit.Assert.assertEquals;
 
-public class ExpiryICacheTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ExpiryICacheTest.class);
+public class ExpiryICacheTest extends AbstractTest {
 
     // default keyCount entries of int, is upper bound to approx 8MB possible max, if all put inside expiryPolicy time
     public int keyCount = 1000000;
@@ -82,7 +79,7 @@ public class ExpiryICacheTest {
             @Override
             public void run() throws Exception {
                 int cacheSize = cache.size();
-                LOGGER.info(basename + " ICache size: " + cacheSize);
+                logger.info(basename + " ICache size: " + cacheSize);
                 assertEquals(basename + " ICache should be empty, but TTL events are not processed", 0, cacheSize);
             }
         });

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.simulator.tests.icache;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
 
@@ -44,7 +43,7 @@ import static org.junit.Assert.assertFalse;
  * The expiryDuration can be configured.
  * We verify that the cache is empty and items have expired.
  */
-public class ExpiryTest {
+public class ExpiryTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -52,8 +51,6 @@ public class ExpiryTest {
         GET,
         GET_ASYNC
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(ExpiryTest.class);
 
     public String basename = ExpiryTest.class.getSimpleName();
     public int expiryDuration = 500;
@@ -89,7 +86,7 @@ public class ExpiryTest {
         for (Counter counter : results) {
             totalCounter.add(counter);
         }
-        LOGGER.info(basename + " " + totalCounter + " from " + results.size() + " worker Threads");
+        logger.info(basename + " " + totalCounter + " from " + results.size() + " worker Threads");
 
         for (int i = 0; i < keyCount; i++) {
             assertFalse(basename + " ICache should not contain key " + i, cache.containsKey(i));
@@ -143,7 +140,7 @@ public class ExpiryTest {
             results.add(counter);
 
             // sleep to give time for expiration
-            sleepDurationTwice(LOGGER, expiryPolicy.getExpiryForCreation());
+            sleepDurationTwice(logger, expiryPolicy.getExpiryForCreation());
         }
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.simulator.tests.icache;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.icache.helpers.CacheUtils;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryEventFilter;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryListener;
@@ -48,11 +47,9 @@ import static org.junit.Assert.assertEquals;
  * We compare those to the number of events we have generated using different cache operations.
  * We verify that no unexpected events have been received.
  */
-public class ListenerICacheTest {
+public class ListenerICacheTest extends AbstractTest {
 
     private static final int PAUSE_FOR_LAST_EVENTS_SECONDS = 10;
-
-    private static final ILogger LOGGER = Logger.getLogger(ListenerICacheTest.class);
 
     private enum Operation {
         PUT,
@@ -113,8 +110,8 @@ public class ListenerICacheTest {
 
     @Verify(global = false)
     public void localVerify() {
-        LOGGER.info(basename + " Listener " + listener);
-        LOGGER.info(basename + " Filter " + filter);
+        logger.info(basename + " Listener " + listener);
+        logger.info(basename + " Filter " + filter);
     }
 
     @Verify
@@ -123,13 +120,13 @@ public class ListenerICacheTest {
         for (Counter counter : results) {
             totalCounter.add(counter);
         }
-        LOGGER.info(basename + " " + totalCounter + " from " + results.size() + " Worker threads");
+        logger.info(basename + " " + totalCounter + " from " + results.size() + " Worker threads");
 
         ICacheEntryListener totalEvents = new ICacheEntryListener();
         for (ICacheEntryListener entryListener : listeners) {
             totalEvents.add(entryListener);
         }
-        LOGGER.info(basename + " totalEvents: " + totalEvents);
+        logger.info(basename + " totalEvents: " + totalEvents);
         assertEquals(basename + " unexpected events found", 0, totalEvents.getUnexpected());
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
@@ -17,12 +17,11 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.icache.helpers.CacheUtils;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheOperationCounter;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -35,11 +34,11 @@ import javax.cache.spi.CachingProvider;
 
 /**
  * In this tests we are intentionally creating, destroying, closing and using cache managers and their caches.
- *
+ * <p>
  * This type of cache usage is well outside normal usage, however we found several bugs with this test. It could highlight memory
  * leaks when repeatedly creating and destroying caches and/or managers, something that regular test would not find.
  */
-public class MangleICacheTest {
+public class MangleICacheTest extends AbstractTest {
 
     public enum Operation {
         CLOSE_CACHING_PROVIDER,
@@ -53,8 +52,6 @@ public class MangleICacheTest {
 
         PUT
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MangleICacheTest.class);
 
     public String basename = MangleICacheTest.class.getSimpleName();
     public int maxCaches = 100;
@@ -93,7 +90,7 @@ public class MangleICacheTest {
         for (ICacheOperationCounter counter : results) {
             total.add(counter);
         }
-        LOGGER.info(basename + ": " + total + " from " + results.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + results.size() + " worker threads");
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ReadWriteICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ReadWriteICacheTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.simulator.tests.icache;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheReadWriteCounter;
 import com.hazelcast.simulator.tests.icache.helpers.RecordingCacheLoader;
 import com.hazelcast.simulator.tests.icache.helpers.RecordingCacheWriter;
@@ -43,9 +42,7 @@ import static org.junit.Assert.assertNotNull;
  * A large delay and high concurrent calls to loadAll could overflow some internal queues.
  * We verify that the cache contains all keys and that the keys have been loaded through a loader instance.
  */
-public class ReadWriteICacheTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ReadWriteICacheTest.class);
+public class ReadWriteICacheTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -101,8 +98,8 @@ public class ReadWriteICacheTest {
         RecordingCacheLoader loader = (RecordingCacheLoader) config.getCacheLoaderFactory().create();
         RecordingCacheWriter writer = (RecordingCacheWriter) config.getCacheWriterFactory().create();
 
-        LOGGER.info(basename + ": " + loader);
-        LOGGER.info(basename + ": " + writer);
+        logger.info(basename + ": " + loader);
+        logger.info(basename + ": " + writer);
     }
 
     @Verify(global = true)
@@ -111,7 +108,7 @@ public class ReadWriteICacheTest {
         for (ICacheReadWriteCounter counter : counters) {
             total.add(counter);
         }
-        LOGGER.info(basename + ": " + total + " from " + counters.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + counters.size() + " worker threads");
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -25,6 +23,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -40,9 +39,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCacheManager;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateStrings;
 
-public class StringICacheTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(StringICacheTest.class);
+public class StringICacheTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -76,7 +73,7 @@ public class StringICacheTest {
         cache = cacheManager.getCache(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)
-                                .addDefaultOperation(Operation.GET);
+                .addDefaultOperation(Operation.GET);
     }
 
     @Teardown
@@ -86,7 +83,7 @@ public class StringICacheTest {
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, hazelcastInstance, minNumberOfMembers);
+        waitClusterSize(logger, hazelcastInstance, minNumberOfMembers);
 
         keys = generateStringKeys(keyCount, keyLength, keyLocality, hazelcastInstance);
         values = generateStrings(valueCount, valueLength);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/jmx/PartitionServiceMBeanTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/jmx/PartitionServiceMBeanTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.jmx;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -25,6 +23,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorkerWithMultipleProbes;
 
@@ -35,9 +34,7 @@ import java.lang.management.ManagementFactory;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClusterSize;
 
-public class PartitionServiceMBeanTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(PartitionServiceMBeanTest.class);
+public class PartitionServiceMBeanTest extends AbstractTest {
 
     private enum Operation {
         IS_LOCAL_MEMBER_SAFE,
@@ -67,12 +64,12 @@ public class PartitionServiceMBeanTest {
 
     @Teardown
     public void tearDown() {
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, targetInstance, minNumberOfMembers);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllEntrySetTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllEntrySetTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -40,9 +39,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * A test that verifies the IMap.entrySet() or IMap.entrySet(true-predicate) behavior.
  */
-public class AllEntrySetTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(AllEntrySetTest.class);
+public class AllEntrySetTest extends AbstractTest {
 
     // properties
     public String basename = AllEntrySetTest.class.getSimpleName();
@@ -67,7 +64,7 @@ public class AllEntrySetTest {
     @Teardown
     public void teardown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = true)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllKeySetTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllKeySetTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -39,9 +38,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * A test that verifies the IMap.keySet() or IMap.keySet(true-predicate) behavior.
  */
-public class AllKeySetTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(AllKeySetTest.class);
+public class AllKeySetTest extends AbstractTest {
 
     // properties
     public String basename = AllKeySetTest.class.getSimpleName();
@@ -66,7 +63,7 @@ public class AllKeySetTest {
     @Teardown
     public void teardown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = true)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllValuesTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllValuesTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -39,9 +38,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * A test that verifies the IMap.values() or IMap.values(true-predicate) behavior.
  */
-public class AllValuesTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(AllValuesTest.class);
+public class AllValuesTest extends AbstractTest {
 
     // properties
     public String basename = AllKeySetTest.class.getSimpleName();
@@ -66,7 +63,7 @@ public class AllValuesTest {
     @Teardown
     public void teardown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = true)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
@@ -35,6 +33,7 @@ import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -51,10 +50,7 @@ import static java.lang.Math.abs;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
-public class ExtractorMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ExtractorMapTest.class);
-    private static final ThrottlingLogger THROTTLING_LOGGER = ThrottlingLogger.newLogger(LOGGER, 5000);
+public class ExtractorMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -70,7 +66,7 @@ public class ExtractorMapTest {
     public boolean usePortable;
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
-
+    private final ThrottlingLogger throttlingLogger = ThrottlingLogger.newLogger(logger, 5000);
     private IMap<Integer, Object> map;
 
     @Setup
@@ -137,7 +133,7 @@ public class ExtractorMapTest {
                     } finally {
                         probe.done(started);
                     }
-                    THROTTLING_LOGGER.info(format("Query 'payloadFromExtractor[%d]= %d' returned %d results.", index, key,
+                    throttlingLogger.info(format("Query 'payloadFromExtractor[%d]= %d' returned %d results.", index, key,
                             result.size()));
                     for (Object resultSillySequence : result) {
                         assertValidSequence(key, resultSillySequence);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/GrowingMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/GrowingMapTest.java
@@ -18,8 +18,6 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IdGenerator;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.TestRunner;
@@ -27,6 +25,7 @@ import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.util.Random;
@@ -34,9 +33,7 @@ import java.util.Random;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class GrowingMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(GrowingMapTest.class);
+public class GrowingMapTest extends AbstractTest {
 
     // properties
     public String basename = GrowingMapTest.class.getSimpleName();
@@ -117,11 +114,11 @@ public class GrowingMapTest {
 
                 insertIteration++;
                 if (insertIteration % logFrequency == 0) {
-                    LOGGER.info(Thread.currentThread().getName() + " At insert iteration: " + insertIteration);
+                    logger.info(Thread.currentThread().getName() + " At insert iteration: " + insertIteration);
                 }
             }
 
-            LOGGER.info(Thread.currentThread().getName() + " Inserted " + insertIteration + " key/value pairs");
+            logger.info(Thread.currentThread().getName() + " Inserted " + insertIteration + " key/value pairs");
             return insertIteration;
         }
 
@@ -138,7 +135,7 @@ public class GrowingMapTest {
 
                 readIteration++;
                 if (readIteration % logFrequency == 0) {
-                    LOGGER.info(Thread.currentThread().getName() + " At read iteration: " + readIteration);
+                    logger.info(Thread.currentThread().getName() + " At read iteration: " + readIteration);
                 }
             }
         }
@@ -160,7 +157,7 @@ public class GrowingMapTest {
 
                 deleteIteration++;
                 if (deleteIteration % logFrequency == 0) {
-                    LOGGER.info(Thread.currentThread().getName() + " At delete iteration: " + deleteIteration);
+                    logger.info(Thread.currentThread().getName() + " At delete iteration: " + deleteIteration);
                 }
             }
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorkerWithMultipleProbes;
 
-import javax.ws.rs.GET;
 import java.util.Random;
 
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntKeys;

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -38,9 +37,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperat
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClusterSize;
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntKeys;
 
-public class IntIntMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(IntIntMapTest.class);
+public class IntIntMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -77,12 +74,12 @@ public class IntIntMapTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, targetInstance, minNumberOfMembers);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateIntKeys(keyCount, keyLocality, targetInstance);
         Streamer<Integer, Integer> streamer = StreamerFactory.getInstance(map);
         Random random = new Random();

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapAsyncOpsTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapAsyncOpsTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.MapOperationCounter;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
@@ -33,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 
-public class MapAsyncOpsTest {
+public class MapAsyncOpsTest extends AbstractTest {
 
     private enum Operation {
         PUT_ASYNC,
@@ -42,8 +41,6 @@ public class MapAsyncOpsTest {
         REMOVE_ASYNC,
         DESTROY
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MapAsyncOpsTest.class);
 
     // properties
     public String basename = MapAsyncOpsTest.class.getSimpleName();
@@ -69,10 +66,10 @@ public class MapAsyncOpsTest {
         results = targetInstance.getList(basename + "report");
 
         operationSelectorBuilder.addOperation(Operation.PUT_ASYNC, putAsyncProb)
-                                .addOperation(Operation.PUT_ASYNC_TTL, putAsyncTTLProb)
-                                .addOperation(Operation.GET_ASYNC, getAsyncProb)
-                                .addOperation(Operation.REMOVE_ASYNC, removeAsyncProb)
-                                .addOperation(Operation.DESTROY, destroyProb);
+                .addOperation(Operation.PUT_ASYNC_TTL, putAsyncTTLProb)
+                .addOperation(Operation.GET_ASYNC, getAsyncProb)
+                .addOperation(Operation.REMOVE_ASYNC, removeAsyncProb)
+                .addOperation(Operation.DESTROY, destroyProb);
     }
 
     @Verify(global = true)
@@ -81,14 +78,14 @@ public class MapAsyncOpsTest {
         for (MapOperationCounter mapOperationsCount : results) {
             totalMapOperationsCount.add(mapOperationsCount);
         }
-        LOGGER.info(basename + ": " + totalMapOperationsCount + " total of " + results.size());
+        logger.info(basename + ": " + totalMapOperationsCount + " total of " + results.size());
     }
 
     @Verify(global = false)
     public void verify() {
         sleepSeconds(maxTTLExpirySeconds * 2);
 
-        LOGGER.info(basename + ": map size  =" + map.size());
+        logger.info(basename + ": map size  =" + map.size());
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapCasTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapCasTest.java
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * This tests the cas method: replace. So for optimistic concurrency control.
- *
+ * <p>
  * We have a bunch of predefined keys, and we are going to concurrently increment the value and we protect ourselves against lost
  * updates using cas method replace.
- *
+ * <p>
  * Locally we keep track of all increments, and if the sum of these local increments matches the global increment, we are done.
  */
 public class MapCasTest {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapComplexPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapComplexPredicateTest.java
@@ -16,14 +16,13 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.ComplexDomainObject;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
@@ -38,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.logging.Level.INFO;
 
 @SuppressWarnings({"checkstyle:linelength", "checkstyle:trailingcomment"})
-public class MapComplexPredicateTest {
+public class MapComplexPredicateTest extends AbstractTest {
 
     public enum QUERY_TYPE {
 
@@ -290,9 +289,6 @@ public class MapComplexPredicateTest {
         }
     }
 
-    private static final ILogger LOGGER = Logger.getLogger(MapComplexPredicateTest.class);
-    private static final ThrottlingLogger THROTTLING_LOGGER = ThrottlingLogger.newLogger(LOGGER, 5000);
-
     public String basename = MapComplexPredicateTest.class.getSimpleName();
     public int mapSize = 1000000;
     public QUERY_TYPE query = QUERY_TYPE.QUERY1;
@@ -300,6 +296,7 @@ public class MapComplexPredicateTest {
 
     private Random random = new Random();
     private IMap<String, ComplexDomainObject> map;
+    private final ThrottlingLogger throttlingLogger = ThrottlingLogger.newLogger(logger, 5000);
 
     @Setup
     public void setUp(TestContext testContext) {
@@ -443,7 +440,7 @@ public class MapComplexPredicateTest {
             long durationNanos = System.nanoTime() - startTime;
             long durationMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
 
-            THROTTLING_LOGGER.log(INFO, "Query Evaluation Took " + durationMillis + "ms. Size of the result size: " + entries.size());
+            throttlingLogger.log(INFO, "Query Evaluation Took " + durationMillis + "ms. Size of the result size: " + entries.size());
         }
     }
 }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapDataIntegrityTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapDataIntegrityTest.java
@@ -22,12 +22,11 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.util.Random;
@@ -39,9 +38,7 @@ import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class MapDataIntegrityTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapDataIntegrityTest.class);
+public class MapDataIntegrityTest extends AbstractTest {
 
     // properties
     public String basename = MapDataIntegrityTest.class.getSimpleName();
@@ -84,7 +81,7 @@ public class MapDataIntegrityTest {
                     sleepSeconds(1);
                 }
             }
-            LOGGER.info(format("%s: %d partitions", basename, partitionSet.size()));
+            logger.info(format("%s: %d partitions", basename, partitionSet.size()));
 
             Member localMember = targetInstance.getCluster().getLocalMember();
             for (int i = 0; i < totalIntegrityKeys; i++) {
@@ -93,29 +90,29 @@ public class MapDataIntegrityTest {
                     integrityMap.put(i, value);
                 }
             }
-            LOGGER.info(format("%s: integrityMap=%s size=%d", basename, integrityMap.getName(), integrityMap.size()));
+            logger.info(format("%s: integrityMap=%s size=%d", basename, integrityMap.getName(), integrityMap.size()));
 
             Config config = targetInstance.getConfig();
             MapConfig mapConfig = config.getMapConfig(integrityMap.getName());
-            LOGGER.info(format("%s: %s", basename, mapConfig));
+            logger.info(format("%s: %s", basename, mapConfig));
         }
     }
 
     @Verify(global = false)
     public void verify() {
         if (isMemberNode(targetInstance)) {
-            LOGGER.info(format("%s: cluster size=%d", basename, targetInstance.getCluster().getMembers().size()));
+            logger.info(format("%s: cluster size=%d", basename, targetInstance.getCluster().getMembers().size()));
         }
 
-        LOGGER.info(format("%s: integrityMap=%s size=%d", basename, integrityMap.getName(), integrityMap.size()));
+        logger.info(format("%s: integrityMap=%s size=%d", basename, integrityMap.getName(), integrityMap.size()));
         int totalErrorCount = 0;
         int totalNullValueCount = 0;
         for (MapIntegrityThread integrityThread : integrityThreads) {
             totalErrorCount += integrityThread.sizeErrorCount;
             totalNullValueCount += integrityThread.nullValueCount;
         }
-        LOGGER.info(format("%s: total integrityMapSizeErrorCount=%d", basename, totalErrorCount));
-        LOGGER.info(format("%s: total integrityMapNullValueCount=%d", basename, totalNullValueCount));
+        logger.info(format("%s: total integrityMapSizeErrorCount=%d", basename, totalErrorCount));
+        logger.info(format("%s: total integrityMapNullValueCount=%d", basename, totalNullValueCount));
 
         assertEquals(format("%s: (verify) integrityMap=%s map size", basename, integrityMap.getName()),
                 totalIntegrityKeys, integrityMap.size());

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEntryListenerTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEntryListenerTest.java
@@ -18,14 +18,13 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.EntryListenerImpl;
 import com.hazelcast.simulator.tests.map.helpers.EventCount;
 import com.hazelcast.simulator.tests.map.helpers.ScrambledZipfianGenerator;
@@ -41,12 +40,12 @@ import static org.junit.Assert.assertEquals;
 /**
  * This test is using a map to generate map entry events. We use an {@link com.hazelcast.core.EntryListener} implementation to
  * count the received events. We are generating and counting add, remove, update and evict events.
- *
+ * <p>
  * As currently the event system of Hazelcast is on a "best effort" basis, it is possible that the number of generated events will
  * not equal the number of events received. In the future the Hazelcast event system could change. For now we can say the number
  * of events received can not be greater than the number of events generated.
  */
-public class MapEntryListenerTest {
+public class MapEntryListenerTest extends AbstractTest {
 
     private enum MapOperation {
         PUT,
@@ -62,7 +61,6 @@ public class MapEntryListenerTest {
     }
 
     private static final int SLEEP_CATCH_EVENTS_MILLIS = 8000;
-    private static final ILogger LOGGER = Logger.getLogger(MapEntryListenerTest.class);
 
     // properties
     public String basename = MapEntryListenerTest.class.getSimpleName();
@@ -152,7 +150,7 @@ public class MapEntryListenerTest {
         }
         total.waitWhileListenerEventsIncrease(listener, 10);
 
-        LOGGER.info(format("Event counter for %s (actual / expected)"
+        logger.info(format("Event counter for %s (actual / expected)"
                         + "%n add: %d / %d"
                         + "%n update: %d / %d"
                         + "%n remove: %d / %d"

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEvictAndStoreTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEvictAndStoreTest.java
@@ -20,12 +20,11 @@ import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.MapStoreWithCounterPerKey;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
@@ -37,9 +36,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * This test checks for duplicate store entries when eviction happens and MapStore is slow (see Hazelcast issue #4448).
  */
-public class MapEvictAndStoreTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapEvictAndStoreTest.class);
+public class MapEvictAndStoreTest extends AbstractTest {
 
     // properties
     public String basename = MapEvictAndStoreTest.class.getSimpleName();
@@ -54,7 +51,7 @@ public class MapEvictAndStoreTest {
         map = targetInstance.getMap(basename);
         keyCounter = targetInstance.getAtomicLong(basename);
 
-        assertMapStoreConfiguration(LOGGER, targetInstance, basename, MapStoreWithCounterPerKey.class);
+        assertMapStoreConfiguration(logger, targetInstance, basename, MapStoreWithCounterPerKey.class);
     }
 
     @Verify(global = false)
@@ -64,20 +61,20 @@ public class MapEvictAndStoreTest {
         }
 
         MapConfig mapConfig = targetInstance.getConfig().getMapConfig(basename);
-        LOGGER.info(basename + ": MapConfig: " + mapConfig);
+        logger.info(basename + ": MapConfig: " + mapConfig);
 
         MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
-        LOGGER.info(basename + ": MapStoreConfig: " + mapStoreConfig);
+        logger.info(basename + ": MapStoreConfig: " + mapStoreConfig);
 
         int sleepSeconds = mapConfig.getTimeToLiveSeconds() * 2 + mapStoreConfig.getWriteDelaySeconds() * 2;
-        LOGGER.info("Sleeping for " + sleepSeconds + " seconds to wait for delay and TTL values.");
+        logger.info("Sleeping for " + sleepSeconds + " seconds to wait for delay and TTL values.");
         sleepSeconds(sleepSeconds);
 
         MapStoreWithCounterPerKey mapStore = (MapStoreWithCounterPerKey) mapStoreConfig.getImplementation();
-        LOGGER.info(basename + ": map size = " + map.size());
-        LOGGER.info(basename + ": map store = " + mapStore);
+        logger.info(basename + ": map size = " + map.size());
+        logger.info(basename + ": map store = " + mapStore);
 
-        LOGGER.info(basename + ": Checking if some keys where stored more than once");
+        logger.info(basename + ": Checking if some keys where stored more than once");
         for (Object key : mapStore.keySet()) {
             assertEquals("There were multiple calls to MapStore.store", 1, mapStore.valueOf(key));
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapLockTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
 import static java.lang.String.format;
@@ -32,14 +31,12 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Test for the {@link IMap#lock(Object)} method.
- *
+ * <p>
  * We use {@link IMap#lock(Object)} to control concurrent access to map key/value pairs. There are a total of {@link #keyCount}
  * keys stored in a map which are initialized to zero, we concurrently increment the value of a random key. We keep track of all
  * increments to each key and verify the value in the map for each key is equal to the total increments done on each key.
  */
-public class MapLockTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapLockTest.class);
+public class MapLockTest extends AbstractTest {
 
     // properties
     public String basename = MapLockTest.class.getSimpleName();
@@ -72,7 +69,7 @@ public class MapLockTest {
                 expected[i] += increments[i];
             }
         }
-        LOGGER.info(format("%s: collected increments from %d worker threads", basename, incrementsList.size()));
+        logger.info(format("%s: collected increments from %d worker threads", basename, incrementsList.size()));
 
         int failures = 0;
         for (int i = 0; i < keyCount; i++) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapMaxSizeTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapMaxSizeTest.java
@@ -19,12 +19,11 @@ import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.MapMaxSizeOperationCounter;
 import com.hazelcast.simulator.worker.selector.OperationSelector;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -39,11 +38,11 @@ import static org.junit.Assert.assertTrue;
 /**
  * This tests runs {@link IMap#put(Object, Object)} and {@link IMap#get(Object)} operations on a map, which is configured with
  * {@link com.hazelcast.config.MaxSizeConfig.MaxSizePolicy#PER_NODE}.
- *
+ * <p>
  * With some probability distribution we are doing put, putAsync, get and verification operations on the map.
  * We verify during the test and at the end that the map has not exceeded its max configured size.
  */
-public class MapMaxSizeTest {
+public class MapMaxSizeTest extends AbstractTest {
 
     private enum MapOperation {
         PUT,
@@ -55,8 +54,6 @@ public class MapMaxSizeTest {
         PUT_SYNC,
         PUT_ASYNC
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MapMaxSizeTest.class);
 
     // properties
     public String basename = MapMaxSizeTest.class.getSimpleName();
@@ -100,7 +97,7 @@ public class MapMaxSizeTest {
             assertEqualsStringFormat("Expected MaxSizePolicy %s, but was %s", PER_NODE, maxSizeConfig.getMaxSizePolicy());
             assertTrue("Expected MaxSizePolicy.getSize() < Integer.MAX_VALUE", maxSizePerNode < Integer.MAX_VALUE);
 
-            LOGGER.info("MapSizeConfig of " + basename + ": " + maxSizeConfig);
+            logger.info("MapSizeConfig of " + basename + ": " + maxSizeConfig);
         }
     }
 
@@ -110,7 +107,7 @@ public class MapMaxSizeTest {
         for (MapMaxSizeOperationCounter operationCounter : operationCounterList) {
             total.add(operationCounter);
         }
-        LOGGER.info(format("Operation counters from %s: %s", basename, total));
+        logger.info(format("Operation counters from %s: %s", basename, total));
 
         assertMapMaxSize();
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPredicateTest.java
@@ -18,8 +18,6 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
@@ -31,6 +29,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.Employee;
 import com.hazelcast.simulator.tests.map.helpers.PredicateOperationCounter;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
@@ -51,12 +50,12 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * In this test we are using different predicate methods to execute a query on a map of {@link Employee} objects.
- *
+ * <p>
  * This test also concurrently updates and modifies the employee objects in the map while the predicate queries are executing. The
  * test may also destroy the map while while predicate are executing. We verify the result of every query to ensure that the
  * objects returned fit the requirements of the query.
  */
-public class MapPredicateTest {
+public class MapPredicateTest extends AbstractTest {
 
     private enum Operation {
         PREDICATE_BUILDER,
@@ -65,8 +64,6 @@ public class MapPredicateTest {
         UPDATE_EMPLOYEE,
         DESTROY_MAP
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MapPredicateTest.class);
 
     public String basename = MapPredicateTest.class.getSimpleName();
     public int keyCount = 100;
@@ -120,7 +117,7 @@ public class MapPredicateTest {
         for (PredicateOperationCounter operationCounter : operationCounterList) {
             total.add(operationCounter);
         }
-        LOGGER.info(format("Operation counters from %s: %s", basename, total));
+        logger.info(format("Operation counters from %s: %s", basename, total));
     }
 
     @RunWithWorker
@@ -177,7 +174,7 @@ public class MapPredicateTest {
                 double avg = spendTimeMs / (double) iterationsLastMinute;
                 double perf = (iterationsLastMinute * 1000d) / (double) spendTimeMs;
 
-                LOGGER.info(format("last minute: iterations=%d, min=%d ms, max=%d ms, avg=%.2f ms, perf=%.2f predicates/second",
+                logger.info(format("last minute: iterations=%d, min=%d ms, max=%d ms, avg=%.2f ms, perf=%.2f predicates/second",
                         iterationsLastMinute, minLastMinute, maxLastMinute, avg, perf));
 
                 maxLastMinute = Long.MIN_VALUE;

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllOnTheFlyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllOnTheFlyTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
 import java.util.SortedMap;
@@ -33,13 +32,11 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperat
 
 /**
  * Test for {@link IMap#putAll(java.util.Map)} which creates the input values on the fly during the RUN phase.
- *
+ * <p>
  * You can configure the {@link #batchSize} to determine the number of inserted values per operation.
  * You can configure the {@link #keyRange} to determine the key range for inserted values.
  */
-public class MapPutAllOnTheFlyTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapPutAllOnTheFlyTest.class);
+public class MapPutAllOnTheFlyTest extends AbstractTest {
 
     // properties
     public String basename = MapPutAllOnTheFlyTest.class.getSimpleName();
@@ -58,7 +55,7 @@ public class MapPutAllOnTheFlyTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllTest.java
@@ -17,14 +17,13 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.GenericTypes;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -38,12 +37,10 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperat
 
 /**
  * Test for {@link IMap#putAll(Map)} which uses a set of prepared maps with input values during the RUN phase.
- *
+ * <p>
  * You can configure the {@link #keyType} and {@link #valueType} for the used maps.
  */
-public class MapPutAllTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapPutAllTest.class);
+public class MapPutAllTest extends AbstractTest {
 
     // properties
     public String basename = MapPutAllTest.class.getSimpleName();
@@ -79,7 +76,7 @@ public class MapPutAllTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
 
         if (valueType == GenericTypes.INTEGER) {
             valueSize = Integer.MAX_VALUE;

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapRaceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapRaceTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * This test verifies that there are race problems if the {@link IMap} is not used correctly.
- *
+ * <p>
  * This test is expected to fail.
  */
 public class MapRaceTest {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapReduceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapReduceTest.java
@@ -19,8 +19,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.mapreduce.Collator;
 import com.hazelcast.mapreduce.Combiner;
 import com.hazelcast.mapreduce.CombinerFactory;
@@ -36,6 +34,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.Employee;
 import com.hazelcast.simulator.tests.map.helpers.MapReduceOperationCounter;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -48,15 +47,13 @@ import java.util.Set;
 
 import static org.junit.Assert.assertTrue;
 
-public class MapReduceTest {
+public class MapReduceTest extends AbstractTest {
 
     private enum Operation {
         MAP_REDUCE,
         GET_MAP_ENTRY,
         MODIFY_MAP_ENTRY
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MapReduceTest.class);
 
     // properties
     public String baseName = MapReduceTest.class.getSimpleName();
@@ -97,7 +94,7 @@ public class MapReduceTest {
         for (MapReduceOperationCounter operationCounter : operationCounterList) {
             total.add(operationCounter);
         }
-        LOGGER.info(baseName + ": " + total + " from " + operationCounterList.size() + " worker threads");
+        logger.info(baseName + ": " + total + " from " + operationCounterList.size() + " worker threads");
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapStoreTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapStoreTest.java
@@ -19,13 +19,12 @@ import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.MapOperationCounter;
 import com.hazelcast.simulator.tests.map.helpers.MapStoreWithCounter;
 import com.hazelcast.simulator.utils.AssertTask;
@@ -44,12 +43,12 @@ import static org.junit.Assert.assertNull;
 
 /**
  * This test operates on a map which has a {@link com.hazelcast.core.MapStore} configured.
- *
+ * <p>
  * We use map operations such as loadAll, put, get, delete or destroy with some probability distribution to trigger
  * {@link com.hazelcast.core.MapStore} methods. We verify that the the key/value pairs in the map are also "persisted"
  * into the {@link com.hazelcast.core.MapStore}.
  */
-public class MapStoreTest {
+public class MapStoreTest extends AbstractTest {
 
     private enum MapOperation {
         LOAD_ALL,
@@ -67,8 +66,6 @@ public class MapStoreTest {
         PUT_IF_ABSENT,
         REPLACE
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MapStoreTest.class);
 
     public String basename = MapStoreTest.class.getSimpleName();
     public int keyCount = 10;
@@ -128,7 +125,7 @@ public class MapStoreTest {
                 .addOperation(MapPutOperation.PUT_IF_ABSENT, putUsingPutIfAbsent)
                 .addOperation(MapPutOperation.REPLACE, putUsingReplaceProb);
 
-        assertMapStoreConfiguration(LOGGER, targetInstance, basename, MapStoreWithCounter.class);
+        assertMapStoreConfiguration(logger, targetInstance, basename, MapStoreWithCounter.class);
     }
 
     @Verify(global = true)
@@ -137,7 +134,7 @@ public class MapStoreTest {
         for (MapOperationCounter operationCounter : operationCounterList) {
             total.add(operationCounter);
         }
-        LOGGER.info(basename + ": " + total + " from " + operationCounterList.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + operationCounterList.size() + " worker threads");
     }
 
     @Verify(global = false)
@@ -150,13 +147,13 @@ public class MapStoreTest {
         int writeDelayMs = (int) TimeUnit.SECONDS.toMillis(mapStoreConfig.getWriteDelaySeconds());
 
         int sleepMs = mapStoreMaxDelayMs * 2 + maxTTLExpiryMs * 2 + (writeDelayMs * 2);
-        LOGGER.info("Sleeping for " + TimeUnit.MILLISECONDS.toSeconds(sleepMs) + " seconds to wait for delay and TTL values.");
+        logger.info("Sleeping for " + TimeUnit.MILLISECONDS.toSeconds(sleepMs) + " seconds to wait for delay and TTL values.");
         sleepMillis(sleepMs);
 
         final MapStoreWithCounter mapStore = (MapStoreWithCounter) mapStoreConfig.getImplementation();
 
-        LOGGER.info(basename + ": map size = " + map.size());
-        LOGGER.info(basename + ": map store = " + mapStore);
+        logger.info(basename + ": map size = " + map.size());
+        logger.info(basename + ": map store = " + mapStore);
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTTLSaturationTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTTLSaturationTest.java
@@ -20,13 +20,12 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
 import java.util.concurrent.TimeUnit;
@@ -34,9 +33,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.FormatUtils.humanReadableByteCount;
 
-public class MapTTLSaturationTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTTLSaturationTest.class);
+public class MapTTLSaturationTest extends AbstractTest {
 
     // properties
     public String basename = MapTTLSaturationTest.class.getSimpleName();
@@ -72,14 +69,14 @@ public class MapTTLSaturationTest {
         protected void timeStep() throws Exception {
             double usedPercentage = heapUsedPercentage();
             if (usedPercentage >= maxHeapUsagePercentage) {
-                LOGGER.info(basename + " heap used: " + usedPercentage + " %, map size: " + map.size());
+                logger.info(basename + " heap used: " + usedPercentage + " %, map size: " + map.size());
 
                 sleepSeconds(10);
             } else {
                 for (int i = 0; i < 1000; i++) {
                     counter++;
                     if (counter % 100000 == 0) {
-                        LOGGER.info(basename + " at: " + counter + ", heap used: " + usedPercentage
+                        logger.info(basename + " at: " + counter + ", heap used: " + usedPercentage
                                 + " %, map size: " + map.size());
                     }
                     long key = getRandom().nextLong();
@@ -101,12 +98,12 @@ public class MapTTLSaturationTest {
         long max = Runtime.getRuntime().maxMemory();
         double usedOfMax = 100.0 * ((double) used / (double) max);
 
-        LOGGER.info(basename + ' ' + header);
-        LOGGER.info(basename + " map size: " + map.size());
-        LOGGER.info(basename + " free: " + humanReadableByteCount(free, true) + " = " + free);
-        LOGGER.info(basename + " used: " + humanReadableByteCount(used, true) + " = " + used);
-        LOGGER.info(basename + " max: " + humanReadableByteCount(max, true) + " = " + max);
-        LOGGER.info(basename + " usedOfMax: " + usedOfMax + '%');
+        logger.info(basename + ' ' + header);
+        logger.info(basename + " map size: " + map.size());
+        logger.info(basename + " free: " + humanReadableByteCount(free, true) + " = " + free);
+        logger.info(basename + " used: " + humanReadableByteCount(used, true) + " = " + used);
+        logger.info(basename + " max: " + humanReadableByteCount(max, true) + " = " + max);
+        logger.info(basename + " usedOfMax: " + usedOfMax + '%');
     }
 
     private static double heapUsedPercentage() {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.MapOperationCounter;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -39,13 +38,11 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * In this test we are using map put methods with an expire time.
- *
+ * <p>
  * We put keys at random into the map using sync and async methods with some probability distribution.
  * In the end we verify that the map is empty and all key value pairs have expired out of the map.
  */
-public class MapTimeToLiveTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTimeToLiveTest.class);
+public class MapTimeToLiveTest extends AbstractTest {
 
     private enum Operation {
         PUT_TTL,
@@ -92,7 +89,7 @@ public class MapTimeToLiveTest {
         for (MapOperationCounter counter : results) {
             total.add(counter);
         }
-        LOGGER.info(basename + ": " + total + " total of " + results.size());
+        logger.info(basename + ": " + total + " total of " + results.size());
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextConflictTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextConflictTest.java
@@ -19,13 +19,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyIncrementPair;
 import com.hazelcast.simulator.tests.helpers.TxnCounter;
 import com.hazelcast.simulator.utils.ThreadSpawner;
@@ -41,16 +40,14 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Testing transaction context with multi keys.
- *
+ * <p>
  * A number of map keys (maxKeysPerTxn) are chosen at random to take part in the transaction. As maxKeysPerTxn increases as a
  * proportion of keyCount, more conflict will occur between the transactions, less transactions will be committed successfully and
  * more transactions are rolled back.
  */
-public class MapTransactionContextConflictTest {
+public class MapTransactionContextConflictTest extends AbstractTest {
 
     private static final int MAX_INCREMENT = 999;
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTransactionContextConflictTest.class);
 
     public String basename = MapTransactionContextConflictTest.class.getSimpleName();
     public int threadCount = 3;
@@ -123,7 +120,7 @@ public class MapTransactionContextConflictTest {
                         localIncrements[p.key] += p.increment;
                     }
                 } catch (TransactionException commitException) {
-                    LOGGER.warning(basename + ": commit failed. tried key increments=" + putIncrements, commitException);
+                    logger.warning(basename + ": commit failed. tried key increments=" + putIncrements, commitException);
                     if (throwCommitException) {
                         throw rethrow(commitException);
                     }
@@ -132,7 +129,7 @@ public class MapTransactionContextConflictTest {
                         context.rollbackTransaction();
                         count.rolled++;
                     } catch (TransactionException rollBackException) {
-                        LOGGER.warning(basename + ": rollback failed " + rollBackException.getMessage(), rollBackException);
+                        logger.warning(basename + ": rollback failed " + rollBackException.getMessage(), rollBackException);
                         count.failedRollbacks++;
 
                         if (throwRollBackException) {
@@ -153,7 +150,7 @@ public class MapTransactionContextConflictTest {
         for (TxnCounter c : counts) {
             total.add(c);
         }
-        LOGGER.info(basename + ": " + total + " from " + counts.size() + " worker threads");
+        logger.info(basename + ": " + total + " from " + counts.size() + " worker threads");
 
         IList<long[]> allIncrements = targetInstance.getList(basename + "inc");
         long[] expected = new long[keyCount];
@@ -168,7 +165,7 @@ public class MapTransactionContextConflictTest {
         for (int i = 0; i < keyCount; i++) {
             if (expected[i] != map.get(i)) {
                 failures++;
-                LOGGER.info(basename + ": key=" + i + " expected " + expected[i] + " != " + "actual " + map.get(i));
+                logger.info(basename + ": key=" + i + " expected " + expected[i] + " != " + "actual " + map.get(i));
             }
         }
         assertEquals(basename + ": " + failures + " key=>values have been incremented unExpected", 0, failures);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextTest.java
@@ -17,11 +17,10 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionOptions;
@@ -29,9 +28,7 @@ import com.hazelcast.transaction.TransactionOptions.TransactionType;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.rethrow;
 
-public class MapTransactionContextTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTransactionContextTest.class);
+public class MapTransactionContextTest extends AbstractTest {
 
     // properties
     public TransactionType transactionType = TransactionType.TWO_PHASE;
@@ -78,7 +75,7 @@ public class MapTransactionContextTest {
 
                 transactionContext.commitTransaction();
             } catch (Exception e) {
-                LOGGER.severe("----------------------tx exception -------------------------", e);
+                logger.severe("----------------------tx exception -------------------------", e);
 
                 if (failOnException) {
                     throw rethrow(e);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionGetForUpdateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionGetForUpdateTest.java
@@ -19,13 +19,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.TxnCounter;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 import com.hazelcast.transaction.TransactionContext;
@@ -42,9 +41,7 @@ import static org.junit.Assert.assertEquals;
  * increments to each key.  In the end we verify that for each key value pair the a value in the map matches the increments
  * done on that key,
  */
-public class MapTransactionGetForUpdateTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTransactionGetForUpdateTest.class);
+public class MapTransactionGetForUpdateTest extends AbstractTest {
 
     // properties
     public String basename = MapTransactionGetForUpdateTest.class.getSimpleName();
@@ -117,7 +114,7 @@ public class MapTransactionGetForUpdateTest {
                 } catch (Exception commitFailedException) {
                     if (context != null) {
                         try {
-                            LOGGER.warning(basename + ": commit failed key=" + key + " inc=" + increment, commitFailedException);
+                            logger.warning(basename + ": commit failed key=" + key + " inc=" + increment, commitFailedException);
                             if (rethrowAllException) {
                                 throw rethrow(commitFailedException);
                             }
@@ -125,7 +122,7 @@ public class MapTransactionGetForUpdateTest {
                             context.rollbackTransaction();
                             count.rolled++;
                         } catch (Exception rollBackFailedException) {
-                            LOGGER.warning(basename + ": rollback failed key=" + key + " inc=" + increment,
+                            logger.warning(basename + ": rollback failed key=" + key + " inc=" + increment,
                                     rollBackFailedException);
                             count.failedRollbacks++;
 
@@ -148,7 +145,7 @@ public class MapTransactionGetForUpdateTest {
         for (TxnCounter c : counts) {
             total.add(c);
         }
-        LOGGER.info(basename + ": " + total + " from " + counts.size() + " workers");
+        logger.info(basename + ": " + total + " from " + counts.size() + " workers");
 
         IList<long[]> allIncrements = targetInstance.getList(basename + "res");
         long[] expected = new long[keyCount];
@@ -164,7 +161,7 @@ public class MapTransactionGetForUpdateTest {
         for (int i = 0; i < keyCount; i++) {
             if (expected[i] != map.get(i)) {
                 failures++;
-                LOGGER.info(basename + ": key=" + i + " expected " + expected[i] + " != " + "actual " + map.get(i));
+                logger.info(basename + ": key=" + i + " expected " + expected[i] + " != " + "actual " + map.get(i));
             }
         }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
@@ -18,8 +18,6 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -27,6 +25,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -41,14 +40,12 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperat
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClusterSize;
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntKeys;
 
-public class MapTransactionReadWriteTest {
+public class MapTransactionReadWriteTest extends AbstractTest {
 
     enum Operation {
         PUT,
         GET
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTransactionReadWriteTest.class);
 
     // properties
     public String basename = MapTransactionReadWriteTest.class.getSimpleName();
@@ -79,12 +76,12 @@ public class MapTransactionReadWriteTest {
     @Teardown
     public void teardown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, targetInstance, minNumberOfMembers);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateIntKeys(keyCount, keyLocality, targetInstance);
 
         Random random = new Random();

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionTest.java
@@ -19,13 +19,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
@@ -42,9 +41,7 @@ import static org.junit.Assert.assertEquals;
  * we concurrently increment the value of a random key.  We keep track of all increments to each key and verify
  * the value in the map for each key is equal to the total increments done on each key.
  */
-public class MapTransactionTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MapTransactionTest.class);
+public class MapTransactionTest extends AbstractTest {
 
     // properties
     public String basename = getClass().getSimpleName();
@@ -80,7 +77,7 @@ public class MapTransactionTest {
     public void verify() {
         long[] total = new long[keyCount];
 
-        LOGGER.info(basename + ": collected increments from " + resultList.size() + " worker threads");
+        logger.info(basename + ": collected increments from " + resultList.size() + " worker threads");
 
         for (long[] increments : resultList) {
             for (int i = 0; i < increments.length; i++) {
@@ -92,7 +89,7 @@ public class MapTransactionTest {
         for (int i = 0; i < keyCount; i++) {
             if (total[i] != map.get(i)) {
                 failures++;
-                LOGGER.info(basename + ": key=" + i + " expected val " + total[i] + " !=  map val" + map.get(i));
+                logger.info(basename + ": key=" + i + " expected val " + total[i] + " !=  map val" + map.get(i));
             }
         }
 
@@ -134,7 +131,7 @@ public class MapTransactionTest {
                 if (reThrowTransactionException) {
                     throw rethrow(e);
                 }
-                LOGGER.warning(basename + ": caught TransactionException ", e);
+                logger.warning(basename + ": caught TransactionException ", e);
             }
         }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MultiValueMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MultiValueMapTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
@@ -32,6 +30,7 @@ import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -48,10 +47,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
-public class MultiValueMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(MultiValueMapTest.class);
-    private static final ThrottlingLogger THROTTLING_LOGGER = ThrottlingLogger.newLogger(LOGGER, 5000);
+public class MultiValueMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -65,8 +61,8 @@ public class MultiValueMapTest {
     public boolean useIndex;
     public boolean usePortable;
 
+    private final ThrottlingLogger throttlingLogger = ThrottlingLogger.newLogger(logger, 5000);
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
-
     private IMap<Integer, Object> map;
 
     @Setup
@@ -133,7 +129,7 @@ public class MultiValueMapTest {
                     } finally {
                         probe.done(started);
                     }
-                    THROTTLING_LOGGER.info(format("Query 'payloadField[any]= %d' returned %d results.", key, result.size()));
+                    throttlingLogger.info(format("Query 'payloadField[any]= %d' returned %d results.", key, result.size()));
                     for (Object resultSillySequence : result) {
                         assertValidSequence(resultSillySequence);
                     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/PagingPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/PagingPredicateTest.java
@@ -32,13 +32,13 @@ import com.hazelcast.simulator.worker.tasks.IWorker;
 /**
  * Test to exercising PagingPredicate.
  * It's intended to be used for benchmarking purposes, it doesn't validate correctness of results.
- *
+ * <p>
  * It has 2 working modes:
  * <ol>
- *    <li>Sequential Mode - where workers are paging in a sequential orders. Ie. Page1, Page2, PageN, PageN+1, etc</li>
- *    <li>Random Mode - where workers are selecting arbitrary pages</li>
+ * <li>Sequential Mode - where workers are paging in a sequential orders. Ie. Page1, Page2, PageN, PageN+1, etc</li>
+ * <li>Random Mode - where workers are selecting arbitrary pages</li>
  * </ol>
- *
+ * <p>
  * Implementation note: There is a small code duplication in worker implementations - it could be eliminated by
  * introducing a common superclass, but I believe it would just make things more complicated.
  */

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SerializationStrategyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SerializationStrategyTest.java
@@ -16,14 +16,13 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.domain.DomainObject;
 import com.hazelcast.simulator.tests.map.domain.DomainObjectFactory;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
@@ -44,7 +43,7 @@ import static org.apache.commons.lang3.RandomUtils.nextDouble;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 
-public class SerializationStrategyTest {
+public class SerializationStrategyTest extends AbstractTest {
 
     private enum Operation {
         GET_BY_KEY,
@@ -59,8 +58,6 @@ public class SerializationStrategyTest {
         IDENTIFIED_DATA_SERIALIZABLE
     }
 
-    private static final ILogger LOGGER = Logger.getLogger(SerializationStrategyTest.class);
-    private static final ThrottlingLogger THROTTLING_LOGGER = ThrottlingLogger.newLogger(LOGGER, 5000);
 
     // properties
     public String basename = SerializationStrategyTest.class.getSimpleName();
@@ -73,7 +70,7 @@ public class SerializationStrategyTest {
     public double getByIntIndexProb = 0;
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
-
+    private final ThrottlingLogger throttlingLogger = ThrottlingLogger.newLogger(logger, 5000);
     private IMap<String, DomainObject> map;
     private Set<String> uniqueStrings;
 
@@ -152,7 +149,7 @@ public class SerializationStrategyTest {
                     String string = getUniqueString();
                     Predicate predicate = Predicates.equal("stringVal", string);
                     Set<Map.Entry<String, DomainObject>> entries = map.entrySet(predicate);
-                    THROTTLING_LOGGER.log(Level.INFO, "GetByStringIndex: " + entries.size() + " entries");
+                    throttlingLogger.log(Level.INFO, "GetByStringIndex: " + entries.size() + " entries");
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown Operation: " + operation);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SplitClusterDataTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SplitClusterDataTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClusterSize;
@@ -31,9 +30,7 @@ import static com.hazelcast.simulator.utils.CommonUtils.sleepMillis;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static org.junit.Assert.assertEquals;
 
-public class SplitClusterDataTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(SplitClusterDataTest.class);
+public class SplitClusterDataTest extends AbstractTest {
 
     public String basename = SplitClusterDataTest.class.getSimpleName();
     public int maxItems = 10000;
@@ -57,7 +54,7 @@ public class SplitClusterDataTest {
 
     @Warmup(global = true)
     public void warmup() {
-        waitClusterSize(LOGGER, targetInstance, clusterSize);
+        waitClusterSize(logger, targetInstance, clusterSize);
 
         for (int i = 0; i < maxItems; i++) {
             map.put(i, i);
@@ -82,13 +79,13 @@ public class SplitClusterDataTest {
 
     @Verify(global = false)
     public void verify() {
-        LOGGER.info(basename + ": cluster size =" + targetInstance.getCluster().getMembers().size());
-        LOGGER.info(basename + ": map size =" + map.size());
+        logger.info(basename + ": cluster size =" + targetInstance.getCluster().getMembers().size());
+        logger.info(basename + ": map size =" + map.size());
 
         if (targetInstance.getCluster().getMembers().size() == splitClusterSize) {
-            LOGGER.info(basename + ": check again cluster =" + targetInstance.getCluster().getMembers().size());
+            logger.info(basename + ": check again cluster =" + targetInstance.getCluster().getMembers().size());
         } else {
-            LOGGER.info(basename + ": check again cluster =" + targetInstance.getCluster().getMembers().size());
+            logger.info(basename + ": check again cluster =" + targetInstance.getCluster().getMembers().size());
 
             int max = 0;
             while (map.size() != maxItems) {
@@ -99,7 +96,7 @@ public class SplitClusterDataTest {
             }
 
             assertEquals("data loss ", map.size(), maxItems);
-            LOGGER.info(basename + "verify OK ");
+            logger.info(basename + "verify OK ");
         }
     }
 }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
@@ -17,14 +17,13 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.DataSerializableEmployee;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -38,9 +37,8 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperat
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateString;
 import static com.hazelcast.simulator.worker.metronome.MetronomeFactory.withFixedIntervalMs;
 
-public class SqlPredicateTest {
+public class SqlPredicateTest extends AbstractTest {
 
-    private static final ILogger LOGGER = Logger.getLogger(SqlPredicateTest.class);
     private static final String[] NAMES = {"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg"};
 
     // properties
@@ -65,7 +63,7 @@ public class SqlPredicateTest {
     @Teardown
     public void teardown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = true)
@@ -78,8 +76,8 @@ public class SqlPredicateTest {
             streamer.pushEntry(key, value);
         }
         streamer.await();
-        LOGGER.info("Map size is: " + map.size());
-        LOGGER.info("Map localKeySet size is: " + map.localKeySet().size());
+        logger.info("Map size is: " + map.size());
+        logger.info("Map localKeySet size is: " + map.localKeySet().size());
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapMonotonicTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapMonotonicTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -42,8 +41,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateStrings;
 import static com.hazelcast.simulator.worker.metronome.MetronomeFactory.withFixedIntervalMs;
 
-public class StringStringMapMonotonicTest {
-    private static final ILogger LOGGER = Logger.getLogger(StringStringMapMonotonicTest.class);
+public class StringStringMapMonotonicTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -85,12 +83,12 @@ public class StringStringMapMonotonicTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, targetInstance, minNumberOfMembers);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);
         values = generateStrings(valueCount, valueLength);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -39,9 +38,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClust
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateStrings;
 
-public class StringStringMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(StringStringMapTest.class);
+public class StringStringMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -81,12 +78,12 @@ public class StringStringMapTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, targetInstance, minNumberOfMembers);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);
         values = generateStrings(valueCount, valueLength);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/IntegerGenerator.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/IntegerGenerator.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
  * may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ScrambledZipfianGenerator.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ScrambledZipfianGenerator.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
  * may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ZipfianGenerator.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ZipfianGenerator.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
  * * may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ZipfianUtils.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ZipfianUtils.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
  * may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/AbstractMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/AbstractMapTest.java
@@ -18,9 +18,8 @@ package com.hazelcast.simulator.tests.map.queryresultsize;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.HazelcastTestUtils;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
@@ -38,9 +37,7 @@ import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-abstract class AbstractMapTest {
-
-    protected static final ILogger LOGGER = Logger.getLogger(AbstractMapTest.class);
+abstract class AbstractMapTest extends AbstractTest {
 
     HazelcastInstance hazelcastInstance;
     IMap<Object, Integer> map;
@@ -70,14 +67,14 @@ abstract class AbstractMapTest {
             minResultSizeLimit = getStaticFieldValue(queryResultSizeLimiterClazz, "MINIMUM_MAX_RESULT_LIMIT", int.class);
             resultLimitFactor = getStaticFieldValue(queryResultSizeLimiterClazz, "MAX_RESULT_LIMIT_FACTOR", float.class);
         } catch (Exception e) {
-            LOGGER.warning(format("%s: QueryResultSizeLimiter is not implemented in this Hazelcast version", basename));
+            logger.warning(format("%s: QueryResultSizeLimiter is not implemented in this Hazelcast version", basename));
         }
 
         int clusterSize = hazelcastInstance.getCluster().getMembers().size();
         this.globalKeyCount = getGlobalKeyCount(minResultSizeLimit, resultLimitFactor);
         this.localKeyCount = (int) Math.ceil(globalKeyCount / (double) clusterSize);
 
-        LOGGER.info(format("%s: Filling map with %d items (%d items per member, %d members in cluster)",
+        logger.info(format("%s: Filling map with %d items (%d items per member, %d members in cluster)",
                 basename, globalKeyCount, localKeyCount, clusterSize));
     }
 
@@ -112,7 +109,7 @@ abstract class AbstractMapTest {
         }
         streamer.await();
 
-        logPartitionStatistics(LOGGER, basename, map, true);
+        logPartitionStatistics(logger, basename, map, true);
     }
 
     protected void baseVerify(boolean expectedExceptions) {
@@ -120,7 +117,7 @@ abstract class AbstractMapTest {
         long ops = operationCounter.get();
         long exceptions = exceptionCounter.get();
 
-        LOGGER.info(basename + ": Map size: " + mapSize + ", Ops: " + ops + ", Exceptions: " + exceptions);
+        logger.info(basename + ": Map size: " + mapSize + ", Ops: " + ops + ", Exceptions: " + exceptions);
 
         assertTrue(format("Expected mapSize >= globalKeyCount (%d >= %d)", mapSize, globalKeyCount), mapSize >= globalKeyCount);
         assertTrue(format("Expected ops > 0 (%d > 0)", ops), ops > 0);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapLatencyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapLatencyTest.java
@@ -27,13 +27,13 @@ import com.hazelcast.simulator.worker.tasks.IWorker;
  * This test creates latency probe results for {@link com.hazelcast.core.IMap#values()}, {@link com.hazelcast.core.IMap#keySet()}
  * and {@link com.hazelcast.core.IMap#entrySet()}. It is used to ensure that the query result size limit has no bad impact on the
  * latency of those method calls.
- *
+ * <p>
  * To achieve this we fill a map slightly below the trigger limit of the query result size limit, so we are sure it will never
  * trigger the exception. Then we call the map methods and measure their latency.
- *
+ * <p>
  * The test can be configured to use {@link String} or {@link Integer} keys. You can also override the number of filled items
  * with the {@link #keyCount} property, e.g. to test the latency impact of this feature with an empty map.
- *
+ * <p>
  * This test works fine with all Hazelcast versions, since it does not use any new functionality. Just be sure the default
  * values in {@link AbstractMapTest} match with the default values of the query result size limit in Hazelcast 3.5. Otherwise
  * the map will be filled with a different number of keys and the latency results may not be comparable.

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapResultSizeLimitTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapResultSizeLimitTest.java
@@ -26,13 +26,13 @@ import com.hazelcast.simulator.worker.tasks.IWorker;
 /**
  * This test verifies that {@link com.hazelcast.core.IMap#values()}, {@link com.hazelcast.core.IMap#keySet()} and
  * {@link com.hazelcast.core.IMap#entrySet()} throw an exception if the configured result size limit is exceeded.
- *
+ * <p>
  * To achieve this we fill a map slightly above the trigger limit of the query result size limit, so we are sure it will always
  * trigger the exception. Then we call the map methods and verify that each call created an exception.
- *
+ * <p>
  * The test can be configured to use {@link String} or {@link Integer} keys. You can also override the number of filled items
  * with the {@link #keyCount} property, e.g. to test for missing exceptions with enabled result size limit and an empty map.
- *
+ * <p>
  * You have to activate the query result size limit by providing a custom hazelcast.xml with the following setting:
  * <pre>
  *   {@code

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/ProducerConsumerTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/ProducerConsumerTest.java
@@ -18,14 +18,13 @@ package com.hazelcast.simulator.tests.queue;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.io.Serializable;
@@ -34,9 +33,7 @@ import java.util.Random;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.rethrow;
 import static org.junit.Assert.assertEquals;
 
-public class ProducerConsumerTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ProducerConsumerTest.class);
+public class ProducerConsumerTest extends AbstractTest {
 
     // properties
     public String basename = ProducerConsumerTest.class.getSimpleName();
@@ -104,7 +101,7 @@ public class ProducerConsumerTest {
 
                     iteration++;
                     if (iteration % 10 == 0) {
-                        LOGGER.info(String.format(
+                        logger.info(String.format(
                                 "%s prod-id: %d, iteration: %d, produced: %d, workQueue: %d, consumed: %d",
                                 Thread.currentThread().getName(), id, iteration,
                                 produced.get(), workQueue.size(), consumed.get()
@@ -136,7 +133,7 @@ public class ProducerConsumerTest {
 
                     iteration++;
                     if (iteration % 20 == 0) {
-                        LOGGER.info(String.format(
+                        logger.info(String.format(
                                 "%s prod-id: %d, iteration: %d, produced: %d, workQueue: %d, consumed: %d",
                                 Thread.currentThread().getName(), id, iteration,
                                 produced.get(), workQueue.size(), consumed.get()

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/QueueTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/QueueTest.java
@@ -17,14 +17,13 @@ package com.hazelcast.simulator.tests.queue;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.util.Queue;
@@ -35,9 +34,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyLocality.RANDOM;
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static org.junit.Assert.assertEquals;
 
-public class QueueTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(QueueTest.class);
+public class QueueTest extends AbstractTest {
 
     // properties
     public String basename = QueueTest.class.getSimpleName();
@@ -113,7 +110,7 @@ public class QueueTest {
             fromQueue = queues[fromIndex];
             toQueue = queues[toIndex];
 
-            LOGGER.info(String.format(
+            logger.info(String.format(
                     "%s fromQueue[%d] %s: %d, toQueue[%d] %s: %d",
                     Thread.currentThread().getName(),
                     fromIndex, fromQueue.getName(), fromQueue.size(),
@@ -132,7 +129,7 @@ public class QueueTest {
 
                     iteration++;
                     if (logFrequency > 0 && iteration % logFrequency == 0) {
-                        LOGGER.info(String.format(
+                        logger.info(String.format(
                                 "%s iteration: %d, fromQueue size: %d, toQueue size: %d",
                                 Thread.currentThread().getName(), iteration, fromQueue.size(), toQueue.size()
                         ));

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/TxnQueueWithLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/TxnQueueWithLockTest.java
@@ -20,13 +20,12 @@ import com.hazelcast.core.IList;
 import com.hazelcast.core.ILock;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.TransactionalQueue;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.TxnCounter;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 import com.hazelcast.transaction.TransactionContext;
@@ -36,9 +35,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * This simulator test simulates the issue #2287
  */
-public class TxnQueueWithLockTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(TxnQueueWithLockTest.class);
+public class TxnQueueWithLockTest extends AbstractTest {
 
     public String basename = TxnQueueWithLockTest.class.getSimpleName();
     public int threadCount = 5;
@@ -92,16 +89,16 @@ public class TxnQueueWithLockTest {
                             ctx.rollbackTransaction();
                             counter.rolled++;
 
-                            LOGGER.severe(basename + ": Exception in txn " + counter, txnException);
+                            logger.severe(basename + ": Exception in txn " + counter, txnException);
                         } catch (Exception rollException) {
                             counter.failedRollbacks++;
-                            LOGGER.severe(basename + ": Exception in roll " + counter, rollException);
+                            logger.severe(basename + ": Exception in roll " + counter, rollException);
                         }
                     } finally {
                         firstLock.unlock();
                     }
                 } catch (Exception e) {
-                    LOGGER.severe(basename + ": outer Exception" + counter, e);
+                    logger.severe(basename + ": outer Exception" + counter, e);
                 }
             }
             IList<TxnCounter> results = instance.getList(basename + "results");
@@ -122,7 +119,7 @@ public class TxnQueueWithLockTest {
             total.add(counter);
         }
 
-        LOGGER.info(basename + ": " + total + " from " + results.size() + " worker Threads  Queue size=" + queue.size());
+        logger.info(basename + ": " + total + " from " + results.size() + " worker Threads  Queue size=" + queue.size());
         assertFalse(basename + ": firstLock.isLocked()", firstLock.isLocked());
         assertFalse(basename + ": secondLock.isLocked()", secondLock.isLocked());
         // TODO: check if this assert can be re-enabled: assertEquals(total.committed - total.rolled, queue.size())

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.replicatedmap;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 import com.hazelcast.simulator.worker.metronome.MetronomeType;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -35,9 +34,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperat
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateStrings;
 import static com.hazelcast.simulator.worker.metronome.MetronomeFactory.withFixedIntervalMs;
 
-public class ReplicatedMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ReplicatedMapTest.class);
+public class ReplicatedMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -76,7 +73,7 @@ public class ReplicatedMapTest {
     @Teardown
     public void tearDown() throws Exception {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(targetInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTimeToLiveTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTimeToLiveTest.java
@@ -18,13 +18,12 @@ package com.hazelcast.simulator.tests.replicatedmap;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.map.helpers.MapOperationCounter;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.worker.metronome.Metronome;
@@ -40,9 +39,7 @@ import static com.hazelcast.simulator.utils.TestUtils.assertTrueEventually;
 import static com.hazelcast.simulator.worker.metronome.MetronomeFactory.withFixedIntervalMs;
 import static org.junit.Assert.assertEquals;
 
-public class ReplicatedMapTimeToLiveTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ReplicatedMapTimeToLiveTest.class);
+public class ReplicatedMapTimeToLiveTest extends AbstractTest {
 
     private enum Operation {
         PUT_TTL,
@@ -82,13 +79,13 @@ public class ReplicatedMapTimeToLiveTest {
         for (MapOperationCounter counter : results) {
             total.add(counter);
         }
-        LOGGER.info(basename + ": " + total + " total of " + results.size());
+        logger.info(basename + ": " + total + " total of " + results.size());
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
 
-                LOGGER.info(basename + ": " + "assert map Size = " + map.size());
+                logger.info(basename + ": " + "assert map Size = " + map.size());
                 assertEquals(basename + ": Replicated Map should be empty, some TTL events are not processed", 0, map.size());
             }
         });

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/slow/SlowOperationMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/slow/SlowOperationMapTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.simulator.tests.slow;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -27,6 +25,7 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
@@ -51,14 +50,12 @@ import static org.junit.Assert.fail;
 
 /**
  * This test invokes slowed down map operations on a Hazelcast instance to provoke slow operation logs.
- *
+ * <p>
  * In the verification phase we check for the correct number of slow operation logs (one per operation type).
  *
  * @since Hazelcast 3.5
  */
-public class SlowOperationMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(SlowOperationMapTest.class);
+public class SlowOperationMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -138,7 +135,7 @@ public class SlowOperationMapTest {
         int expected = (int) (Math.min(putCount, 1) + Math.min(getCount, 1));
         long operationCount = putCount + getCount;
 
-        LOGGER.info(format("Expecting %d slow operation logs after completing %d operations (%d put, %d get).",
+        logger.info(format("Expecting %d slow operation logs after completing %d operations (%d put, %d get).",
                 expected, operationCount, putCount, getCount));
 
         assertNotNull("Could not retrieve slow operation logs", slowOperationLogs);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ClusterStatisticsTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ClusterStatisticsTest.java
@@ -18,12 +18,11 @@ package com.hazelcast.simulator.tests.special;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.PartitionService;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.IWorker;
 import com.hazelcast.simulator.worker.tasks.NoOperationWorker;
 
@@ -31,9 +30,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberN
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.logPartitionStatistics;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 
-public class ClusterStatisticsTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ClusterStatisticsTest.class);
+public class ClusterStatisticsTest extends AbstractTest {
 
     // properties
     public String basename = ClusterStatisticsTest.class.getSimpleName();
@@ -58,14 +55,14 @@ public class ClusterStatisticsTest {
 
         int retry = 0;
         while (!partitionService.isClusterSafe() && retry++ < isClusterSafeRetries) {
-            LOGGER.info(basename + ": isClusterSafe() " + partitionService.isClusterSafe());
+            logger.info(basename + ": isClusterSafe() " + partitionService.isClusterSafe());
             sleepSeconds(1);
         }
-        LOGGER.info(basename + ": isClusterSafe() " + partitionService.isClusterSafe());
-        LOGGER.info(basename + ": isLocalMemberSafe() " + partitionService.isLocalMemberSafe());
-        LOGGER.info(basename + ": getCluster().getMembers().size() " + hazelcastInstance.getCluster().getMembers().size());
+        logger.info(basename + ": isClusterSafe() " + partitionService.isClusterSafe());
+        logger.info(basename + ": isLocalMemberSafe() " + partitionService.isLocalMemberSafe());
+        logger.info(basename + ": getCluster().getMembers().size() " + hazelcastInstance.getCluster().getMembers().size());
 
-        logPartitionStatistics(LOGGER, basename, map, false);
+        logPartitionStatistics(logger, basename, map, false);
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/FailingTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/FailingTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.special;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.TestPhase;
@@ -27,6 +25,7 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.EmptyStatement;
 import com.hazelcast.simulator.utils.ExceptionReporter;
 
@@ -41,7 +40,7 @@ import static org.junit.Assert.fail;
 /**
  * A test that causes a failure. This is useful for testing the simulator framework and for demonstration purposes.
  */
-public class FailingTest {
+public class FailingTest extends AbstractTest {
 
     public enum Failure {
         EXCEPTION,
@@ -63,8 +62,6 @@ public class FailingTest {
         MEMBER,
         CLIENT
     }
-
-    private static final ILogger LOGGER = Logger.getLogger(FailingTest.class);
 
     // properties
     public TestPhase testPhase = TestPhase.RUN;
@@ -177,7 +174,7 @@ public class FailingTest {
                 break;
             }
         }
-        LOGGER.severe("We should never reach this code! List size: " + list.size());
+        logger.severe("We should never reach this code! List size: " + list.size());
     }
 
     private static boolean matchingType(Type type, TestContext testContext) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/MapHeapHogWarmupTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/MapHeapHogWarmupTest.java
@@ -17,13 +17,12 @@ package com.hazelcast.simulator.tests.special;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.util.concurrent.TimeUnit;
@@ -36,13 +35,12 @@ import static java.lang.String.format;
 
 /**
  * Fills up the cluster to a defined heap usage factor during warmup phase.
- *
+ * <p>
  * This tests intentionally has an empty run phase.
  */
-public class MapHeapHogWarmupTest {
+public class MapHeapHogWarmupTest extends AbstractTest {
 
     private static final long APPROX_ENTRY_BYTES_SIZE = 238;
-    private static final ILogger LOGGER = Logger.getLogger(MapHeapHogWarmupTest.class);
 
     // properties
     public String basename = MapHeapHogWarmupTest.class.getSimpleName();
@@ -92,7 +90,7 @@ public class MapHeapHogWarmupTest {
 
         StringBuilder sb = new StringBuilder(basename).append(": After warmup phase the map size is ").append(map.size());
         addMemoryStatistics(sb);
-        LOGGER.info(sb.toString());
+        logger.info(sb.toString());
     }
 
     @Verify
@@ -103,7 +101,7 @@ public class MapHeapHogWarmupTest {
 
         StringBuilder sb = new StringBuilder(basename).append(": In local verify phase the map size is ").append(map.size());
         addMemoryStatistics(sb);
-        LOGGER.info(sb.toString());
+        logger.info(sb.toString());
     }
 
     @Run
@@ -133,7 +131,7 @@ public class MapHeapHogWarmupTest {
                 if (isLogger && key % logFrequency == 0) {
                     sb.append(basename).append(": In warmup phase the map size is ").append(map.size());
                     addMemoryStatistics(sb);
-                    LOGGER.info(sb.toString());
+                    logger.info(sb.toString());
                     sb.setLength(0);
                 }
             }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ProbeConcurrencyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ProbeConcurrencyTest.java
@@ -15,22 +15,19 @@
  */
 package com.hazelcast.simulator.tests.special;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 import com.hazelcast.simulator.worker.tasks.IWorker;
 
 /**
  * This test is to debug and check probe results from a very controlled test case.
- *
+ * <p>
  * By adjusting the threadCount and maxOperations the invocation count of probes are absolutely predictable.
  */
-public class ProbeConcurrencyTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ProbeConcurrencyTest.class);
+public class ProbeConcurrencyTest extends AbstractTest {
 
     // properties
     public String basename = ProbeConcurrencyTest.class.getSimpleName();
@@ -39,7 +36,7 @@ public class ProbeConcurrencyTest {
 
     @Setup
     public void setUp(TestContext testContext) {
-        LOGGER.info("ThreadCount: " + threadCount + " max operations: " + maxOperations);
+        logger.info("ThreadCount: " + threadCount + " max operations: " + maxOperations);
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/helpers/InvocationTestClass.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/helpers/InvocationTestClass.java
@@ -36,7 +36,7 @@ public class InvocationTestClass {
                 + "}" + NEW_LINE;
     }
 
-    @SuppressFBWarnings({"VO_VOLATILE_INCREMENT" })
+    @SuppressFBWarnings({"VO_VOLATILE_INCREMENT"})
     public void shouldBeCalled() {
         invokeCounter++;
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.syntheticmap;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
@@ -25,6 +23,7 @@ import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorkerWithMultipleProbes;
@@ -36,9 +35,7 @@ import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClust
 import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateStringKeys;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateStrings;
 
-public class StringStringSyntheticMapTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(StringStringSyntheticMapTest.class);
+public class StringStringSyntheticMapTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -78,12 +75,12 @@ public class StringStringSyntheticMapTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        LOGGER.info(getOperationCountInformation(hazelcastInstance));
+        logger.info(getOperationCountInformation(hazelcastInstance));
     }
 
     @Warmup(global = false)
     public void warmup() {
-        waitClusterSize(LOGGER, hazelcastInstance, minNumberOfMembers);
+        waitClusterSize(logger, hazelcastInstance, minNumberOfMembers);
         keys = generateStringKeys(keyCount, keyLength, keyLocality, hazelcastInstance);
         values = generateStrings(valueCount, valueLength);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ITopicTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ITopicTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Creates a number of {@link ITopic} and a number of listeners per topic. Each member publishes messages to every topic.
- *
+ * <p>
  * This test is inherently unreliable because the {@link ITopic} relies on the event system which is unreliable.
  * When messages are published with a too high rate, eventually the event system will drop incoming events.
  */

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ReliableTopicTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ReliableTopicTest.java
@@ -20,8 +20,6 @@ import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
@@ -31,6 +29,7 @@ import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.utils.ExceptionReporter;
@@ -49,9 +48,7 @@ import static com.hazelcast.simulator.utils.UuidUtil.newSecureUuidString;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
-public class ReliableTopicTest {
-
-    private static final ILogger LOGGER = Logger.getLogger(ReliableTopicTest.class);
+public class ReliableTopicTest extends AbstractTest {
 
     // properties
     public String basename = ReliableTopicTest.class.getSimpleName();
@@ -228,7 +225,7 @@ public class ReliableTopicTest {
             values.put(threadId, actualValue);
 
             if (received.getAndIncrement() % 100000 == 0) {
-                LOGGER.info(toString() + " is at " + message.getMessageObject().toString());
+                logger.info(toString() + " is at " + message.getMessageObject().toString());
             }
         }
 


### PR DESCRIPTION
Currently only the Logger has been pulled out. In the future other state can be pulled out like testcontext, HazelcastInstance etc.