### PR TITLE
Configurable output directory

### DIFF
--- a/archetype/src/main/resources/archetype-resources/workdir/run.sh
+++ b/archetype/src/main/resources/archetype-resources/workdir/run.sh
@@ -15,6 +15,4 @@ coordinator     --memberWorkerCount 2 \
                 --monitorPerformance \
                 test.properties
 
-provisioner --download
-
 provisioner --terminate

--- a/dist/src/main/dist/conf/after-completion.sh
+++ b/dist/src/main/dist/conf/after-completion.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script is executed after the coordinator completes executing a test-suite and optionally has downloaded the artifacts.
+# It will be executed 'locally'; on the machine that ran the executor, and not remotely.
+#
+# This script can be used for post processing e.g. HDR file conversion.
+#
+# This script can be copied into the working directory and modified.
+
+
+# exit on failure
+set -e
+
+dir=$1
+if [ ! -d "${dir}" ]; then
+  echo Directory $dir does not exist.
+  exit 1
+fi
+
+# Convert all hdr files to hgrm files so they can easily be plot using
+# http://hdrhistogram.github.io/HdrHistogram/plotFiles.html
+hdr_files=($(find $dir | grep .hdr))
+for hdr_file in "${hdr_files[@]}"
+do
+        # prevent getting *.hdr as result in case of empty directory
+        file_name="${hdr_file%.*}"
+
+        classpath=$(ls $SIMULATOR_HOME/lib/HdrHistogram*)
+        java -cp ${classpath}  org.HdrHistogram.HistogramLogProcessor -i ${hdr_file} -o ${file_name}
+done
+

--- a/dist/src/main/dist/conf/worker.sh
+++ b/dist/src/main/dist/conf/worker.sh
@@ -41,16 +41,6 @@ esac
 
 java -classpath ${CLASSPATH} ${JVM_ARGS} ${MAIN}
 
-# Convert all hdr files to hgrm files so they can easily be plot using
-# http://hdrhistogram.github.io/HdrHistogram/plotFiles.html
-for HDR_FILE in *.hdr; do
-        # prevent getting *.hdr as result in case of empty directory
-        [ -f "$HDR_FILE" ] || break
-        FILE_NAME="${HDR_FILE%.*}"
-        java -cp ${CLASSPATH}  org.HdrHistogram.HistogramLogProcessor -i ${HDR_FILE} -o ${FILE_NAME}
-done
-
-
 
 #########################################################################
 # Yourkit

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -57,6 +57,7 @@ import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingDirectory;
 import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
 import static com.hazelcast.simulator.utils.FileUtils.newFile;
+import static com.hazelcast.simulator.utils.FileUtils.rename;
 import static com.hazelcast.simulator.utils.FormatUtils.HORIZONTAL_RULER;
 import static com.hazelcast.simulator.utils.FormatUtils.secondsToHuman;
 import static com.hazelcast.simulator.utils.NativeUtils.execute;
