### PR TITLE
Using epoch time on performance.csv

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceLogWriter.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceLogWriter.java
@@ -20,35 +20,37 @@ import java.text.DecimalFormat;
 
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
 import static com.hazelcast.simulator.utils.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Responsible for writing to performance stats to disk in csv format.
  */
-final class PerformanceStatsWriter {
+final class PerformanceLogWriter {
 
     private final StringBuffer sb = new StringBuffer();
-    private final DecimalFormat format = new DecimalFormat("#.##");
+    private final DecimalFormat format = new DecimalFormat("#.###");
     private final File file;
 
-    PerformanceStatsWriter(File file) {
+    PerformanceLogWriter(File file) {
         this.file = checkNotNull(file, "file can't be null");
         writeHeader();
     }
 
     private void writeHeader() {
-        String columns = "time-millis,timestamp,operations,operations-delta,operations/second,number-of-tests,total-tests\n";
+        String columns = "epoch,timestamp,operations,operations-delta,operations/second,number-of-tests,total-tests\n";
         appendText(columns, file);
     }
 
     void write(long timeMillis,
-                      String timestamp,
-                      long operationsTotal,
-                      long operationsDelta,
-                      double operationsPerSecond,
-                      long numberOfTests,
-                      long totalTests) {
+               String timestamp,
+               long operationsTotal,
+               long operationsDelta,
+               double operationsPerSecond,
+               long numberOfTests,
+               long totalTests) {
         sb.setLength(0);
-        sb.append(timeMillis);
+        // ms are expressed in epoch time after the decimal point
+        sb.append(format.format(timeMillis * 1d / SECONDS.toMillis(1)));
         sb.append(',').append(timestamp);
         sb.append(',').append(operationsTotal);
         sb.append(',').append(operationsDelta);

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/TestPerformanceTracker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/TestPerformanceTracker.java
@@ -53,8 +53,8 @@ final class TestPerformanceTracker {
 
     private final Map<String, HistogramLogWriter> histogramLogWriterMap = new HashMap<String, HistogramLogWriter>();
     private final long testStartedTimestamp;
-    private final PerformanceStatsWriter performanceStatsWriter;
     private long lastIterations;
+    private final PerformanceLogWriter performanceLogWriter;
     private long lastTimestamp;
     private Map<String, Histogram> intervalHistogramMap;
     private double intervalAvgLatency;
@@ -71,7 +71,7 @@ final class TestPerformanceTracker {
         this.testId = testContainer.getTestCase().getId();
         this.testStartedTimestamp = testContainer.getTestStartedTimestamp();
         this.lastTimestamp = testStartedTimestamp;
-        this.performanceStatsWriter = new PerformanceStatsWriter(new File("performance-" + testId + ".csv"));
+        this.performanceLogWriter = new PerformanceLogWriter(new File("performance-" + testId + ".csv"));
 
         for (String probeName : testContainer.getProbeMap().keySet()) {
             histogramLogWriterMap.put(probeName, createHistogramLogWriter(testId, probeName, testStartedTimestamp));
@@ -143,7 +143,7 @@ final class TestPerformanceTracker {
     }
 
     void writeStatsToFile(long epochTime, String timestamp) {
-        performanceStatsWriter.write(
+        performanceLogWriter.write(
                 epochTime,
                 timestamp,
                 totalOperationCount,

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/WorkerPerformanceMonitor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/WorkerPerformanceMonitor.java
@@ -90,7 +90,7 @@ public class WorkerPerformanceMonitor {
      */
     private final class WorkerPerformanceMonitorThread extends Thread {
 
-        private final PerformanceStatsWriter globalPerformanceStatsWriter;
+        private final PerformanceLogWriter globalPerformanceLogWriter;
         private final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
         private final Map<String, TestPerformanceTracker> trackers = new ConcurrentHashMap<String, TestPerformanceTracker>();
         private final ServerConnector serverConnector;
@@ -105,7 +105,7 @@ public class WorkerPerformanceMonitor {
             this.serverConnector = serverConnector;
             this.testContainers = testContainers;
             this.intervalNanos = intervalNanos;
-            this.globalPerformanceStatsWriter = new PerformanceStatsWriter(new File("performance.csv"));
+            this.globalPerformanceLogWriter = new PerformanceLogWriter(new File("performance.csv"));
         }
 
         @Override
@@ -283,7 +283,7 @@ public class WorkerPerformanceMonitor {
             }
 
             // global performance stats
-            globalPerformanceStatsWriter.write(
+            globalPerformanceLogWriter.write(
                     currentTimestamp,
                     dateString,
                     globalOperationsCount,


### PR DESCRIPTION
The performance.csv now using epoch time. Time in millis is converted to seconds,
but millis are allowed to be expressed using a double.

This is comparable with e.g. dstats output