### PR TITLE
Fixes nested propertybinding issues

### DIFF
--- a/DummyTestRunnerid.java
+++ b/DummyTestRunnerid.java
@@ -1,0 +1,34 @@
+import com.hazelcast.simulator.test.*;
+import com.hazelcast.simulator.test.annotations.*;
+import com.hazelcast.simulator.worker.*;
+import com.hazelcast.simulator.worker.tasks.*;
+import com.hazelcast.simulator.worker.metronome.*;
+import com.hazelcast.simulator.probes.*;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+public class DummyTestRunnerid extends TimeStepRunner {
+
+    public DummyTestRunnerid(com.hazelcast.simulator.test.TestContainer_NestedPropertyBindingTest.DummyTest testInstance, TimeStepModel model) {
+        super(testInstance, model);
+    }
+
+    @Override
+    public void timeStepLoop() throws Exception {
+        final AtomicLong iterations = this.iterations;
+        final TestContextImpl testContext = (TestContextImpl)this.testContext;
+        final com.hazelcast.simulator.test.TestContainer_NestedPropertyBindingTest.DummyTest testInstance = (com.hazelcast.simulator.test.TestContainer_NestedPropertyBindingTest.DummyTest)this.testInstance;
+        final com.hazelcast.simulator.probes.impl.HdrProbe timestepProbe = (com.hazelcast.simulator.probes.impl.HdrProbe)probeMap.get("timestep");
+
+
+        long startNanos;
+        long iteration = 0;
+        while (!testContext.isStopped()) {
+            startNanos = System.nanoTime();
+            testInstance.timestep( );
+            timestepProbe.recordValue(System.nanoTime() - startNanos);
+            iteration++;
+            iterations.lazySet(iteration);
+        }
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/PropertyBindingSupport.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/PropertyBindingSupport.java
@@ -20,8 +20,11 @@ import com.hazelcast.simulator.test.TestCase;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-import static com.hazelcast.simulator.utils.ReflectionUtils.getFieldValueInternal;
+import static com.hazelcast.simulator.utils.ReflectionUtils.getFieldValue0;
 import static java.lang.String.format;
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isPublic;
@@ -58,6 +61,21 @@ public final class PropertyBindingSupport {
         return bind0(instance, propertyName, value);
     }
 
+    public static Set<String> bindAll(Object instance, TestCase testCase) {
+        Set<String> usedProperties = new HashSet<String>();
+
+        for (Map.Entry<String, String> entry : testCase.getProperties().entrySet()) {
+            String fullPropertyPath = entry.getKey().trim();
+            String value = entry.getValue().trim();
+
+            if (bind0(instance, fullPropertyPath, value)) {
+                usedProperties.add(fullPropertyPath);
+            }
+        }
+
+        return usedProperties;
+    }
+
     /**
      * Returns a single property contained in the {@link TestCase} instance.
      * <p>
@@ -85,19 +103,18 @@ public final class PropertyBindingSupport {
 
         String[] path = property.split("\\.");
 
-        object = findPropertyObjectInPath(object, property, path);
-
-        Field field = findPropertyField(object.getClass(), path[path.length - 1]);
-        if (field == null) {
+        object = findTargetObject(object, property, path);
+        if (object == null) {
             return false;
         }
 
-        if (isProbeField(field)) {
+        Field field = findField(object.getClass(), path[path.length - 1]);
+        if (field == null || isProbeField(field)) {
             return false;
         }
 
         try {
-            setValue(object, value, field);
+            setField(field, object, value);
             return true;
         } catch (Exception e) {
             throw new BindException(format("Failed to bind value [%s] to property [%s.%s] of type [%s]",
@@ -105,35 +122,50 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static Object findPropertyObjectInPath(Object object, String property, String[] path) {
-        Field field;
+    private static Object findTargetObject(Object parent, String property, String[] path) {
         for (int i = 0; i < path.length - 1; i++) {
-            Class<?> clazz = object.getClass();
-            String element = path[i];
-            field = findPropertyField(clazz, element);
+            Class<?> clazz = parent.getClass();
+            String fieldName = path[i];
+            Field field = findField(clazz, fieldName);
             if (field == null) {
-                throw new BindException(format("Failed to find field [%s] in property [%s]", element, property));
+                if (i == 0) {
+                    // we have no match at all
+                    return null;
+                } else {
+                    // we found at least one item in the path.
+                    throw new BindException(
+                            format("Failed to find field [%s.%s] in property [%s]", clazz.getName(), fieldName, property));
+                }
             }
-            object = getFieldValueInternal(object, field, clazz.getName(), property);
-            if (object == null) {
-                throw new BindException(format("Failed to bind to property [%s] encountered a null value at field [%s]",
-                        property, field));
+
+            Object child = getFieldValue0(parent, field, clazz.getName(), property);
+            if (child == null) {
+                try {
+                    child = field.getType().newInstance();
+                    field.set(parent, child);
+                } catch (InstantiationException e) {
+                    throw new BindException(format("Failed to initialize null field '%s'", field), e);
+                } catch (IllegalAccessException e) {
+                    throw new BindException(format("Failed to initialize null field '%s'", field), e);
+                }
             }
+
+            parent = child;
         }
-        return object;
+        return parent;
     }
 
-    private static Field findPropertyField(Class clazz, String property) {
+    private static Field findField(Class clazz, String fieldName) {
         try {
-            Field field = clazz.getDeclaredField(property);
+            Field field = clazz.getDeclaredField(fieldName);
             if (!isPublic(field.getModifiers())) {
-                throw new BindException(format("Property [%s.%s] is not public", clazz.getName(), property));
+                throw new BindException(format("Property [%s.%s] is not public", clazz.getName(), fieldName));
             }
             if (isStatic(field.getModifiers())) {
-                throw new BindException(format("Property [%s.%s] is static", clazz.getName(), property));
+                throw new BindException(format("Property [%s.%s] is static", clazz.getName(), fieldName));
             }
             if (isFinal(field.getModifiers())) {
-                throw new BindException(format("Property [%s.%s] is final", clazz.getName(), property));
+                throw new BindException(format("Property [%s.%s] is final", clazz.getName(), fieldName));
             }
             return field;
         } catch (NoSuchFieldException e) {
@@ -141,7 +173,7 @@ public final class PropertyBindingSupport {
             if (superClass == null) {
                 return null;
             }
-            return findPropertyField(superClass, property);
+            return findField(superClass, fieldName);
         }
     }
 
@@ -149,16 +181,10 @@ public final class PropertyBindingSupport {
         return Probe.class.equals(field.getType());
     }
 
-    private static void setValue(Object object, String value, Field field) throws IllegalAccessException {
-        if (setIntegralValue(object, value, field)) {
-            return;
-        }
-
-        if (setFloatingPointValue(object, value, field)) {
-            return;
-        }
-
-        if (setNonNumericValue(object, value, field)) {
+    private static void setField(Field field, Object object, String value) throws IllegalAccessException {
+        if (setIntegralField(field, object, value)
+                || setFloatingPointField(field, object, value)
+                || setNonNumericField(field, object, value)) {
             return;
         }
 
@@ -167,68 +193,68 @@ public final class PropertyBindingSupport {
                         object.getClass().getName(), field.getName(), field.getType()));
     }
 
-    private static boolean setIntegralValue(Object object, String value, Field field) throws IllegalAccessException {
+    private static boolean setIntegralField(Field field, Object object, String value) throws IllegalAccessException {
         if (Byte.TYPE.equals(field.getType())) {
             // primitive byte
             field.set(object, Byte.parseByte(value));
         } else if (Byte.class.equals(field.getType())) {
-            bindByte(object, value, field);
+            setByteField(object, value, field);
         } else if (Short.TYPE.equals(field.getType())) {
             // primitive short
             field.set(object, Short.parseShort(value));
         } else if (Short.class.equals(field.getType())) {
-            bindShort(object, value, field);
+            setShortField(object, value, field);
         } else if (Integer.TYPE.equals(field.getType())) {
             // primitive integer
             field.set(object, Integer.parseInt(value));
         } else if (Integer.class.equals(field.getType())) {
-            bindInteger(object, value, field);
+            setIntegerField(object, value, field);
         } else if (Long.TYPE.equals(field.getType())) {
             // primitive long
             field.set(object, Long.parseLong(value));
         } else if (Long.class.equals(field.getType())) {
-            bindLong(object, value, field);
+            setLongField(object, value, field);
         } else {
             return false;
         }
         return true;
     }
 
-    private static boolean setFloatingPointValue(Object object, String value, Field field) throws IllegalAccessException {
+    private static boolean setFloatingPointField(Field field, Object object, String value) throws IllegalAccessException {
         if (Float.TYPE.equals(field.getType())) {
             // primitive float
             field.set(object, Float.parseFloat(value));
         } else if (Float.class.equals(field.getType())) {
-            bindFloat(object, value, field);
+            setFloatField(object, value, field);
         } else if (Double.TYPE.equals(field.getType())) {
             // primitive double
             field.set(object, Double.parseDouble(value));
         } else if (Double.class.equals(field.getType())) {
-            bindDouble(object, value, field);
+            setDoubleField(object, value, field);
         } else {
             return false;
         }
         return true;
     }
 
-    private static boolean setNonNumericValue(Object object, String value, Field field) throws IllegalAccessException {
+    private static boolean setNonNumericField(Field field, Object object, String value) throws IllegalAccessException {
         if (Boolean.TYPE.equals(field.getType())) {
-            bindPrimitiveBoolean(object, value, field);
+            setPrimitiveBooleanField(object, value, field);
         } else if (Boolean.class.equals(field.getType())) {
-            bindBoolean(object, value, field);
+            setBooleanField(object, value, field);
         } else if (field.getType().isAssignableFrom(Class.class)) {
-            bindClass(object, value, field);
+            setClassField(object, value, field);
         } else if (String.class.equals(field.getType())) {
-            bindString(object, value, field);
+            setStringField(object, value, field);
         } else if (field.getType().isEnum()) {
-            bindEnum(object, value, field);
+            setEnumField(object, value, field);
         } else {
             return false;
         }
         return true;
     }
 
-    private static void bindByte(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setByteField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -236,7 +262,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindShort(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setShortField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -244,7 +270,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindInteger(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setIntegerField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -252,7 +278,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindLong(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setLongField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -260,7 +286,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindFloat(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setFloatField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -268,7 +294,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindDouble(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setDoubleField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -276,7 +302,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindPrimitiveBoolean(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setPrimitiveBooleanField(Object object, String value, Field field) throws IllegalAccessException {
         if ("true".equals(value)) {
             field.set(object, true);
         } else if ("false".equals(value)) {
@@ -286,7 +312,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindBoolean(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setBooleanField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else if ("true".equals(value)) {
@@ -298,7 +324,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindClass(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setClassField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -310,7 +336,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindString(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setStringField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {
@@ -318,7 +344,7 @@ public final class PropertyBindingSupport {
         }
     }
 
-    private static void bindEnum(Object object, String value, Field field) throws IllegalAccessException {
+    private static void setEnumField(Object object, String value, Field field) throws IllegalAccessException {
         if (NULL_LITERAL.equals(value)) {
             field.set(object, null);
         } else {

--- a/simulator/src/test/java/com/hazelcast/simulator/test/AbstractTestContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/AbstractTestContainerTest.java
@@ -16,6 +16,11 @@ abstract class AbstractTestContainerTest {
         return new TestContainer(testContext, test, new TestCase("foo"));
     }
 
+
+    <T> TestContainer createTestContainer(T test, TestCase testCase) {
+        return new TestContainer(testContext, test, testCase);
+    }
+
     public static class BaseTest {
 
         boolean runCalled;

--- a/simulator/src/test/java/com/hazelcast/simulator/test/TestContainer_NestedPropertyBindingTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/TestContainer_NestedPropertyBindingTest.java
@@ -1,0 +1,53 @@
+package com.hazelcast.simulator.test;
+
+import com.hazelcast.simulator.test.annotations.TimeStep;
+import com.hazelcast.simulator.utils.BindException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TestContainer_NestedPropertyBindingTest extends AbstractTestContainerTest {
+
+    @Test
+    public void test() throws Exception {
+        TestCase testCase = new TestCase("id")
+                .setProperty("nested.intField", 10)
+                .setProperty("nested.booleanField", true)
+                .setProperty("nested.stringField", "somestring");
+
+        DummyTest test = new DummyTest();
+
+        testContainer = createTestContainer(test, testCase);
+
+        assertNotNull(test.nested);
+        assertEquals(10, test.nested.intField);
+        assertEquals(true, test.nested.booleanField);
+        assertEquals("somestring", test.nested.stringField);
+    }
+
+
+    @Test(expected = BindException.class)
+    public void testNestedPropertyNotFound() throws Exception {
+        TestCase testCase = new TestCase("id")
+                .setProperty("nested.notexist", 10);
+
+        DummyTest test = new DummyTest();
+        createTestContainer(test, testCase);
+    }
+
+    public class DummyTest {
+        public NestedProperties nested = new NestedProperties();
+
+        @TimeStep
+        public void timestep(){
+
+        }
+    }
+
+    public class NestedProperties {
+        public int intField;
+        public boolean booleanField;
+        public String stringField;
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupport_Test.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupport_Test.java
@@ -9,7 +9,7 @@ import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstru
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class PropertyBindingSupportTest {
+public class PropertyBindingSupport_Test {
 
     private final TestCase testCase = new TestCase(getClass().getName());
     private final SomeObject someObject = new SomeObject();
@@ -60,9 +60,9 @@ public class PropertyBindingSupportTest {
         bind0(someObject, "nullOtherObject.stringField", "newValue");
     }
 
-    @Test(expected = BindException.class)
+    @Test
     public void bind_withPath_missingProperty() {
-        bind0(someObject, "notExist.stringField", "newValue");
+        assertFalse(bind0(someObject, "notExist.stringField", "newValue"));
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupport_nestedPropertiesTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/PropertyBindingSupport_nestedPropertiesTest.java
@@ -1,0 +1,88 @@
+package com.hazelcast.simulator.utils;
+
+import com.hazelcast.simulator.test.TestCase;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.simulator.utils.PropertyBindingSupport.bindAll;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class PropertyBindingSupport_nestedPropertiesTest {
+
+    @Test
+    public void test() {
+        TestCase testCase = new TestCase("id")
+                .setProperty("arm.finger.length", 10)
+                .setProperty("age", 40);
+
+        Person person = new Person();
+        Set<String> usedProperties = bindAll(person, testCase);
+
+        assertEquals(40, person.age);
+        assertEquals(10, person.arm.finger.length);
+        assertEquals(asSet("arm.finger.length", "age"), usedProperties);
+    }
+
+    @Test
+    public void testNotAllPropertiesBound() {
+        TestCase testCase = new TestCase("id")
+                .setProperty("foo",1000)
+                .setProperty("arm.finger.length", 10)
+                .setProperty("age", 40);
+
+        Person person = new Person();
+        Set<String> usedProperties = bindAll(person, testCase);
+
+        assertEquals(40, person.age);
+        assertEquals(10, person.arm.finger.length);
+        assertEquals(asSet("arm.finger.length", "age"), usedProperties);
+    }
+
+    @Test(expected = BindException.class)
+    public void testBadMatch() {
+        TestCase testCase = new TestCase("id")
+                .setProperty("arm.house.length", 10);
+
+        Person person = new Person();
+        bindAll(person, testCase);
+    }
+
+    @Test
+    public void testReconstructObjectGraph() {
+        TestCase testCase = new TestCase("id")
+                .setProperty("nullArm.finger.length", 10);
+
+        Person person = new Person();
+        Set<String> usedProperties = bindAll(person, testCase);
+
+        assertNotNull(person.nullArm);
+        assertNotNull(person.nullArm.finger);
+        assertEquals(10, person.nullArm.finger.length);
+        assertEquals(asSet("nullArm.finger.length"), usedProperties);
+    }
+
+    public Set<String> asSet(String... strings) {
+        Set<String> result = new HashSet<String>();
+        for (String s : strings) {
+            result.add(s);
+        }
+        return result;
+    }
+
+    public static class Person {
+        public Arm arm = new Arm();
+        public Arm nullArm;
+        public int age;
+    }
+
+    public static class Arm {
+        public Finger finger = new Finger();
+    }
+
+    public static class Finger {
+        public int length;
+    }
+}

--- a/utils/src/main/java/com/hazelcast/simulator/utils/ReflectionUtils.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/ReflectionUtils.java
@@ -67,7 +67,7 @@ public final class ReflectionUtils {
 
     public static void setFieldValue(Object instance, Field field, Object value) {
         field.setAccessible(true);
-        setFieldValueInternal(instance, field, value);
+        setFieldValue0(instance, field, value);
     }
 
     public static <E> E getFieldValue(Object instance, String fieldName) {
@@ -81,7 +81,7 @@ public final class ReflectionUtils {
         } catch (Exception e) {
             throw new ReflectionException(e);
         }
-        return getFieldValueInternal(instance, field, clazz.getName(), fieldName);
+        return getFieldValue0(instance, field, clazz.getName(), fieldName);
     }
 
     /**
@@ -100,7 +100,7 @@ public final class ReflectionUtils {
         }
 
         field.setAccessible(true);
-        return getFieldValueInternal(null, field, clazz.getName(), fieldName);
+        return getFieldValue0(null, field, clazz.getName(), fieldName);
     }
 
     /**
@@ -141,7 +141,7 @@ public final class ReflectionUtils {
         constructor.newInstance();
     }
 
-    static void setFieldValueInternal(Object instance, Field field, Object value) {
+    static void setFieldValue0(Object instance, Field field, Object value) {
         try {
             field.set(instance, value);
         } catch (IllegalAccessException e) {
@@ -150,7 +150,7 @@ public final class ReflectionUtils {
     }
 
     @SuppressWarnings("unchecked")
-    static <E> E getFieldValueInternal(Object instance, Field field, String className, String fieldName) {
+    static <E> E getFieldValue0(Object instance, Field field, String className, String fieldName) {
         try {
             return (E) field.get(instance);
         } catch (IllegalAccessException e) {

--- a/utils/src/test/java/com/hazelcast/simulator/utils/ReflectionUtilsTest.java
+++ b/utils/src/test/java/com/hazelcast/simulator/utils/ReflectionUtilsTest.java
@@ -12,14 +12,14 @@ import java.util.List;
 
 import static com.hazelcast.simulator.utils.ReflectionUtils.getField;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getFieldValue;
-import static com.hazelcast.simulator.utils.ReflectionUtils.getFieldValueInternal;
+import static com.hazelcast.simulator.utils.ReflectionUtils.getFieldValue0;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getFields;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getFirstField;
 import static com.hazelcast.simulator.utils.ReflectionUtils.getMethodByName;
 import static com.hazelcast.simulator.utils.ReflectionUtils.invokeMethod;
 import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
 import static com.hazelcast.simulator.utils.ReflectionUtils.setFieldValue;
-import static com.hazelcast.simulator.utils.ReflectionUtils.setFieldValueInternal;
+import static com.hazelcast.simulator.utils.ReflectionUtils.setFieldValue0;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -209,13 +209,13 @@ public class ReflectionUtilsTest {
     public void testSetFieldValueInternal_privateField() {
         SetFieldTest setFieldTest = new SetFieldTest();
         Field field = getField(SetFieldTest.class, "injectField", Object.class);
-        setFieldValueInternal(setFieldTest, field, "value");
+        setFieldValue0(setFieldTest, field, "value");
     }
 
     @Test(expected = ReflectionException.class)
     public void testGetFieldValueInternal_privateField() {
         Field field = getField(StaticClass.class, "staticField", int.class);
-        getFieldValueInternal(null, field, "StaticClass", "staticField");
+        getFieldValue0(null, field, "StaticClass", "staticField");
     }
 
     @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Also add a new feature that an object graph can be reconstructed is added.

So imagine you have class Person with a null arm, then you can define

'arm.finger.nail.length=10'

and the whole object graph is being recreated. 

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/939