@@ -64,6 +65,7 @@ import static com.hazelcast.simulator.utils.jars.HazelcastJARs.OUT_OF_THE_BOX;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+@SuppressWarnings("checkstyle:methodcount")
 public final class Coordinator {
 
     static final String SIMULATOR_VERSION = getSimulatorVersion();
@@ -72,7 +74,7 @@ public final class Coordinator {
 
     private static final Logger LOGGER = Logger.getLogger(Coordinator.class);
 
-    private final File outputDirectory = new File(System.getProperty("user.dir"));
+    private final File outputDirectory;
 
     private final TestPhaseListeners testPhaseListeners = new TestPhaseListeners();
     private final PerformanceStateContainer performanceStateContainer = new PerformanceStateContainer();
@@ -96,21 +98,33 @@ public final class Coordinator {
     private RemoteClient remoteClient;
     private CoordinatorConnector coordinatorConnector;
 
-    public Coordinator(TestSuite testSuite, ComponentRegistry componentRegistry, CoordinatorParameters coordinatorParameters,
-                       WorkerParameters workerParameters, ClusterLayoutParameters clusterLayoutParameters) {
+    public Coordinator(TestSuite testSuite,
+                       ComponentRegistry componentRegistry,
+                       CoordinatorParameters coordinatorParameters,
+                       WorkerParameters workerParameters,
+                       ClusterLayoutParameters clusterLayoutParameters) {
         this(testSuite, componentRegistry, coordinatorParameters, workerParameters, clusterLayoutParameters,
                 new ClusterLayout(componentRegistry, workerParameters, clusterLayoutParameters));
     }
 
-    Coordinator(TestSuite testSuite, ComponentRegistry componentRegistry, CoordinatorParameters coordinatorParameters,
-                WorkerParameters workerParameters, ClusterLayoutParameters clusterLayoutParameters, ClusterLayout clusterLayout) {
+    Coordinator(TestSuite testSuite,
+                ComponentRegistry componentRegistry,
+                CoordinatorParameters coordinatorParameters,
+                WorkerParameters workerParameters,
+                ClusterLayoutParameters clusterLayoutParameters,
+                ClusterLayout clusterLayout) {
+
+        this.outputDirectory = ensureExistingDirectory(new File(System.getProperty("user.dir"), testSuite.getId()));
+
         this.testSuite = testSuite;
         this.componentRegistry = componentRegistry;
         this.coordinatorParameters = coordinatorParameters;
         this.workerParameters = workerParameters;
         this.clusterLayoutParameters = clusterLayoutParameters;
         this.hdrHistogramContainer = new HdrHistogramContainer(outputDirectory, performanceStateContainer);
-        this.failureContainer = new FailureContainer(testSuite, componentRegistry);
+
+        this.failureContainer = new FailureContainer(
+                outputDirectory, componentRegistry, testSuite.getTolerableFailures());
 
         this.simulatorProperties = coordinatorParameters.getSimulatorProperties();
         this.bash = new Bash(simulatorProperties);
@@ -169,6 +183,7 @@ public final class Coordinator {
         echoLocal("Total number of Hazelcast member workers: %s", clusterLayout.getMemberWorkerCount());
         echoLocal("Total number of Hazelcast client workers: %s", clusterLayout.getClientWorkerCount());
         echoLocal("Last TestPhase to sync: %s", lastTestPhaseToSync);
+        echoLocal("Output directory: " + outputDirectory.getAbsolutePath());
 
         boolean performanceEnabled = workerParameters.isMonitorPerformance();
         int performanceIntervalSeconds = workerParameters.getWorkerPerformanceMonitorIntervalSeconds();
@@ -207,8 +222,21 @@ public final class Coordinator {
             if (hazelcastJARs != null) {
                 hazelcastJARs.shutdown();
             }
-            moveLogFiles();
+
+            download();
+
+            executeAfterCompletion();
+
             OperationTypeCounter.printStatistics();
+        }
+    }
+
+
+    private void executeAfterCompletion() {
+        if (coordinatorParameters.getAfterCompletionFile() != null) {
+            echoLocal("Executing after-completion script:" + coordinatorParameters.getAfterCompletionFile());
+            bash.execute(coordinatorParameters.getAfterCompletionFile() + " " + outputDirectory.getAbsolutePath());
+            echoLocal("Finished after-completion script");
         }
     }
 
@@ -385,22 +413,84 @@ public final class Coordinator {
         }
     }
 
-    private void moveLogFiles() {
-        if (isLocal(simulatorProperties)) {
-            File workerHome = newFile(getSimulatorHome(), WORKERS_HOME_NAME);
-            File targetDirectory = ensureExistingDirectory(newFile(".", WORKERS_HOME_NAME), testSuite.getId());
-
-            String workerPath = workerHome.getAbsolutePath();
-            String targetPath = targetDirectory.getAbsolutePath();
-
-            execute(format("mv %s/%s/* %s || true", workerPath, testSuite.getId(), targetPath));
-            execute(format("rmdir %s/%s || true", workerPath, testSuite.getId()));
-            execute(format("rmdir %s || true", workerPath));
-            execute(format("mv ./agent.err %s/ || true", targetPath));
-            execute(format("mv ./agent.out %s/ || true", targetPath));
-            execute(format("mv ./failures-%s.txt %s/ || true", testSuite.getId(), targetPath));
-            execute(format("mv ./%s_* %s/ || true", testSuite.getId(), targetPath));
+    private void download() {
+        if (!coordinatorParameters.skipDownload()) {
+            if (isLocal(simulatorProperties)) {
+                downloadLocal();
+            } else {
+                downloadRemote();
+            }
         }
+    }
+
+    private void downloadLocal() {
+        echoLocal("Retrieving artifacts of local machine");
+
+        File workerHome = newFile(getSimulatorHome(), WORKERS_HOME_NAME);
+        String workerPath = workerHome.getAbsolutePath();
+
+        execute(format("mv %s/%s/* %s || true", workerPath, testSuite.getId(), outputDirectory.getAbsolutePath()));
+        execute(format("rmdir %s/%s || true", workerPath, testSuite.getId()));
+        execute(format("rmdir %s || true", workerPath));
+        execute(format("mv ./agent.err %s/ || true", outputDirectory.getAbsolutePath()));
+        execute(format("mv ./agent.out %s/ || true", outputDirectory.getAbsolutePath()));
+    }
+
+    private void downloadRemote() {
+        long started = System.nanoTime();
+        echoLocal("Download artifacts of %s machines...", componentRegistry.agentCount());
+
+        ThreadSpawner spawner = new ThreadSpawner("download", true);
+
+        final String baseCommand = "rsync --copy-links %s-avv -e \"ssh %s\" %s@%%s:%%s %s";
+        final String sshOptions = simulatorProperties.getSshOptions();
+        final String sshUser = simulatorProperties.getUser();
+
+        // download Worker logs
+        for (final AgentData agentData : componentRegistry.getAgents()) {
+            spawner.spawn(new Runnable() {
+                @Override
+                public void run() {
+                    String ip = agentData.getPublicAddress();
+                    String workersPath = format("hazelcast-simulator-%s/workers/%s", getSimulatorVersion(), testSuite.getId());
+
+                    String rsyncCommand = format(baseCommand, "", sshOptions, sshUser,
+                            outputDirectory.getParentFile().getAbsolutePath());
+
+                    echoLocal("Downloading Worker logs from %s", ip);
+                    bash.executeQuiet(format(rsyncCommand, ip, workersPath));
+                }
+            });
+        }
+
+        // download Agent logs
+        spawner.spawn(new Runnable() {
+            @Override
+            public void run() {
+                for (final AgentData agentData : componentRegistry.getAgents()) {
+                    String ip = agentData.getPublicAddress();
+                    String agentAddress = agentData.getAddress().toString();
+
+                    echoLocal("Downloading Agent logs from %s", ip);
+                    String rsyncCommand = format(
+                            baseCommand, "--backup --suffix=-%s ", sshOptions, sshUser, outputDirectory.getAbsolutePath());
+
+                    bash.executeQuiet(format(rsyncCommand, ip, ip, "agent.out"));
+                    bash.executeQuiet(format(rsyncCommand, ip, ip, "agent.err"));
+
+                    File agentOut = new File(outputDirectory.getAbsolutePath(), "agent.out");
+                    File agentErr = new File(outputDirectory.getAbsolutePath(), "agent.err");
+
+                    rename(agentOut, new File(outputDirectory.getAbsolutePath(), agentAddress + '-' + ip + "-agent.out"));
+                    rename(agentErr, new File(outputDirectory.getAbsolutePath(), agentAddress + '-' + ip + "-agent.err"));
+                }
+            }
+        });
+
+        spawner.awaitCompletion();
+
+        long elapsed = getElapsedSeconds(started);
+        echoLocal("Finished downloading artifacts of %s machines (%s seconds)", componentRegistry.agentCount(), elapsed);
     }
 
     private void echoTestSuiteStart(int testCount, boolean isParallel) {
@@ -439,7 +529,7 @@ public final class Coordinator {
         try {
             init(args).run();
         } catch (Exception e) {
-            exitWithError(LOGGER, "Failed to run TestSuite", e);
+            exitWithError(LOGGER, "Failed to run Coordinator", e);
         }
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -204,6 +204,9 @@ final class CoordinatorCli {
             "Sets the license key for Hazelcast Enterprise Edition.")
             .withRequiredArg().ofType(String.class);
 
+    private final OptionSpec skipDownloadSpec = parser.accepts("skipDownload",
+            "Prevents downloading of the created worker artifacts.");
+
     private CoordinatorCli() {
     }
 
@@ -242,7 +245,9 @@ final class CoordinatorCli {
                 options.valueOf(cli.targetTypeSpec),
                 options.valueOf(cli.targetCountSpec),
                 options.valueOf(cli.syncToTestPhaseSpec),
-                options.valueOf(cli.workerVmStartupDelayMsSpec)
+                options.valueOf(cli.workerVmStartupDelayMsSpec),
+                options.has(cli.skipDownloadSpec),
+                getDefaultConfigurationFile("after-completion.sh")
         );
 
         String memberHzConfig = loadMemberHzConfig(options, cli);

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
@@ -27,6 +27,7 @@ class CoordinatorParameters {
     private final SimulatorProperties simulatorProperties;
     private final String workerClassPath;
 
+    private final boolean skipDownload;
     private final boolean uploadHazelcastJARs;
     private final boolean enterpriseEnabled;
     private final boolean verifyEnabled;
@@ -38,25 +39,35 @@ class CoordinatorParameters {
 
     private final TestPhase lastTestPhaseToSync;
     private final int workerVmStartupDelayMs;
+    private final String afterCompletionFile;
 
     @SuppressWarnings("checkstyle:parameternumber")
-    CoordinatorParameters(SimulatorProperties properties, String workerClassPath, boolean uploadHazelcastJARs,
-                          boolean enterpriseEnabled, boolean verifyEnabled, boolean parallel, boolean refreshJvm,
-                          TargetType targetType, int targetCount, TestPhase lastTestPhaseToSync, int workerVmStartupDelayMs) {
+    CoordinatorParameters(SimulatorProperties properties,
+                          String workerClassPath,
+                          boolean uploadHazelcastJARs,
+                          boolean enterpriseEnabled,
+                          boolean verifyEnabled,
+                          boolean parallel,
+                          boolean refreshJvm,
+                          TargetType targetType,
+                          int targetCount,
+                          TestPhase lastTestPhaseToSync,
+                          int workerVmStartupDelayMs,
+                          boolean skipDownload,
+                          String afterCompletionFile) {
         this.simulatorProperties = properties;
         this.workerClassPath = workerClassPath;
-
         this.uploadHazelcastJARs = uploadHazelcastJARs;
         this.enterpriseEnabled = enterpriseEnabled;
         this.verifyEnabled = verifyEnabled;
         this.parallel = parallel;
         this.refreshJvm = refreshJvm;
-
         this.targetType = targetType;
         this.targetCount = targetCount;
-
         this.lastTestPhaseToSync = lastTestPhaseToSync;
         this.workerVmStartupDelayMs = workerVmStartupDelayMs;
+        this.skipDownload = skipDownload;
+        this.afterCompletionFile = afterCompletionFile;
     }
 
     public int getWorkerVmStartupDelayMs() {
@@ -101,5 +112,13 @@ class CoordinatorParameters {
 
     TestPhase getLastTestPhaseToSync() {
         return lastTestPhaseToSync;
+    }
+
+    public boolean skipDownload() {
+        return skipDownload;
+    }
+
+    public String getAfterCompletionFile() {
+        return afterCompletionFile;
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureContainer.java
@@ -19,12 +19,10 @@ import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.operation.FailureOperation;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.test.FailureType;
-import com.hazelcast.simulator.test.TestSuite;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.apache.log4j.Logger;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -60,16 +58,10 @@ public class FailureContainer {
     private final ComponentRegistry componentRegistry;
     private final Set<FailureType> nonCriticalFailures;
 
-    public FailureContainer(TestSuite testSuite, ComponentRegistry componentRegistry) {
-        this(testSuite.getId(), componentRegistry, testSuite.getTolerableFailures());
-    }
-
-    public FailureContainer(String testSuiteId, ComponentRegistry componentRegistry) {
-        this(testSuiteId, componentRegistry, Collections.<FailureType>emptySet());
-    }
-
-    public FailureContainer(String testSuiteId, ComponentRegistry componentRegistry, Set<FailureType> nonCriticalFailures) {
-        this.file = new File("failures-" + testSuiteId + ".txt");
+    public FailureContainer(File outputDirectory,
+                            ComponentRegistry componentRegistry,
+                            Set<FailureType> nonCriticalFailures) {
+        this.file = new File(outputDirectory, "failures.txt");
         this.componentRegistry = componentRegistry;
         this.nonCriticalFailures = nonCriticalFailures;
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/HdrHistogramContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/HdrHistogramContainer.java
@@ -20,7 +20,6 @@ import com.hazelcast.simulator.probes.impl.ResultImpl;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.worker.performance.PerformanceState;
 import org.HdrHistogram.Histogram;
-import org.HdrHistogram.HistogramLogProcessor;
 import org.HdrHistogram.HistogramLogWriter;
 import org.apache.log4j.Logger;
 
@@ -79,8 +78,7 @@ public class HdrHistogramContainer {
         printHgrmRenderUrl();
 
         for (String probeName : result.probeNames()) {
-
-            String baseFileName = testSuiteId + '_' + testId + "_" + probeName;
+            String baseFileName = testId + "_" + probeName;
 
             Histogram histogram = result.getHistogram(probeName);
             File hdrFile = new File(outputDirectory, baseFileName + ".hdr");
@@ -91,11 +89,6 @@ public class HdrHistogramContainer {
             } catch (IOException e) {
                 LOGGER.error(e);
             }
-
-            // the HistogramLogProcessor creates 2 files, one with basename and no extension and one with 'hgrm' extension
-            File hgrmFile = new File(outputDirectory, baseFileName);
-            LOGGER.info("Writing " + hgrmFile.getAbsolutePath() + ".hgrm");
-            HistogramLogProcessor.main(new String[]{"-i", hdrFile.getAbsolutePath(), "-o", hgrmFile.getAbsolutePath()});
         }
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -19,6 +19,7 @@ import com.hazelcast.simulator.protocol.operation.StartTestOperation;
 import com.hazelcast.simulator.protocol.operation.StartTestPhaseOperation;
 import com.hazelcast.simulator.protocol.operation.StopTestOperation;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
+import com.hazelcast.simulator.test.FailureType;
 import com.hazelcast.simulator.test.TestCase;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.TestPhase;
@@ -27,6 +28,7 @@ import com.hazelcast.simulator.tests.FailingTest;
 import com.hazelcast.simulator.tests.SuccessTest;
 import com.hazelcast.simulator.utils.AssertTask;
 import com.hazelcast.simulator.utils.CommonUtils;
+import com.hazelcast.simulator.utils.FileUtils;
 import com.hazelcast.simulator.utils.TestUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -35,6 +37,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -75,6 +79,7 @@ public class AgentSmokeTest implements FailureListener {
     private static TestPhaseListeners testPhaseListeners;
     private static CoordinatorConnector coordinatorConnector;
     private static RemoteClient remoteClient;
+    private static File outputDirectory;
 
     private final BlockingQueue<FailureOperation> failureOperations = new LinkedBlockingQueue<FailureOperation>();
 
@@ -93,9 +98,9 @@ public class AgentSmokeTest implements FailureListener {
 
         testPhaseListeners = new TestPhaseListeners();
         PerformanceStateContainer performanceStateContainer = new PerformanceStateContainer();
-        File outputDirectory = TestUtils.createTmpDirectory();
+        outputDirectory = TestUtils.createTmpDirectory();
         HdrHistogramContainer hdrHistogramContainer = new HdrHistogramContainer(outputDirectory, performanceStateContainer);
-        failureContainer = new FailureContainer("agentSmokeTest", null);
+        failureContainer = new FailureContainer(outputDirectory, null, new HashSet<FailureType>());
 
         coordinatorConnector = new CoordinatorConnector(failureContainer, testPhaseListeners, performanceStateContainer,
                 hdrHistogramContainer);
@@ -117,10 +122,11 @@ public class AgentSmokeTest implements FailureListener {
 
             resetUserDir();
             deleteLogs();
-            deleteQuiet("failures-agentSmokeTest.txt");
 
             resetLogLevel();
         }
+
+        deleteQuiet(outputDirectory);
     }
 
     @Override

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -4,9 +4,12 @@ import com.hazelcast.simulator.protocol.registry.AgentData;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.test.TestSuite;
+import com.hazelcast.simulator.test.annotations.BeforeRun;
 import com.hazelcast.simulator.utils.CloudProviderUtils;
 import com.hazelcast.simulator.utils.CommandLineExitException;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -50,9 +53,10 @@ public class CoordinatorCliTest {
     private static File propertiesFile;
 
     private final List<String> args = new ArrayList<String>();
+    private String testSuiteId;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
         setDistributionUserDir();
         createAgentsFileWithLocalhost();
 
@@ -62,13 +66,25 @@ public class CoordinatorCliTest {
         propertiesFile = ensureExistingFile("simulator.properties");
     }
 
+    @Before
+    public void before(){
+        args.add("--testSuiteId");
+        testSuiteId = "testrun-" + System.currentTimeMillis();
+        args.add(testSuiteId);
+    }
+
     @AfterClass
-    public static void tearDown() {
+    public static void afterClass() {
         resetUserDir();
         deleteAgentsFile();
 
         deleteQuiet(testSuiteFile);
         deleteQuiet(propertiesFile);
+    }
+
+    @After
+    public void after(){
+        deleteQuiet(new File(testSuiteId).getAbsoluteFile());
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorParametersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorParametersTest.java
@@ -16,8 +16,20 @@ public class CoordinatorParametersTest {
     public void testConstructor() {
         SimulatorProperties properties = mock(SimulatorProperties.class);
 
-        CoordinatorParameters coordinatorParameters = new CoordinatorParameters(properties, "workerClassPath", false, true, false,
-                true, false, TargetType.PREFER_CLIENT, 5, LOCAL_TEARDOWN,0);
+        CoordinatorParameters coordinatorParameters = new CoordinatorParameters(
+                properties,
+                "workerClassPath",
+                false,
+                true,
+                false,
+                true,
+                false,
+                TargetType.PREFER_CLIENT,
+                5,
+                LOCAL_TEARDOWN,
+                0,
+                true,
+                null);
 
         assertEquals(properties, coordinatorParameters.getSimulatorProperties());
         assertEquals("workerClassPath", coordinatorParameters.getWorkerClassPath());

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorTest.java
@@ -9,10 +9,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+
 import static com.hazelcast.simulator.TestEnvironmentUtils.resetUserDir;
 import static com.hazelcast.simulator.TestEnvironmentUtils.setDistributionUserDir;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_EC2;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_LOCAL;
+import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
 import static com.hazelcast.simulator.utils.jars.HazelcastJARs.BRING_MY_OWN;
 import static com.hazelcast.simulator.utils.jars.HazelcastJARs.OUT_OF_THE_BOX;
 import static org.mockito.Mockito.mock;
@@ -22,12 +25,13 @@ public class CoordinatorTest {
 
     private SimulatorProperties properties;
     private Coordinator coordinator;
+    private TestSuite testSuite;
 
     @Before
     public void setUp() {
         setDistributionUserDir();
 
-        TestSuite testSuite = new TestSuite();
+        testSuite = new TestSuite("testrun-" + System.currentTimeMillis());
         ComponentRegistry componentRegistry = new ComponentRegistry();
 
         properties = mock(SimulatorProperties.class);
@@ -47,6 +51,7 @@ public class CoordinatorTest {
 
     @After
     public void tearDown() {
+        deleteQuiet(new File(testSuite.getId()).getAbsoluteFile());
         resetUserDir();
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/HdrHistogramContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/HdrHistogramContainerTest.java
@@ -41,7 +41,7 @@ public class HdrHistogramContainerTest {
         when(performanceStateContainer.get("testId")).thenReturn(performanceState);
 
         outputDirectory = createTmpDirectory();
-        hdrFile = new File(outputDirectory, "testSuiteId_testId_workerProbe.hdr");
+        hdrFile = new File(outputDirectory, "testId_workerProbe.hdr");
         hdrHistogramContainer = new HdrHistogramContainer(outputDirectory, performanceStateContainer);
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/TestCaseRunnerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/TestCaseRunnerTest.java
@@ -21,6 +21,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 
+import java.io.File;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
@@ -77,7 +78,7 @@ public class TestCaseRunnerTest {
         TestCase testCase1 = new TestCase("CoordinatorTest1");
         TestCase testCase2 = new TestCase("CoordinatorTest2");
 
-        testSuite = new TestSuite();
+        testSuite = new TestSuite("testrun-" + System.currentTimeMillis());
         testSuite.addTest(testCase1);
         testSuite.addTest(testCase2);
 
@@ -101,10 +102,8 @@ public class TestCaseRunnerTest {
 
     @After
     public void cleanUp() {
+        deleteQuiet(new File(testSuite.getId()).getAbsoluteFile());
         deleteQuiet(AgentsFile.NAME);
-        deleteQuiet("failures-" + testSuite.getId() + ".txt");
-        deleteQuiet("probes-" + testSuite.getId() + "_CoordinatorTest1.xml");
-        deleteQuiet("probes-" + testSuite.getId() + "_CoordinatorTest2.xml");
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/ProtocolUtil.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/ProtocolUtil.java
@@ -20,6 +20,7 @@ import com.hazelcast.simulator.protocol.exception.ExceptionLogger;
 import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
 import com.hazelcast.simulator.protocol.processors.TestOperationProcessor;
+import com.hazelcast.simulator.test.FailureType;
 import com.hazelcast.simulator.test.TestContainer;
 import com.hazelcast.simulator.utils.TestUtils;
 import com.hazelcast.simulator.utils.ThreadSpawner;
@@ -29,6 +30,7 @@ import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -165,7 +167,7 @@ class ProtocolUtil {
         PerformanceStateContainer performanceStateContainer = new PerformanceStateContainer();
         File outputDirectory = TestUtils.createTmpDirectory();
         HdrHistogramContainer hdrHistogramContainer = new HdrHistogramContainer(outputDirectory, performanceStateContainer);
-        FailureContainer failureContainer = new FailureContainer("ProtocolUtil", null);
+        FailureContainer failureContainer = new FailureContainer(outputDirectory, null, new HashSet<FailureType>());
         CoordinatorConnector coordinatorConnector = new CoordinatorConnector(failureContainer, testPhaseListeners,
                 performanceStateContainer, hdrHistogramContainer);
         for (int i = 1; i <= numberOfAgents; i++) {

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/connector/CoordinatorConnectorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/connector/CoordinatorConnectorTest.java
@@ -12,11 +12,13 @@ import com.hazelcast.simulator.protocol.core.SimulatorMessage;
 import com.hazelcast.simulator.protocol.core.SimulatorProtocolException;
 import com.hazelcast.simulator.protocol.operation.FailureOperation;
 import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
+import com.hazelcast.simulator.test.FailureType;
 import com.hazelcast.simulator.utils.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +59,8 @@ public class CoordinatorConnectorTest {
 
         File outputDirectory = TestUtils.createTmpDirectory();
         HdrHistogramContainer hdrHistogramContainer = new HdrHistogramContainer(outputDirectory, performanceStateContainer);
-        FailureContainer failureContainer = new FailureContainer("ProtocolUtil", null);
+        FailureContainer failureContainer = new FailureContainer(outputDirectory, null, new HashSet<FailureType>());
+
         executorService = mock(ExecutorService.class);
 
         coordinatorConnector = new CoordinatorConnector(failureContainer, testPhaseListeners, performanceStateContainer,

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -96,7 +97,7 @@ public class CoordinatorOperationProcessorTest implements FailureListener {
 
         outputDirectory = TestUtils.createTmpDirectory();
         hdrHistogramContainer = new HdrHistogramContainer(outputDirectory, performanceStateContainer);
-        failureContainer = new FailureContainer("CoordinatorOperationProcessorTest", componentRegistry);
+        failureContainer = new FailureContainer(outputDirectory, componentRegistry, new HashSet<FailureType>());
 
         processor = new CoordinatorOperationProcessor(exceptionLogger, failureContainer, testPhaseListeners,
                 performanceStateContainer, hdrHistogramContainer);
@@ -105,7 +106,6 @@ public class CoordinatorOperationProcessorTest implements FailureListener {
     @After
     public void tearDown() {
         deleteQuiet(outputDirectory);
-        deleteQuiet(new File("failures-CoordinatorOperationProcessorTest.txt"));
     }
 
     @Override

--- a/utils/src/main/java/com/hazelcast/simulator/utils/FileUtils.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/FileUtils.java
@@ -284,9 +284,9 @@ public final class FileUtils {
         return dir;
     }
 
-    public static void ensureExistingDirectory(File dir) {
+    public static File ensureExistingDirectory(File dir) {
         if (dir.isDirectory()) {
-            return;
+            return dir;
         }
 
         if (dir.isFile()) {
@@ -296,6 +296,8 @@ public final class FileUtils {
         if (!dir.mkdirs()) {
             throw new UncheckedIOException("Could not create directory: " + dir.getAbsolutePath());
         }
+
+        return dir;
     }
 
     public static void rename(File source, File target) {


### PR DESCRIPTION
The output directory for all artifacts for a testsuite run are now downloaded in a new directory in the working directory. This directory will have some timestamp by default, but by setting the testsuite id, the directory name is also determined.

There is also an automatic download of the worker directories of the remote machine for that given testsuite-id.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/887

Another closely related feature is added. There is now a script which gets executed after the coordinator has completes running the testsuite and the artifacts are downloaded. This script will do whatever is needed, e.g. creating hgrm based on hdr files. If a file with the name 'after-completion.sh' s added to the working dir, one can fully control what is happening.