### PR TITLE
Deprecated TestContext.getTargetInstance

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
@@ -24,6 +24,11 @@ public interface TestContext {
      */
     String LOCALHOST = "127.0.0.1";
 
+    /**
+     *
+     * @return
+     * @deprecated since 0.8. Use {@link com.hazelcast.simulator.test.annotations.InjectHazelcastInstance}.
+     */
     HazelcastInstance getTargetInstance();
 
     String getTestId();

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
@@ -73,7 +73,7 @@ public class AsyncAtomicLongTest extends AbstractTest {
         if (isMemberNode(targetInstance)) {
             counters = new AsyncAtomicLong[countersLength];
 
-            String[] names = generateStringKeys(basename, countersLength, keyLocality, testContext.getTargetInstance());
+            String[] names = generateStringKeys(basename, countersLength, keyLocality, targetInstance);
             for (int i = 0; i < countersLength; i++) {
                 counters[i] = (AsyncAtomicLong) targetInstance.getAtomicLong(names[i]);
             }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/atomiclong/AtomicLongTest.java
@@ -59,7 +59,7 @@ public class AtomicLongTest extends AbstractTest {
         totalCounter = targetInstance.getAtomicLong(basename + ":TotalCounter");
         counters = new IAtomicLong[countersLength];
 
-        String[] names = generateStringKeys(basename, countersLength, keyLocality, testContext.getTargetInstance());
+        String[] names = generateStringKeys(basename, countersLength, keyLocality, targetInstance);
         for (int i = 0; i < countersLength; i++) {
             counters[i] = targetInstance.getAtomicLong(names[i]);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
@@ -70,7 +70,7 @@ public class ExtractorMapTest extends AbstractTest {
     @Setup
     public void setUp() {
         String mapName = usePortable ? "Portable " + basename : basename;
-        map = testContext.getTargetInstance().getMap(mapName);
+        map = targetInstance.getMap(mapName);
 
         operationSelectorBuilder
                 .addOperation(Operation.PUT, putProbability)

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/PutAsyncAndThenTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/PutAsyncAndThenTest.java
@@ -46,7 +46,7 @@ public class PutAsyncAndThenTest extends AbstractTest {
     @Setup
     public void setUp() {
         map = targetInstance.getMap(basename);
-        keys = generateStringKeys(basename, keyCount, keyLocality, testContext.getTargetInstance());
+        keys = generateStringKeys(basename, keyCount, keyLocality, targetInstance);
     }
 
     @RunWithWorker

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/FailingTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/FailingTest.java
@@ -73,7 +73,7 @@ public class FailingTest extends AbstractTest {
 
     @Setup
     public void setUp() throws Exception {
-        if (matchingType(type, testContext)) {
+        if (matchingType(type)) {
             isSelected = isSelected(selection, testContext);
         }
 
@@ -175,20 +175,20 @@ public class FailingTest extends AbstractTest {
         logger.severe("We should never reach this code! List size: " + list.size());
     }
 
-    private static boolean matchingType(Type type, TestContext testContext) {
+    private boolean matchingType(Type type) {
         if (type == Type.ALL) {
             return true;
         }
-        if (type == Type.MEMBER && isMemberNode(testContext.getTargetInstance())) {
+        if (type == Type.MEMBER && isMemberNode(targetInstance)) {
             return true;
         }
-        if (type == Type.CLIENT && isClient(testContext.getTargetInstance())) {
+        if (type == Type.CLIENT && isClient(targetInstance)) {
             return true;
         }
         return false;
     }
 
-    private static boolean isSelected(Selection selection, TestContext testContext) {
+    private boolean isSelected(Selection selection, TestContext testContext) {
         switch (selection) {
             case ALL:
                 return true;
@@ -201,7 +201,7 @@ public class FailingTest extends AbstractTest {
         }
     }
 
-    private static IMap<String, Boolean> getMap(TestContext testContext) {
-        return testContext.getTargetInstance().getMap("failureSelection" + testContext.getTestId());
+    private IMap<String, Boolean> getMap(TestContext testContext) {
+        return targetInstance.getMap("failureSelection" + testContext.getTestId());
     }
 }

--- a/tests/tests-hz36/src/main/java/com/hazelcast/simulator/tests/map/PutAsyncAndThenTest.java
+++ b/tests/tests-hz36/src/main/java/com/hazelcast/simulator/tests/map/PutAsyncAndThenTest.java
@@ -46,7 +46,7 @@ public class PutAsyncAndThenTest extends AbstractTest {
     @Setup
     public void setUp() {
         map = targetInstance.getMap(basename);
-        keys = generateStringKeys(basename, keyCount, keyLocality, testContext.getTargetInstance());
+        keys = generateStringKeys(basename, keyCount, keyLocality, targetInstance);
     }
 
     @RunWithWorker


### PR DESCRIPTION
TargetInstance can be acquired using @InjectTargetInstance annotation.

This reduces coupling with the HZ framework. Makes it easier in the future for
other imdg's to be added under simulator.