### PR TITLE
Simplified test setup

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/common/ShutdownThread.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/ShutdownThread.java
@@ -44,12 +44,12 @@ public abstract class ShutdownThread extends Thread {
     }
 
     ShutdownThread(String name, AtomicBoolean shutdownStarted, boolean shutdownLog4j,
-                             long waitForShutdownTimeoutMillis) {
+                   long waitForShutdownTimeoutMillis) {
         this(name, shutdownStarted, shutdownLog4j, waitForShutdownTimeoutMillis, new CountDownLatch(1));
     }
 
     private ShutdownThread(String name, AtomicBoolean shutdownStarted, boolean shutdownLog4j,
-                             long waitForShutdownTimeoutMillis, CountDownLatch shutdownComplete) {
+                           long waitForShutdownTimeoutMillis, CountDownLatch shutdownComplete) {
         super(name);
         setDaemon(false);
 

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/selector/OperationSelectorBuilder.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/selector/OperationSelectorBuilder.java
@@ -74,7 +74,7 @@ public class OperationSelectorBuilder<T extends Enum<T>> {
     /**
      * Register an operation to be returned when no operation registered via {@link #addOperation(Enum, double)} has been
      * selected.
-     *
+     * <p>
      * All remaining probability will be consumed by this method.
      *
      * @param operation operation to be selected if no other operation is configured

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/tasks/AbstractMonotonicWorker.java
@@ -48,7 +48,7 @@ public abstract class AbstractMonotonicWorker extends VeryAbstractWorker {
 
     /**
      * This method is called for each iteration of {@link #run()}.
-     *
+     * <p>
      * Won't be called if an error occurs in {@link #beforeRun()}.
      *
      * @throws Exception is allowed to throw exceptions which are automatically reported as failure

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/AbstractTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/AbstractTest.java
@@ -15,8 +15,12 @@
  */
 package com.hazelcast.simulator.tests;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.InjectHazelcastInstance;
+import com.hazelcast.simulator.test.annotations.InjectTestContext;
 
 /**
  * An Abstract Test that provides basic behavior so it doesn't need to be repeated for every test.
@@ -27,4 +31,9 @@ public abstract class AbstractTest {
 
     protected final ILogger logger = Logger.getLogger(getClass());
 
+    @InjectHazelcastInstance
+    protected HazelcastInstance targetInstance;
+
+    @InjectTestContext
+    protected TestContext testContext;
 }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/GenericOperationTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/GenericOperationTest.java
@@ -15,13 +15,11 @@
  */
 package com.hazelcast.simulator.tests;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -60,12 +58,9 @@ public class GenericOperationTest extends AbstractTest {
     private final OperationSelectorBuilder<PrioritySelector> operationSelectorBuilder
             = new OperationSelectorBuilder<PrioritySelector>();
 
-    private HazelcastInstance instance;
-
     @Setup
-    public void setUp(TestContext testContext) {
-        instance = testContext.getTargetInstance();
-        operationService = getOperationService(instance);
+    public void setUp() {
+        operationService = getOperationService(targetInstance);
 
         operationSelectorBuilder
                 .addOperation(PrioritySelector.PRIORITY, priorityProb)
@@ -74,7 +69,7 @@ public class GenericOperationTest extends AbstractTest {
 
     @Warmup
     public void warmup() {
-        Set<Member> memberSet = instance.getCluster().getMembers();
+        Set<Member> memberSet = targetInstance.getCluster().getMembers();
         memberAddresses = new Address[memberSet.size()];
 
         int i = 0;
@@ -85,7 +80,7 @@ public class GenericOperationTest extends AbstractTest {
 
     @Teardown
     public void tearDown() {
-        logger.info(getOperationCountInformation(instance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
@@ -17,10 +17,8 @@ package com.hazelcast.simulator.tests.concurrent.atomiclong;
 
 import com.hazelcast.core.AsyncAtomicLong;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -70,12 +68,9 @@ public class AsyncAtomicLongTest extends AbstractTest {
 
     private IAtomicLong totalCounter;
     private AsyncAtomicLong[] counters;
-    private HazelcastInstance targetInstance;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         totalCounter = targetInstance.getAtomicLong(basename + ":TotalCounter");
         if (isMemberNode(targetInstance)) {
             counters = new AsyncAtomicLong[countersLength];

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
@@ -16,9 +16,7 @@
 package com.hazelcast.simulator.tests.concurrent.atomiclong;
 
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -54,15 +52,12 @@ public class AtomicLongTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> builder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private AtomicLong operationsCounter = new AtomicLong();
     private IAtomicLong totalCounter;
     private IAtomicLong[] counters;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         totalCounter = targetInstance.getAtomicLong(basename + ":TotalCounter");
         counters = new IAtomicLong[countersLength];
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomicreference/AtomicReferenceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomicreference/AtomicReferenceTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.concurrent.atomicreference;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicReference;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -52,14 +50,11 @@ public class AtomicReferenceTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> builder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private IAtomicReference<Object>[] counters;
     private Object[] values;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         values = new Object[valueCount];
         Random random = new Random();
         for (int i = 0; i < valueCount; i++) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LeaseLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LeaseLockTest.java
@@ -15,11 +15,8 @@
  */
 package com.hazelcast.simulator.tests.concurrent.lock;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
-import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -37,13 +34,6 @@ public class LeaseLockTest extends AbstractTest {
     public int maxLeaseTimeMillis = 100;
     public int maxTryTimeMillis = 100;
     public boolean allowZeroMillisRemainingLeaseLockTime = false;
-
-    private HazelcastInstance targetInstance;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-    }
 
     @Verify
     public void verify() {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockConflictTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockConflictTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.concurrent.lock;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ILock;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -46,19 +44,16 @@ public class LockConflictTest extends AbstractTest {
     public int tryLockTimeOutMs = 10;
     public boolean throwException = false;
 
-    private HazelcastInstance hazelcastInstance;
     private IList<Long> list;
-
     private IList<long[]> globalIncrements;
     private IList<LockCounter> globalCounter;
 
     @Setup
-    public void setup(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-        list = hazelcastInstance.getList(basename);
+    public void setup() {
+        list = targetInstance.getList(basename);
 
-        globalIncrements = hazelcastInstance.getList(basename + "res");
-        globalCounter = hazelcastInstance.getList(basename + "report");
+        globalIncrements = targetInstance.getList(basename + "res");
+        globalCounter = targetInstance.getList(basename + "report");
     }
 
     @Warmup(global = true)
@@ -197,7 +192,7 @@ public class LockConflictTest extends AbstractTest {
         }
 
         private ILock getLock(KeyIncrementPair keyIncrementPair) {
-            return hazelcastInstance.getLock(basename + 'l' + keyIncrementPair.key);
+            return targetInstance.getLock(basename + 'l' + keyIncrementPair.key);
         }
 
         @Override

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.concurrent.lock;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ILock;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
@@ -26,6 +24,7 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
 import static java.lang.String.format;
@@ -33,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class LockTest {
+public class LockTest extends AbstractTest {
 
     // properties
     public String basename = LockTest.class.getSimpleName();
@@ -42,12 +41,9 @@ public class LockTest {
     public int amount = 50;
 
     private IAtomicLong lockCounter;
-    private HazelcastInstance targetInstance;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         lockCounter = targetInstance.getAtomicLong(basename + ":LockCounter");
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/SimpleLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/SimpleLockTest.java
@@ -15,12 +15,9 @@
  */
 package com.hazelcast.simulator.tests.concurrent.lock;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ILock;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
-import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.AbstractTest;
@@ -42,14 +39,6 @@ public class SimpleLockTest extends AbstractTest {
     public int threadCount = 10;
 
     private int totalValue = 0;
-    private TestContext testContext;
-    private HazelcastInstance targetInstance;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
-    }
 
     @Warmup(global = true)
     public void warmup() {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/executor/ExecutorTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/executor/ExecutorTest.java
@@ -19,7 +19,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IExecutorService;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -52,13 +51,9 @@ public class ExecutorTest extends AbstractTest {
     private IExecutorService[] executors;
     private IAtomicLong executedCounter;
     private IAtomicLong expectedExecutedCounter;
-    private TestContext testContext;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         executors = new IExecutorService[executorCount];
         for (int i = 0; i < executors.length; i++) {
             executors[i] = targetInstance.getExecutorService(basename + '-' + i);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientResponseTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientResponseTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.external;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.tests.AbstractTest;
@@ -31,18 +29,16 @@ public class ExternalClientResponseTest extends AbstractTest {
     public String basename = "externalClientsFinished";
     public int delaySeconds = 60;
 
-    private HazelcastInstance hazelcastInstance;
     private ICountDownLatch clientsFinished;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-        clientsFinished = hazelcastInstance.getCountDownLatch(basename);
+    public void setUp() {
+        clientsFinished = targetInstance.getCountDownLatch(basename);
     }
 
     @Run
     public void run() {
-        if (isMemberNode(hazelcastInstance)) {
+        if (isMemberNode(targetInstance)) {
             return;
         }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientStarterTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientStarterTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.external;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.simulator.common.SimulatorProperties;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.tests.AbstractTest;
@@ -40,14 +38,12 @@ public class ExternalClientStarterTest extends AbstractTest {
     private final SimulatorProperties properties = new SimulatorProperties();
     private final Bash bash = new Bash(properties);
 
-    private HazelcastInstance hazelcastInstance;
     private String ipAddress;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-        if (isClient(hazelcastInstance)) {
-            hazelcastInstance.getAtomicLong("externalClientsStarted").addAndGet(processCount);
+    public void setUp() {
+        if (isClient(targetInstance)) {
+            targetInstance.getAtomicLong("externalClientsStarted").addAndGet(processCount);
         }
         ipAddress = testContext.getPublicIpAddress();
 
@@ -57,7 +53,7 @@ public class ExternalClientStarterTest extends AbstractTest {
 
     @Run
     public void run() {
-        if (isMemberNode(hazelcastInstance)) {
+        if (isMemberNode(targetInstance)) {
             return;
         }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/external/ExternalClientTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.external;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -45,24 +43,21 @@ public class ExternalClientTest extends AbstractTest {
     @InjectProbe
     private Probe externalClientProbe;
 
-    private HazelcastInstance hazelcastInstance;
     private boolean isExternalResultsCollectorInstance;
     private ICountDownLatch clientsRunning;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-
-        if (isMemberNode(hazelcastInstance)) {
+    public void setUp() {
+        if (isMemberNode(targetInstance)) {
             return;
         }
 
         // init ICountDownLatch with waitForClientsCount
-        clientsRunning = hazelcastInstance.getCountDownLatch(basename);
+        clientsRunning = targetInstance.getCountDownLatch(basename);
         setCountDownLatch(clientsRunning, waitForClientsCount);
 
         // determine one instance per cluster
-        if (hazelcastInstance.getMap(basename).putIfAbsent(basename, true) == null) {
+        if (targetInstance.getMap(basename).putIfAbsent(basename, true) == null) {
             isExternalResultsCollectorInstance = true;
             logger.info("This instance will collect all probe results from external clients");
         } else {
@@ -72,7 +67,7 @@ public class ExternalClientTest extends AbstractTest {
 
     @Run
     public void run() throws ExecutionException, InterruptedException {
-        if (isMemberNode(hazelcastInstance)) {
+        if (isMemberNode(targetInstance)) {
             return;
         }
 
@@ -101,8 +96,8 @@ public class ExternalClientTest extends AbstractTest {
 
         // get probe results
         logger.info("Collecting results from external clients...");
-        getThroughputResults(hazelcastInstance, expectedResultSize);
-        getLatencyResults(hazelcastInstance, externalClientProbe, expectedResultSize);
+        getThroughputResults(targetInstance, expectedResultSize);
+        getLatencyResults(targetInstance, externalClientProbe, expectedResultSize);
         logger.info("Result collecting ExternalClientTest done!");
     }
 }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -72,11 +70,10 @@ public class AddRemoveListenerICacheTest extends AbstractTest {
     private MutableCacheEntryListenerConfiguration<Integer, Long> listenerConfiguration;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        results = hazelcastInstance.getList(basename);
+    public void setup() {
+        results = targetInstance.getList(basename);
 
-        cacheManager = createCacheManager(hazelcastInstance);
+        cacheManager = createCacheManager(targetInstance);
         cacheManager.getCache(basename);
 
         builder.addOperation(Operation.REGISTER, registerProb)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
@@ -16,14 +16,13 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -44,7 +43,7 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
  * Setting {@link #batchSize} to values greater than 1 causes the batch-effect to kick-in, pipe-lines are utilized better
  * and overall throughput goes up.
  */
-public class BatchingICacheTest {
+public class BatchingICacheTest extends AbstractTest {
 
     private enum Operation {
         PUT,
@@ -62,12 +61,9 @@ public class BatchingICacheTest {
     private ICache<Object, Object> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+    public void setup() {
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cache = (ICache<Object, Object>) cacheManager.getCache(basename);
-
         operationSelectorBuilder.addOperation(Operation.PUT, writeProb).addDefaultOperation(Operation.GET);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CacheLoaderTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CacheLoaderTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -62,9 +60,8 @@ public class CacheLoaderTest extends AbstractTest {
     private Cache<Integer, Integer> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        loaderList = hazelcastInstance.getList(basename + "loaders");
+    public void setup() {
+        loaderList = targetInstance.getList(basename + "loaders");
 
         config = new MutableConfiguration<Integer, Integer>();
         config.setReadThrough(true);
@@ -73,7 +70,7 @@ public class CacheLoaderTest extends AbstractTest {
         recordingCacheLoader.loadAllDelayMs = loadAllDelayMs;
         config.setCacheLoaderFactory(FactoryBuilder.factoryOf(recordingCacheLoader));
 
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cacheManager.createCache(basename, config);
         cache = cacheManager.getCache(basename);
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
@@ -15,15 +15,14 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -42,7 +41,7 @@ import static org.junit.Assert.assertEquals;
  * <p>
  * Locally we keep track of all increments. We verify if the sum of these local increments matches the global increment.
  */
-public class CasICacheTest {
+public class CasICacheTest extends AbstractTest {
 
     public String basename = CasICacheTest.class.getSimpleName();
     public int keyCount = 1000;
@@ -51,11 +50,10 @@ public class CasICacheTest {
     private Cache<Integer, Long> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        resultsPerWorker = hazelcastInstance.getList(basename);
+    public void setup() {
+        resultsPerWorker = targetInstance.getList(basename);
 
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cache = cacheManager.getCache(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ConcurrentCreateICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ConcurrentCreateICacheTest.java
@@ -16,9 +16,7 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -44,16 +42,15 @@ public class ConcurrentCreateICacheTest extends AbstractTest {
     private IList<Counter> counterList;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        counterList = hazelcastInstance.getList(baseName);
+    public void setup() {
+        counterList = targetInstance.getList(baseName);
 
         CacheConfig config = new CacheConfig();
         config.setName(baseName);
 
         Counter counter = new Counter();
         try {
-            CacheManager cacheManager = createCacheManager(hazelcastInstance);
+            CacheManager cacheManager = createCacheManager(targetInstance);
             cacheManager.createCache(baseName, config);
             counter.create++;
         } catch (CacheException e) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CreateDestroyICacheTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -57,11 +55,10 @@ public class CreateDestroyICacheTest extends AbstractTest {
     private CacheManager cacheManager;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        counters = hazelcastInstance.getList(basename);
+    public void setup() {
+        counters = targetInstance.getList(basename);
 
-        cacheManager = createCacheManager(hazelcastInstance);
+        cacheManager = createCacheManager(targetInstance);
 
         builder.addOperation(Operation.CREATE_CACHE, createCacheProb)
                 .addOperation(Operation.PUT_CACHE, putCacheProb)
@@ -69,8 +66,8 @@ public class CreateDestroyICacheTest extends AbstractTest {
                 .addOperation(Operation.DESTROY_CACHE, destroyCacheProb);
     }
 
-    @Verify(global = true)
-    public void verify() {
+    @Verify
+    public void globalVerify() {
         ICacheCreateDestroyCounter total = new ICacheCreateDestroyCounter();
         for (ICacheCreateDestroyCounter counter : counters) {
             total.add(counter);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
@@ -15,15 +15,14 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
@@ -40,7 +39,7 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
 import static com.hazelcast.simulator.utils.CommonUtils.sleepMillis;
 import static org.junit.Assert.assertEquals;
 
-public class EntryProcessorICacheTest {
+public class EntryProcessorICacheTest extends AbstractTest {
 
     // properties
     public String basename = EntryProcessorICacheTest.class.getSimpleName();
@@ -52,11 +51,10 @@ public class EntryProcessorICacheTest {
     private Cache<Integer, Long> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        resultsPerWorker = hazelcastInstance.getList(basename + ":ResultMap");
+    public void setup() {
+        resultsPerWorker = targetInstance.getList(basename + ":ResultMap");
 
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cache = cacheManager.getCache(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryICacheTest.java
@@ -16,8 +16,6 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -46,9 +44,8 @@ public class ExpiryICacheTest extends AbstractTest {
     private ICache<Integer, Integer> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        cache = getCache(hazelcastInstance, basename);
+    public void setup() {
+        cache = getCache(targetInstance, basename);
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ExpiryTest.java
@@ -16,9 +16,7 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -68,10 +66,9 @@ public class ExpiryTest extends AbstractTest {
     private IList<Counter> results;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        cache = getCache(hazelcastInstance, basename);
-        results = hazelcastInstance.getList(basename);
+    public void setup() {
+        cache = getCache(targetInstance, basename);
+        results = targetInstance.getList(basename);
 
         operationSelectorBuilder
                 .addOperation(Operation.PUT, putProb)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ListenerICacheTest.java
@@ -16,9 +16,7 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -84,12 +82,11 @@ public class ListenerICacheTest extends AbstractTest {
     private ICacheEntryEventFilter<Integer, Long> filter;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        results = hazelcastInstance.getList(basename);
-        listeners = hazelcastInstance.getList(basename + "listeners");
+    public void setup() {
+        results = targetInstance.getList(basename);
+        listeners = targetInstance.getList(basename + "listeners");
 
-        cache = CacheUtils.getCache(hazelcastInstance, basename);
+        cache = CacheUtils.getCache(targetInstance, basename);
         listener = new ICacheEntryListener<Integer, Long>();
         filter = new ICacheEntryEventFilter<Integer, Long>();
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/MangleICacheTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -67,13 +65,11 @@ public class MangleICacheTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance hazelcastInstance;
     private IList<ICacheOperationCounter> results;
 
     @Setup
-    public void setup(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-        results = hazelcastInstance.getList(basename);
+    public void setup() {
+        results = targetInstance.getList(basename);
 
         operationSelectorBuilder.addOperation(Operation.CREATE_CACHE_MANAGER, createCacheManagerProb)
                 .addOperation(Operation.CLOSE_CACHE_MANAGER, cacheManagerCloseProb)
@@ -84,8 +80,8 @@ public class MangleICacheTest extends AbstractTest {
                 .addOperation(Operation.CLOSE_CACHE, closeCacheProb);
     }
 
-    @Verify(global = true)
-    public void verify() {
+    @Verify
+    public void globalVerify() {
         ICacheOperationCounter total = new ICacheOperationCounter();
         for (ICacheOperationCounter counter : results) {
             total.add(counter);
@@ -234,7 +230,7 @@ public class MangleICacheTest extends AbstractTest {
                 currentCachingProvider = cacheManager.getCachingProvider();
                 cacheManager.close();
             }
-            cacheManager = CacheUtils.createCacheManager(hazelcastInstance, currentCachingProvider);
+            cacheManager = CacheUtils.createCacheManager(targetInstance, currentCachingProvider);
         }
 
         private Cache<Integer, Integer> getCacheIfExists(int cacheNumber) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
@@ -15,13 +15,12 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
@@ -35,7 +34,7 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
 /**
  * A performance test for the cache. The key is integer and value is a integer
  */
-public class PerformanceICacheTest {
+public class PerformanceICacheTest extends AbstractTest {
 
 
     private enum Operation {
@@ -53,10 +52,8 @@ public class PerformanceICacheTest {
     private Cache<Object, Object> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+    public void setup() {
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cache = cacheManager.getCache(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ReadWriteICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/ReadWriteICacheTest.java
@@ -16,9 +16,7 @@
 package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -67,9 +65,8 @@ public class ReadWriteICacheTest extends AbstractTest {
     private Cache<Integer, Integer> cache;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        counters = hazelcastInstance.getList(basename + "counters");
+    public void setup() {
+        counters = targetInstance.getList(basename + "counters");
 
         RecordingCacheLoader<Integer> loader = new RecordingCacheLoader<Integer>();
         loader.loadDelayMs = getDelayMs;
@@ -84,7 +81,7 @@ public class ReadWriteICacheTest extends AbstractTest {
         config.setCacheLoaderFactory(FactoryBuilder.factoryOf(loader));
         config.setCacheWriterFactory(FactoryBuilder.factoryOf(writer));
 
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cacheManager.createCache(basename, config);
         cache = cacheManager.getCache(basename);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.icache;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -60,16 +58,13 @@ public class StringICacheTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance hazelcastInstance;
     private Cache<String, String> cache;
     private String[] keys;
     private String[] values;
 
     @Setup
-    public void setup(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-
-        CacheManager cacheManager = createCacheManager(hazelcastInstance);
+    public void setup() {
+        CacheManager cacheManager = createCacheManager(targetInstance);
         cache = cacheManager.getCache(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)
@@ -81,11 +76,11 @@ public class StringICacheTest extends AbstractTest {
         cache.close();
     }
 
-    @Warmup(global = false)
+    @Warmup
     public void warmup() {
-        waitClusterSize(logger, hazelcastInstance, minNumberOfMembers);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
 
-        keys = generateStringKeys(keyCount, keyLength, keyLocality, hazelcastInstance);
+        keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);
         values = generateStrings(valueCount, valueLength);
 
         Random random = new Random();

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/jmx/PartitionServiceMBeanTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/jmx/PartitionServiceMBeanTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.jmx;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -47,13 +45,10 @@ public class PartitionServiceMBeanTest extends AbstractTest {
 
     private MBeanServer mBeanServer;
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
-    private HazelcastInstance targetInstance;
     private ObjectName name;
 
     @Setup
-    public void setUp(TestContext testContext) throws Exception {
-        targetInstance = testContext.getTargetInstance();
-
+    public void setUp() throws Exception {
         this.mBeanServer = ManagementFactory.getPlatformMBeanServer();
         this.name = new ObjectName("com.hazelcast:instance=" + targetInstance.getName()
                 + ",name=" + targetInstance.getName() + ",type=HazelcastInstance.PartitionServiceMBean");

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllEntrySetTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllEntrySetTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -53,11 +51,9 @@ public class AllEntrySetTest extends AbstractTest {
     public boolean usePredicate = false;
 
     private IMap<String, String> map;
-    private HazelcastInstance targetInstance;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.targetInstance = testContext.getTargetInstance();
+    public void setup() {
         this.map = targetInstance.getMap(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllKeySetTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllKeySetTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -52,11 +50,9 @@ public class AllKeySetTest extends AbstractTest {
     public boolean usePredicate = false;
 
     private IMap<String, String> map;
-    private HazelcastInstance targetInstance;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.targetInstance = testContext.getTargetInstance();
+    public void setup() {
         this.map = targetInstance.getMap(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllValuesTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllValuesTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -52,11 +50,9 @@ public class AllValuesTest extends AbstractTest {
     public boolean usePredicate = false;
 
     private IMap<String, String> map;
-    private HazelcastInstance targetInstance;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.targetInstance = testContext.getTargetInstance();
+    public void setup() {
         this.map = targetInstance.getMap(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
 import com.hazelcast.query.extractor.ValueReader;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
@@ -70,7 +69,7 @@ public class ExtractorMapTest extends AbstractTest {
     private IMap<Integer, Object> map;
 
     @Setup
-    public void setUp(TestContext testContext) {
+    public void setUp() {
         String mapName = usePortable ? "Portable " + basename : basename;
         map = testContext.getTargetInstance().getMap(mapName);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/GrowingMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/GrowingMapTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IdGenerator;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
@@ -45,17 +43,13 @@ public class GrowingMapTest extends AbstractTest {
     public boolean removeOnStop = true;
     public boolean readValidation = true;
 
-    private TestContext testContext;
     private IdGenerator idGenerator;
     private IMap<Long, Long> map;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-
-        HazelcastInstance hazelcastInstance = testContext.getTargetInstance();
-        idGenerator = hazelcastInstance.getIdGenerator(basename + ":IdGenerator");
-        map = hazelcastInstance.getMap(basename);
+    public void setup() {
+        idGenerator = targetInstance.getIdGenerator(basename + ":IdGenerator");
+        map = targetInstance.getMap(basename);
     }
 
     @Run

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -58,14 +56,12 @@ public class IntIntMapTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private IMap<Integer, Integer> map;
 
     private int[] keys;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getMap(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb).addDefaultOperation(Operation.GET);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapDataIntegrityTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapDataIntegrityTest.java
@@ -17,12 +17,10 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -50,9 +48,6 @@ public class MapDataIntegrityTest extends AbstractTest {
     public boolean mapLoad = true;
     public boolean doRunAsserts = true;
 
-    private TestContext testContext;
-    private HazelcastInstance targetInstance;
-
     private IMap<Integer, byte[]> integrityMap;
     private IMap<Integer, byte[]> stressMap;
 
@@ -60,10 +55,7 @@ public class MapDataIntegrityTest extends AbstractTest {
     private byte[] value;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         integrityMap = targetInstance.getMap(basename + "Integrity");
         stressMap = targetInstance.getMap(basename + "Stress");
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEvictAndStoreTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEvictAndStoreTest.java
@@ -17,10 +17,8 @@ package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -41,13 +39,11 @@ public class MapEvictAndStoreTest extends AbstractTest {
     // properties
     public String basename = MapEvictAndStoreTest.class.getSimpleName();
 
-    private HazelcastInstance targetInstance;
     private IMap<Long, String> map;
     private IAtomicLong keyCounter;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setup() {
         map = targetInstance.getMap(basename);
         keyCounter = targetInstance.getAtomicLong(basename);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapMaxSizeTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapMaxSizeTest.java
@@ -16,10 +16,8 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.config.MaxSizeConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -70,14 +68,12 @@ public class MapMaxSizeTest extends AbstractTest {
     private final OperationSelectorBuilder<MapPutOperation> mapPutOperationSelectorBuilder
             = new OperationSelectorBuilder<MapPutOperation>();
 
-    private HazelcastInstance targetInstance;
     private IMap<Object, Object> map;
     private IList<MapMaxSizeOperationCounter> operationCounterList;
     private int maxSizePerNode;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getMap(basename);
         operationCounterList = targetInstance.getList(basename + "OperationCounter");
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllOnTheFlyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllOnTheFlyTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -43,12 +41,10 @@ public class MapPutAllOnTheFlyTest extends AbstractTest {
     public int batchSize = 10;
     public int keyRange = 1000000;
 
-    private HazelcastInstance targetInstance;
     private IMap<Integer, Integer> map;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getMap(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -63,13 +61,11 @@ public class MapPutAllTest extends AbstractTest {
     // if we want to use putAll() or put() in a loop (this is a nice setting to see what kind of speedup or slowdown to expect)
     public boolean usePutAll = true;
 
-    private HazelcastInstance targetInstance;
     private IMap<Object, Object> map;
     private Map<Object, Object>[] inputMaps;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getMap(basename);
     }
 
@@ -83,7 +79,7 @@ public class MapPutAllTest extends AbstractTest {
         }
     }
 
-    @Warmup(global = false)
+    @Warmup
     @SuppressWarnings("unchecked")
     public void warmup() {
         Object[] keys = keyType.generateKeys(targetInstance, keyLocality, keyCount, keySize);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapReduceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapReduceTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
@@ -29,7 +28,6 @@ import com.hazelcast.mapreduce.KeyValueSource;
 import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -65,14 +63,11 @@ public class MapReduceTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private IMap<Integer, Employee> map;
     private IList<MapReduceOperationCounter> operationCounterList;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-
+    public void setUp() {
         map = targetInstance.getMap(baseName);
         operationCounterList = targetInstance.getList(baseName + "OperationCounter");
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapStoreTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapStoreTest.java
@@ -16,10 +16,8 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.config.MapStoreConfig;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -95,13 +93,11 @@ public class MapStoreTest extends AbstractTest {
     private int putTTlKeyDomain;
     private int putTTlKeyRange;
 
-    private HazelcastInstance targetInstance;
     private IMap<Integer, Integer> map;
     private IList<MapOperationCounter> operationCounterList;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setup() {
         putTTlKeyDomain = keyCount;
         putTTlKeyRange = keyCount;
 
@@ -128,7 +124,7 @@ public class MapStoreTest extends AbstractTest {
         assertMapStoreConfiguration(logger, targetInstance, basename, MapStoreWithCounter.class);
     }
 
-    @Verify(global = true)
+    @Verify
     public void globalVerify() {
         MapOperationCounter total = new MapOperationCounter();
         for (MapOperationCounter operationCounter : operationCounterList) {
@@ -192,31 +188,25 @@ public class MapStoreTest extends AbstractTest {
                 case LOAD_ALL:
                     map.loadAll(true);
                     break;
-
                 case PUT:
                     putOperation(key);
                     break;
-
                 case GET:
                     map.get(key);
                     operationCounter.getCount.incrementAndGet();
                     break;
-
                 case GET_ASYNC:
                     map.getAsync(key);
                     operationCounter.getAsyncCount.incrementAndGet();
                     break;
-
                 case DELETE:
                     map.delete(key);
                     operationCounter.deleteCount.incrementAndGet();
                     break;
-
                 case DESTROY:
                     map.destroy();
                     operationCounter.destroyCount.incrementAndGet();
                     break;
-
                 default:
                     throw new UnsupportedOperationException();
             }
@@ -230,24 +220,20 @@ public class MapStoreTest extends AbstractTest {
                     map.put(key, value);
                     operationCounter.putCount.incrementAndGet();
                     break;
-
                 case PUT_ASYNC:
                     map.putAsync(key, value);
                     operationCounter.putAsyncCount.incrementAndGet();
                     break;
-
                 case PUT_TTL:
                     int delayKey = putTTlKeyDomain + randomInt(putTTlKeyRange);
                     int delayMs = minTTLExpiryMs + randomInt(maxTTLExpiryMs);
                     map.putTransient(delayKey, value, delayMs, TimeUnit.MILLISECONDS);
                     operationCounter.putTransientCount.incrementAndGet();
                     break;
-
                 case PUT_IF_ABSENT:
                     map.putIfAbsent(key, value);
                     operationCounter.putIfAbsentCount.incrementAndGet();
                     break;
-
                 case REPLACE:
                     Integer orig = map.get(key);
                     if (orig != null) {
@@ -255,7 +241,6 @@ public class MapStoreTest extends AbstractTest {
                         operationCounter.replaceCount.incrementAndGet();
                     }
                     break;
-
                 default:
                     throw new UnsupportedOperationException();
             }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTTLSaturationTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTTLSaturationTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -42,8 +41,8 @@ public class MapTTLSaturationTest extends AbstractTest {
     private IMap<Long, Long> map;
 
     @Setup
-    public void setup(TestContext testContext) {
-        map = testContext.getTargetInstance().getMap(basename);
+    public void setup() {
+        map = targetInstance.getMap(basename);
     }
 
     @Verify(global = false)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTimeToLiveTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -71,8 +69,7 @@ public class MapTimeToLiveTest extends AbstractTest {
     private IList<MapOperationCounter> results;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
+    public void setup() {
         map = targetInstance.getMap(basename);
         results = targetInstance.getList(basename + "report");
 
@@ -83,7 +80,7 @@ public class MapTimeToLiveTest extends AbstractTest {
                 .addOperation(Operation.DESTROY, destroyProb);
     }
 
-    @Verify(global = true)
+    @Verify
     public void globalVerify() {
         MapOperationCounter total = new MapOperationCounter();
         for (MapOperationCounter counter : results) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextConflictTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextConflictTest.java
@@ -15,13 +15,10 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
-import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.AbstractTest;
@@ -55,15 +52,6 @@ public class MapTransactionContextConflictTest extends AbstractTest {
     public int maxKeysPerTxn = 5;
     public boolean throwCommitException = false;
     public boolean throwRollBackException = false;
-
-    private HazelcastInstance targetInstance;
-    private TestContext testContext;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
-    }
 
     @Warmup(global = true)
     public void warmup() {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextTest.java
@@ -15,11 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
-import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 import com.hazelcast.transaction.TransactionContext;
@@ -36,13 +33,6 @@ public class MapTransactionContextTest extends AbstractTest {
     public int range = 1000;
     public boolean failOnException = true;
 
-    private HazelcastInstance hz;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        hz = testContext.getTargetInstance();
-    }
-
     @RunWithWorker
     public Worker createWorker() {
         return new Worker();
@@ -58,7 +48,7 @@ public class MapTransactionContextTest extends AbstractTest {
                     .setTransactionType(transactionType)
                     .setDurability(durability);
 
-            TransactionContext transactionContext = hz.newTransactionContext(transactionOptions);
+            TransactionContext transactionContext = targetInstance.newTransactionContext(transactionOptions);
 
             transactionContext.beginTransaction();
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionGetForUpdateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionGetForUpdateTest.java
@@ -15,13 +15,10 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
-import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.AbstractTest;
@@ -51,15 +48,6 @@ public class MapTransactionGetForUpdateTest extends AbstractTest {
     public boolean rethrowRollBackException = false;
     public TransactionOptions.TransactionType transactionType = TransactionOptions.TransactionType.TWO_PHASE;
     public int durability = 1;
-
-    private HazelcastInstance targetInstance;
-    private TestContext testContext;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
-    }
 
     @Warmup(global = true)
     public void warmup() {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
@@ -15,11 +15,9 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -61,13 +59,11 @@ public class MapTransactionReadWriteTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> builder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private IMap<Integer, Integer> map;
     private int[] keys;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setup() {
         map = targetInstance.getMap(basename);
 
         builder.addOperation(Operation.PUT, putProb).addDefaultOperation(Operation.GET);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionTest.java
@@ -15,11 +15,9 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -51,14 +49,12 @@ public class MapTransactionTest extends AbstractTest {
     public int durability = 1;
     public boolean getForUpdate = true;
 
-    private HazelcastInstance targetInstance;
     private IMap<Integer, Long> map;
     private IList<long[]> resultList;
     private TransactionOptions transactionOptions;
 
     @Setup
-    public void setup(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setup() {
         map = targetInstance.getMap(basename);
         resultList = targetInstance.getList(basename + "results");
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SplitClusterDataTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SplitClusterDataTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -37,14 +35,10 @@ public class SplitClusterDataTest extends AbstractTest {
     public int clusterSize = -1;
     public int splitClusterSize = -1;
 
-    private TestContext testContext;
-    private HazelcastInstance targetInstance;
     private IMap<Object, Object> map;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
+    public void setup() {
         map = targetInstance.getMap(basename);
 
         if (clusterSize == -1 || splitClusterSize == -1) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.SqlPredicate;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
@@ -52,11 +50,9 @@ public class SqlPredicateTest extends AbstractTest {
     public double maxSalary = 1000.0;
 
     private IMap<String, DataSerializableEmployee> map;
-    private HazelcastInstance targetInstance;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.targetInstance = testContext.getTargetInstance();
+    public void setup() {
         this.map = targetInstance.getMap(basename);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapMonotonicTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapMonotonicTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -64,15 +62,13 @@ public class StringStringMapMonotonicTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private IMap<String, String> map;
 
     private String[] keys;
     private String[] values;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getMap(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -59,16 +57,14 @@ public class StringStringMapTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private IMap<String, String> map;
 
     private String[] keys;
     private String[] values;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
-        map = targetInstance.getMap(basename);
+    public void setUp() {
+         map = targetInstance.getMap(basename);
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)
                 .addOperation(Operation.SET, setProb)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ScrambledZipfianGenerator.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ScrambledZipfianGenerator.java
@@ -24,7 +24,7 @@ import static com.hazelcast.simulator.tests.map.helpers.ZipfianUtils.hashFNV64;
  * to draw from, either by specifying an itemCount (so that the sequence is of items from 0 to itemCount - 1) or by specifying a
  * min and a max (so that the sequence is of items from min to max inclusive). After you construct the instance, you can change
  * the number of items by calling {@link #nextInt()} or {@link #nextLong()}.
- *
+ * <p>
  * Unlike @ZipfianGenerator, this class scatters the "popular" items across the item space. Use this, instead of
  * {@link ZipfianGenerator}, if you don't want the head of the distribution (the popular items) clustered together.
  */

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ZipfianGenerator.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ZipfianGenerator.java
@@ -27,17 +27,17 @@ import static java.lang.String.format;
  * to draw from, either by specifying an itemCount (so that the sequence is of items from 0 to itemCount - 1) or by specifying a
  * min and a max (so that the sequence is of items from min to max inclusive). After you construct the instance, you can change
  * the number of items by calling {@link #nextInt()} or {@link #nextLong()}.
- *
+ * <p>
  * Note that the popular items will be clustered together, e.g. item 0 is the most popular, item 1 the second most popular, and so
  * on (or min is the most popular, min + 1 the next most popular, etc.) If you don't want this clustering, and instead want the
  * popular items scattered throughout the item space, then use {@link ScrambledZipfianGenerator} instead.
- *
+ * <p>
  * Be aware: initializing this generator may take a long time if there are lots of items to choose from (e.g. over a minute for
  * 100 million objects). This is because certain mathematical values need to be computed to properly generate a zipfian skew, and
  * one of those values (zeta) is a sum sequence from 1 to n, where n is the itemCount. Note that if you increase the number of
  * items in the set, we can compute a new zeta incrementally, so it should be fast unless you have added millions of items.
  * However, if you decrease the number of items, we recompute zeta from scratch, so this can take a long time.
- *
+ * <p>
  * The algorithm used here is from "Quickly Generating Billion-Record Synthetic Databases", Jim Gray et al, SIGMOD 1994.
  */
 @SuppressWarnings("unused")

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/ProducerConsumerTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/ProducerConsumerTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.queue;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -44,13 +42,9 @@ public class ProducerConsumerTest extends AbstractTest {
     private IAtomicLong produced;
     private IQueue<Work> workQueue;
     private IAtomicLong consumed;
-    private TestContext testContext;
 
     @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         produced = targetInstance.getAtomicLong(basename + ":Produced");
         consumed = targetInstance.getAtomicLong(basename + ":Consumed");
         workQueue = targetInstance.getQueue(basename + ":WorkQueue");

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/QueueTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/QueueTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.queue;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -44,16 +42,11 @@ public class QueueTest extends AbstractTest {
     public int logFrequency = 200;
 
     private final AtomicLong totalCounter = new AtomicLong(0);
-
-    private TestContext testContext;
     private IQueue<Long>[] queues;
 
     @Setup
     @SuppressWarnings("unchecked")
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         queues = new IQueue[queueLength];
 
         // the KeyLocality has to be RANDOM here, since we need different queues on each Worker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/TxnQueueWithLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/queue/TxnQueueWithLockTest.java
@@ -15,15 +15,12 @@
  */
 package com.hazelcast.simulator.tests.queue;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ILock;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.TransactionalQueue;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.Run;
-import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.TxnCounter;
@@ -39,15 +36,6 @@ public class TxnQueueWithLockTest extends AbstractTest {
 
     public String basename = TxnQueueWithLockTest.class.getSimpleName();
     public int threadCount = 5;
-
-    private HazelcastInstance instance = null;
-    private TestContext testContext = null;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        this.instance = testContext.getTargetInstance();
-    }
 
     @Run
     public void run() {
@@ -65,17 +53,17 @@ public class TxnQueueWithLockTest extends AbstractTest {
         public void run() {
             while (!testContext.isStopped()) {
                 try {
-                    ILock firstLock = instance.getLock(basename + "l1");
+                    ILock firstLock = targetInstance.getLock(basename + "l1");
                     firstLock.lock();
 
-                    TransactionContext ctx = instance.newTransactionContext();
+                    TransactionContext ctx = targetInstance.newTransactionContext();
                     try {
                         ctx.beginTransaction();
 
                         TransactionalQueue<Integer> queue = ctx.getQueue(basename + 'q');
                         queue.offer(1);
 
-                        ILock secondLock = instance.getLock(basename + "l2");
+                        ILock secondLock = targetInstance.getLock(basename + "l2");
                         secondLock.lock();
                         secondLock.unlock();
 
@@ -101,18 +89,18 @@ public class TxnQueueWithLockTest extends AbstractTest {
                     logger.severe(basename + ": outer Exception" + counter, e);
                 }
             }
-            IList<TxnCounter> results = instance.getList(basename + "results");
+            IList<TxnCounter> results = targetInstance.getList(basename + "results");
             results.add(counter);
         }
     }
 
     @Verify(global = true)
     public void verify() {
-        IQueue queue = instance.getQueue(basename + 'q');
-        ILock firstLock = instance.getLock(basename + "l1");
-        ILock secondLock = instance.getLock(basename + "l2");
+        IQueue queue = targetInstance.getQueue(basename + 'q');
+        ILock firstLock = targetInstance.getLock(basename + "l1");
+        ILock secondLock = targetInstance.getLock(basename + "l2");
 
-        IList<TxnCounter> results = instance.getList(basename + "results");
+        IList<TxnCounter> results = targetInstance.getList(basename + "results");
 
         TxnCounter total = new TxnCounter();
         for (TxnCounter counter : results) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.replicatedmap;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -55,14 +53,12 @@ public class ReplicatedMapTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance targetInstance;
     private ReplicatedMap<Integer, String> map;
 
     private String[] values;
 
     @Setup
-    public void setUp(TestContext testContext) throws Exception {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() throws Exception {
         map = testContext.getTargetInstance().getReplicatedMap(basename + "-" + testContext.getTestId());
 
         operationSelectorBuilder.addOperation(Operation.PUT, putProb)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTimeToLiveTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTimeToLiveTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.replicatedmap;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -64,8 +62,7 @@ public class ReplicatedMapTimeToLiveTest extends AbstractTest {
     private IList<MapOperationCounter> results;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
+    public void setup() {
         map = targetInstance.getReplicatedMap(basename);
         results = targetInstance.getList(basename + "report");
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ClusterStatisticsTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ClusterStatisticsTest.java
@@ -15,10 +15,8 @@
  */
 package com.hazelcast.simulator.tests.special;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.PartitionService;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Warmup;
@@ -36,20 +34,18 @@ public class ClusterStatisticsTest extends AbstractTest {
     public String basename = ClusterStatisticsTest.class.getSimpleName();
     public int isClusterSafeRetries = 10;
 
-    private HazelcastInstance hazelcastInstance;
     private PartitionService partitionService;
     private IMap<Object, Integer> map;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        this.hazelcastInstance = testContext.getTargetInstance();
-        this.partitionService = hazelcastInstance.getPartitionService();
-        this.map = hazelcastInstance.getMap(basename);
+    public void setUp() {
+        this.partitionService = targetInstance.getPartitionService();
+        this.map = targetInstance.getMap(basename);
     }
 
     @Warmup
     public void warmup() {
-        if (!isMemberNode(hazelcastInstance)) {
+        if (!isMemberNode(targetInstance)) {
             return;
         }
 
@@ -60,7 +56,7 @@ public class ClusterStatisticsTest extends AbstractTest {
         }
         logger.info(basename + ": isClusterSafe() " + partitionService.isClusterSafe());
         logger.info(basename + ": isLocalMemberSafe() " + partitionService.isLocalMemberSafe());
-        logger.info(basename + ": getCluster().getMembers().size() " + hazelcastInstance.getCluster().getMembers().size());
+        logger.info(basename + ": getCluster().getMembers().size() " + targetInstance.getCluster().getMembers().size());
 
         logPartitionStatistics(logger, basename, map, false);
     }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/MapHeapHogWarmupTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/MapHeapHogWarmupTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.special;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
@@ -49,14 +47,12 @@ public class MapHeapHogWarmupTest extends AbstractTest {
     public int ttlHours = 24;
     public double approxHeapUsageFactor = 0.9;
 
-    private HazelcastInstance targetInstance;
     private IMap<Long, Long> map;
 
     private long maxEntriesPerThread;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getMap(basename);
 
         // calculate how many entries we have to insert per member and thread

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/PerformanceMonitorLatencyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/PerformanceMonitorLatencyTest.java
@@ -16,10 +16,9 @@
 package com.hazelcast.simulator.tests.special;
 
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.InjectProbe;
 import com.hazelcast.simulator.test.annotations.Run;
-import com.hazelcast.simulator.test.annotations.Setup;
+import com.hazelcast.simulator.tests.AbstractTest;
 
 import java.util.concurrent.TimeUnit;
 
@@ -28,19 +27,12 @@ import static com.hazelcast.simulator.utils.CommonUtils.sleepMillis;
 /**
  * Used to verify the latency measurement with a superficial constant latency value.
  */
-public class PerformanceMonitorLatencyTest {
+public class PerformanceMonitorLatencyTest extends AbstractTest {
 
     private static final long LATENCY_NANOS = TimeUnit.MICROSECONDS.toNanos(20);
 
     @InjectProbe(useForThroughput = true)
     Probe probe;
-
-    private TestContext testContext;
-
-    @Setup
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-    }
 
     @Run
     public void run() {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -15,9 +15,7 @@
  */
 package com.hazelcast.simulator.tests.syntheticmap;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.simulator.probes.Probe;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -55,16 +53,13 @@ public class StringStringSyntheticMapTest extends AbstractTest {
 
     private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
 
-    private HazelcastInstance hazelcastInstance;
     private SyntheticMap<String, String> map;
 
     private String[] keys;
     private String[] values;
 
     @Setup
-    public void setUp(TestContext testContext) {
-        hazelcastInstance = testContext.getTargetInstance();
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
+    public void setUp() {
         map = targetInstance.getDistributedObject(SyntheticMapService.SERVICE_NAME, "map-" + basename);
 
         operationSelectorBuilder
@@ -75,13 +70,13 @@ public class StringStringSyntheticMapTest extends AbstractTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        logger.info(getOperationCountInformation(hazelcastInstance));
+        logger.info(getOperationCountInformation(targetInstance));
     }
 
-    @Warmup(global = false)
+    @Warmup
     public void warmup() {
-        waitClusterSize(logger, hazelcastInstance, minNumberOfMembers);
-        keys = generateStringKeys(keyCount, keyLength, keyLocality, hazelcastInstance);
+        waitClusterSize(logger, targetInstance, minNumberOfMembers);
+        keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);
         values = generateStrings(valueCount, valueLength);
 
         Random random = new Random();

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ITopicTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ITopicTest.java
@@ -15,17 +15,16 @@
  */
 package com.hazelcast.simulator.tests.topic;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestRunner;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
+import com.hazelcast.simulator.tests.AbstractTest;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.worker.tasks.AbstractMonotonicWorker;
 
@@ -43,7 +42,7 @@ import static org.junit.Assert.assertEquals;
  * This test is inherently unreliable because the {@link ITopic} relies on the event system which is unreliable.
  * When messages are published with a too high rate, eventually the event system will drop incoming events.
  */
-public class ITopicTest {
+public class ITopicTest extends AbstractTest {
 
     // properties
     public String basename = ITopicTest.class.getSimpleName();
@@ -61,9 +60,7 @@ public class ITopicTest {
     private List<TopicListener> listeners;
 
     @Setup
-    public void setup(TestContext testContext) {
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
-
+    public void setup() {
         totalExpectedCounter = targetInstance.getAtomicLong(basename + ":TotalExpectedCounter");
         totalFoundCounter = targetInstance.getAtomicLong(basename + ":TotalFoundCounter");
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ReliableTopicTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/topic/ReliableTopicTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.simulator.tests.topic;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
@@ -24,7 +23,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
@@ -59,14 +57,11 @@ public class ReliableTopicTest extends AbstractTest {
     private AtomicLong failures = new AtomicLong();
     private IAtomicLong totalMessagesSend;
     private ITopic<MessageEntity>[] topics;
-    private TestContext testContext;
     private List<MessageListenerImpl> listeners;
 
     @Setup
     @SuppressWarnings("unchecked")
-    public void setup(TestContext testContext) {
-        this.testContext = testContext;
-        HazelcastInstance targetInstance = testContext.getTargetInstance();
+    public void setup() {
         totalMessagesSend = targetInstance.getAtomicLong(basename + ":TotalExpectedCounter");
         topics = new ITopic[topicCount];
         listeners = new LinkedList<MessageListenerImpl>();


### PR DESCRIPTION
targetInstance & testContext are automatically injected in the AbstractTest.

Everything keeps working for tests that don't care about the AbstractTest. So we don't break anything.