### PR TITLE
Lock-free single-producer/multiple-consumer array queue of longs

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/common/SPMCLongArrayQueue.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/SPMCLongArrayQueue.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.simulator.common;
+
+import com.hazelcast.util.QuickMath;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+/**
+ * A single-producer, multiple consumer blocking concurrent queue of {@code long} values.
+ */
+public class SPMCLongArrayQueue {
+    private static final AtomicLongFieldUpdater<SPMCLongArrayQueue> HEAD =
+            AtomicLongFieldUpdater.newUpdater(SPMCLongArrayQueue.class, "head");
+
+    private final AtomicLongArray queue;
+    private final long nullSentinel;
+    private final long mask;
+    private final int capacity;
+
+    private volatile long head;
+    private volatile long tail;
+
+    public SPMCLongArrayQueue(int requestedCapacity, long nullSentinel) {
+        this.nullSentinel = nullSentinel;
+        this.capacity = QuickMath.nextPowerOfTwo(requestedCapacity);
+        this.mask = capacity - 1;
+        this.queue = new AtomicLongArray(capacity);
+    }
+
+    public boolean offer(long value) {
+        assert value != nullSentinel : "";
+        final long acquiredTail = tail;
+        if (acquiredTail - head >= capacity) {
+            return false;
+        }
+        queue.lazySet(seqToArrayIndex(acquiredTail, mask), value);
+        tail = acquiredTail + 1;
+        return true;
+    }
+
+    public long poll() {
+        while (true) {
+            final long acquiredHead = head;
+            if (acquiredHead >= tail) {
+                return nullSentinel;
+            }
+            final int acquiredIndex = seqToArrayIndex(acquiredHead, mask);
+            final long result = queue.get(acquiredIndex);
+            if (HEAD.compareAndSet(this, acquiredHead, acquiredHead + 1)) {
+                return result;
+            }
+        }
+    }
+
+    public long addedCount() {
+        return tail;
+    }
+
+    public long removedCount() {
+        return head;
+    }
+
+    static int seqToArrayIndex(long seq, long mask) {
+        return (int) (seq & mask);
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/common/SPMCLongArrayQueueTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/common/SPMCLongArrayQueueTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.simulator.common;
+
+import com.hazelcast.util.collection.LongHashSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Thread.currentThread;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SPMCLongArrayQueueTest {
+
+    static final int CAPACITY = 128;
+    static final int ENQUEUE_COUNT = 10 * 1000 * 1000;
+    static final int CONSUMER_COUNT = Runtime.getRuntime().availableProcessors() - 1;
+    static final int CONSUMER_CAPACITY_HEADROOM = 10000;
+    private static final long NULL_SENTINEL = 0;
+
+    private final SPMCLongArrayQueue queue = new SPMCLongArrayQueue(CAPACITY, NULL_SENTINEL);
+
+    @Test
+    public void stressTest() throws InterruptedException {
+        final Thread[] consumers = new Thread[CONSUMER_COUNT];
+        final Worker[] workers = new Worker[CONSUMER_COUNT];
+        for (int i = 0; i < consumers.length; i++) {
+            workers[i] = new Worker();
+            consumers[i] = new Thread(workers[i]);
+            consumers[i].start();
+        }
+        System.out.format("Producing %,d items%n", ENQUEUE_COUNT);
+        final long start = System.nanoTime();
+        for (long val = 1; val <= ENQUEUE_COUNT; val++) {
+            while (!queue.offer(val));
+        }
+        final double elapsedSeconds = (System.nanoTime() - start) / (double) SECONDS.toNanos(1);
+        System.out.format("Production done, %,.0f items/sec%n", ENQUEUE_COUNT / elapsedSeconds);
+        Thread.sleep(100);
+        assertEquals("dequeued count mismatches enqueued count", queue.addedCount(), queue.removedCount());
+        for (Thread consumer : consumers) {
+            consumer.interrupt();
+            consumer.join();
+        }
+        System.out.println("Consumers killed, validating");
+        final LongHashSet allDequeued = new LongHashSet(ENQUEUE_COUNT, NULL_SENTINEL);
+        int allDequeuedCount = 0;
+        for (Worker w : workers) {
+            for (int i = 0; i < w.insertionPoint; i++) {
+                assertTrue("Duplicate dequeued value", allDequeued.add(w.dequeued[i]));
+                if (++allDequeuedCount > ENQUEUE_COUNT) {
+                    fail("Dequeued count exceeds enqueued count");
+                }
+            }
+        }
+        assertEquals("wrong allDequeued size", ENQUEUE_COUNT, allDequeued.size());
+        for (long val = 1; val <= ENQUEUE_COUNT; val++) {
+            if (!allDequeued.contains(val)) {
+                fail("Failed to dequeue " + val);
+            }
+        }
+    }
+
+    class Worker implements Runnable {
+        private final long[] dequeued = new long[ENQUEUE_COUNT / CONSUMER_COUNT + CONSUMER_CAPACITY_HEADROOM];
+        int insertionPoint;
+
+        @Override
+        public void run() {
+            while (!currentThread().isInterrupted() && insertionPoint < dequeued.length) {
+                final long got = queue.poll();
+                if (got != NULL_SENTINEL) {
+                    dequeued[insertionPoint++] = got;
+                }
+            }
+            System.out.format("Worker dequeued %,d items more than its fair share%n",
+                    insertionPoint - ENQUEUE_COUNT / CONSUMER_COUNT);
+        }
+    }
+}


### PR DESCRIPTION
Used in Hot Restart test for throughput control and will possibly be generalized to work with `Metronome`.