### PR TITLE
Removed Probe.get method

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/probes/Probe.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/probes/Probe.java
@@ -37,12 +37,4 @@ public interface Probe {
      * @param latencyNanos latency value in nanoseconds
      */
     void recordValue(long latencyNanos);
-
-    /**
-     * Get the number of iterations.
-     *
-     * @return the number of iterations.
-     * @throws UnsupportedOperationException on non-lightweight implementations
-     */
-    long get();
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/probes/impl/EmptyProbe.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/probes/impl/EmptyProbe.java
@@ -41,9 +41,4 @@ public class EmptyProbe implements Probe {
     @Override
     public void recordValue(long latencyNanos) {
     }
-
-    @Override
-    public long get() {
-        return 0;
-    }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
@@ -64,7 +64,6 @@ public class HdrProbe implements Probe {
         return recorder.getIntervalHistogram();
     }
 
-    @Override
     public long get() {
         return getIntervalHistogram().getTotalCount();
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/test/TestContainer_RunTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/TestContainer_RunTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.simulator.test;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.simulator.probes.Probe;
+import com.hazelcast.simulator.probes.impl.HdrProbe;
 import com.hazelcast.simulator.test.annotations.InjectHazelcastInstance;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
@@ -165,7 +166,8 @@ public class TestContainer_RunTest extends AbstractTestContainerTest {
 
         long totalCount = 0;
         for (Probe probe : probeMap.values()) {
-            totalCount += probe.get();
+            HdrProbe hdrProbe = (HdrProbe)probe;
+            totalCount += hdrProbe.get();
         }
         assertEquals(THREAD_COUNT * ITERATION_COUNT, totalCount);
     }


### PR DESCRIPTION
The Probe interface is about recording values; not retrieving the content.