### PR TITLE
Removed the worker- prefix for directory names

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessLauncher.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessLauncher.java
@@ -96,7 +96,7 @@ public class WorkerProcessLauncher {
 
         SimulatorAddress workerAddress = new SimulatorAddress(
                 AddressLevel.WORKER, agent.getAddressIndex(), workerIndex, 0);
-        String workerId = "worker-" + workerAddress + '-' + agent.getPublicAddress() + '-' + type.toLowerCase();
+        String workerId = workerAddress.toString() + '-' + agent.getPublicAddress() + '-' + type.toLowerCase();
         File workerHome = ensureExistingDirectory(testSuiteDir, workerId);
 
         copyResourcesToWorkerHome(workerId);


### PR DESCRIPTION
Removed the `worker-` prefix for directory names to cleanup the redundant naming schema.