### PR TITLE
Dealing with super classes and annotation

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/test/CompositeCallable.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/CompositeCallable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.test;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class CompositeCallable implements Callable {
+
+    private final List<Callable> callables;
+
+    public CompositeCallable(List<Callable> callables) {
+        this.callables = callables;
+    }
+
+    @Override
+    public Object call() throws Exception {
+        for (Callable callable : callables) {
+            callable.call();
+        }
+        return null;
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/AnnotatedMethodRetriever.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/AnnotatedMethodRetriever.java
@@ -148,7 +148,44 @@ public class AnnotatedMethodRetriever {
                 continue;
             }
 
-            methods.add(method);
+            if (!isOveridden(methods, method)) {
+                methods.add(method);
+            }
         }
+    }
+
+    private static boolean isOveridden(List<Method> subMethods, Method superMethod) {
+        for (Method subMethod : subMethods) {
+            if (!subMethod.getName().equals(superMethod.getName())) {
+                continue;
+            }
+
+            Class<?>[] subParamTypes = subMethod.getParameterTypes();
+            Class<?>[] methodParamTypes = superMethod.getParameterTypes();
+            if (subParamTypes.length != methodParamTypes.length) {
+                continue;
+            }
+
+            boolean equalParameters = true;
+            for (int i = 0; i < subParamTypes.length; i++) {
+                if (!subParamTypes[i].equals(methodParamTypes[i])) {
+                    equalParameters = false;
+                    break;
+                }
+            }
+
+            if (!equalParameters) {
+                continue;
+            }
+
+            if (!superMethod.getReturnType().equals(subMethod.getReturnType())) {
+                continue;
+            }
+
+            // todo: in the future we need to deal with covariant return types, bridge methods and parameter types in the methods.
+
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Now  you can make e.g. multiple @Teardown methods, or have them on the super.

This goes for most annotations like setup, teardown, verify etc.

This aligns with @Before/@After from junit

fixes https://github.com/hazelcast/hazelcast-simulator/issues/915