### PR TITLE
HDR TimeUnit fix

### DIFF
--- a/dist/src/main/dist/bin/benchmark-report
+++ b/dist/src/main/dist/bin/benchmark-report
@@ -11,16 +11,15 @@ image_height=1024
 # - cut of parts off the plot which are after completion or before start.
 # - graphs from same benchmark, same color.
 # - time in the hdr file; should be expressed in micro's instead of milli's with a comma?
-# - labels on latency suck
 # - from one of the latency:  [3.19078e+06:3.19078e+06], adjusting to [3.15888e+06:3.22269e+06]
 # - test suite / jvm parameters etc should all be copied into the output directory so the whole bundle is self explaining.
 # - regular latency histogram contains all hgrm files from each benchmark for each commulative probe; but no info which probe
 # - image link should only be printed of image exist
 # - summary of the benchmark
 # - statistics overview doesn't mention the name of the benchmark
-# - latency doesn't have a time unit
 #
 # DONE
+# - latency didn't have grid
 # - latency statistics has 'stuff' inside title
 # - cli:w hat if no directories are passed
 # - problem with dstat not found and reporting
@@ -328,7 +327,9 @@ report_latency(){
 
     plot_start
     plot "set terminal png size $image_width,$image_height"
+    plot "set grid"
     plot "unset xtics"
+    plot "set ylabel 'Latency (μs)'"
     plot "set logscale x"
     plot "set key top left"
     plot "set style line 1 lt 1 lw 3 pt 3 linecolor rgb \"red\""
@@ -358,40 +359,40 @@ report_latency(){
     html_img "latency"
 
     html_img "interval_25"
-    plot_latency_stat "Interval 25%" "Latency (ms)" "interval_25" 3
+    plot_latency_stat "Interval 25%" "Latency (μs)" "interval_25" 3
 
     html_img "interval_50"
-    plot_latency_stat "Interval 50%" "Latency (ms)" "interval_50" 4
+    plot_latency_stat "Interval 50%" "Latency (μs)" "interval_50" 4
 
     html_img "interval_75"
-    plot_latency_stat "Interval 75%" "Latency (ms)" "interval_75" 5
+    plot_latency_stat "Interval 75%" "Latency (μs)" "interval_75" 5
 
     html_img "interval_90"
-    plot_latency_stat "Interval 90%" "Latency (ms)" "interval_90" 6
+    plot_latency_stat "Interval 90%" "Latency (μs)" "interval_90" 6
 
     html_img "interval_99"
-    plot_latency_stat "Interval 99%" "Latency (ms)" "interval_99" 7
+    plot_latency_stat "Interval 99%" "Latency (μs)" "interval_99" 7
 
     html_img "interval_999"
-    plot_latency_stat "Interval 99.9%" "Latency (ms)" "interval_999" 8
+    plot_latency_stat "Interval 99.9%" "Latency (μs)" "interval_999" 8
 
     html_img "interval_9999"
-    plot_latency_stat "Interval 99.99%" "Latency (ms)" "interval_9999" 9
+    plot_latency_stat "Interval 99.99%" "Latency (μs)" "interval_9999" 9
 
     html_img "interval_99999"
-    plot_latency_stat "Interval 99.999%" "Latency (ms)" "interval_99999" 10
+    plot_latency_stat "Interval 99.999%" "Latency (μs)" "interval_99999" 10
 
     html_img "interval_min"
-    plot_latency_stat "Interval Min" "Latency (ms)" "interval_min" 11
+    plot_latency_stat "Interval Min" "Latency (μs)" "interval_min" 11
 
     html_img "interval_max"
-    plot_latency_stat "Interval Max" "Latency (ms)" "interval_max" 12
+    plot_latency_stat "Interval Max" "Latency (μs)" "interval_max" 12
 
     html_img "interval_mean"
-    plot_latency_stat "Interval Mean" "Latency (ms)" "interval_mean" 13
+    plot_latency_stat "Interval Mean" "Latency (μs)" "interval_mean" 13
 
     html_img "interval_std_deviation"
-    plot_latency_stat "Interval Std Deviation" "Latency (ms)" "interval_std_deviation" 14
+    plot_latency_stat "Interval Std Deviation" "Latency (μs)" "interval_std_deviation" 14
 }
 
 plot_dstat_probe(){

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceState.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceState.java
@@ -19,7 +19,7 @@ import static java.lang.Math.max;
 
 /**
  * Container to transfer performance statistics for some time window.
- *
+ * <p>
  * Has methods to combine {@link PerformanceState} instances by adding or setting maximum values.
  */
 public class PerformanceState {
@@ -33,9 +33,9 @@ public class PerformanceState {
     private double intervalThroughput;
     private double totalThroughput;
 
-    private double intervalAvgLatency;
-    private long intervalMaxLatency;
-    private long intervalPercentileLatency;
+    private double intervalLatencyAvgNanos;
+    private long intervalLatencyMaxNanos;
+    private long intervalLatency999PercentileNanos;
 
     /**
      * Creates an empty {@link PerformanceState} instance.
@@ -48,22 +48,27 @@ public class PerformanceState {
     /**
      * Creates a {@link PerformanceState} instance with values.
      *
-     * @param operationCount            Operation count value.
-     * @param intervalThroughput        Throughput value for an interval.
-     * @param totalThroughput           Total throughput value.
-     * @param intervalAvgLatency        Average latency for an interval.
-     * @param intervalPercentileLatency Percentile latency for an interval ({@link PerformanceState#INTERVAL_LATENCY_PERCENTILE}).
-     * @param intervalMaxLatency        Maximum latency for an interval.
+     * @param operationCount                    Operation count value.
+     * @param intervalThroughput                Throughput value for an interval.
+     * @param totalThroughput                   Total throughput value.
+     * @param intervalLatencyAvgNanos           Average latency for an interval.
+     * @param intervalLatency999PercentileNanos 99.9 Percentile latency for an interval
+     *                                          ({@link PerformanceState#INTERVAL_LATENCY_PERCENTILE}).
+     * @param intervalLatencyMaxNanos           Maximum latency for an interval.
      */
-    public PerformanceState(long operationCount, double intervalThroughput, double totalThroughput,
-                            double intervalAvgLatency, long intervalPercentileLatency, long intervalMaxLatency) {
+    public PerformanceState(long operationCount,
+                            double intervalThroughput,
+                            double totalThroughput,
+                            double intervalLatencyAvgNanos,
+                            long intervalLatency999PercentileNanos,
+                            long intervalLatencyMaxNanos) {
         this.operationCount = operationCount;
         this.intervalThroughput = intervalThroughput;
         this.totalThroughput = totalThroughput;
 
-        this.intervalAvgLatency = intervalAvgLatency;
-        this.intervalPercentileLatency = intervalPercentileLatency;
-        this.intervalMaxLatency = intervalMaxLatency;
+        this.intervalLatencyAvgNanos = intervalLatencyAvgNanos;
+        this.intervalLatency999PercentileNanos = intervalLatency999PercentileNanos;
+        this.intervalLatencyMaxNanos = intervalLatencyMaxNanos;
     }
 
     /**
@@ -77,14 +82,14 @@ public class PerformanceState {
 
     /**
      * Combines {@link PerformanceState} instances, e.g. from different Simulator Workers.
-     *
+     * <p>
      * For the real-time performance monitor during the {@link com.hazelcast.simulator.test.TestPhase#RUN} the maximum values
      * should be set, so we get the maximum operation count and throughput values of all {@link PerformanceState} instances of
      * the last interval.
-     *
+     * <p>
      * For the total performance number and the performance per Simulator Agent, the added values should be set, so we get the
      * summed up operation count and throughput values.
-     *
+     * <p>
      * The method always sets the maximum values for latency.
      *
      * @param other                          {@link PerformanceState} which should be added to this instance
@@ -101,9 +106,9 @@ public class PerformanceState {
             intervalThroughput = other.intervalThroughput;
             totalThroughput = other.totalThroughput;
 
-            intervalAvgLatency = other.intervalAvgLatency;
-            intervalPercentileLatency = other.intervalPercentileLatency;
-            intervalMaxLatency = other.intervalMaxLatency;
+            intervalLatencyAvgNanos = other.intervalLatencyAvgNanos;
+            intervalLatency999PercentileNanos = other.intervalLatency999PercentileNanos;
+            intervalLatencyMaxNanos = other.intervalLatencyMaxNanos;
         } else {
             if (addOperationCountAndThroughput) {
                 operationCount += other.operationCount;
@@ -115,9 +120,9 @@ public class PerformanceState {
                 totalThroughput = max(totalThroughput, other.totalThroughput);
             }
 
-            intervalAvgLatency = max(intervalAvgLatency, other.intervalAvgLatency);
-            intervalPercentileLatency = max(intervalPercentileLatency, other.intervalPercentileLatency);
-            intervalMaxLatency = max(intervalMaxLatency, other.intervalMaxLatency);
+            intervalLatencyAvgNanos = max(intervalLatencyAvgNanos, other.intervalLatencyAvgNanos);
+            intervalLatency999PercentileNanos = max(intervalLatency999PercentileNanos, other.intervalLatency999PercentileNanos);
+            intervalLatencyMaxNanos = max(intervalLatencyMaxNanos, other.intervalLatencyMaxNanos);
         }
     }
 
@@ -142,16 +147,16 @@ public class PerformanceState {
         return intervalThroughput;
     }
 
-    public double getIntervalAvgLatency() {
-        return intervalAvgLatency;
+    public double getIntervalLatencyAvgNanos() {
+        return intervalLatencyAvgNanos;
     }
 
-    public long getIntervalPercentileLatency() {
-        return intervalPercentileLatency;
+    public long getIntervalLatency999PercentileNanos() {
+        return intervalLatency999PercentileNanos;
     }
 
-    public long getIntervalMaxLatency() {
-        return intervalMaxLatency;
+    public long getIntervalLatencyMaxNanos() {
+        return intervalLatencyMaxNanos;
     }
 
     @Override
@@ -160,9 +165,9 @@ public class PerformanceState {
                 + "operationCount=" + operationCount
                 + ", intervalThroughput=" + intervalThroughput
                 + ", totalThroughput=" + totalThroughput
-                + ", intervalAvgLatency=" + intervalAvgLatency
-                + ", intervalPercentileLatency=" + intervalPercentileLatency
-                + ", intervalMaxLatency=" + intervalMaxLatency
+                + ", intervalAvgLatencyNanos=" + intervalLatencyAvgNanos
+                + ", intervalLatency999PercentileNanos=" + intervalLatency999PercentileNanos
+                + ", intervalMaxLatencyNanos=" + intervalLatencyMaxNanos
                 + '}';
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/TestPerformanceTracker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/TestPerformanceTracker.java
@@ -51,9 +51,9 @@ final class TestPerformanceTracker {
     private final PerformanceLogWriter performanceLogWriter;
     private long lastTimestamp;
     private Map<String, Histogram> intervalHistogramMap;
-    private double intervalAvgLatency;
-    private long intervalPercentileLatency;
-    private long intervalMaxLatency;
+    private double intervalLatencyAvgNanos;
+    private long intervalLatency999PercentileNanos;
+    private long intervalLatencyMaxNanos;
     private long intervalOperationCount;
     private long totalOperationCount;
     private double intervalThroughput;
@@ -118,9 +118,9 @@ final class TestPerformanceTracker {
                 long intervalMaxLatency, long intervalOperationCount, long iterations, long currentTimestamp) {
         this.intervalHistogramMap = intervalHistograms;
 
-        this.intervalPercentileLatency = intervalPercentileLatency;
-        this.intervalAvgLatency = intervalAvgLatency;
-        this.intervalMaxLatency = intervalMaxLatency;
+        this.intervalLatency999PercentileNanos = intervalPercentileLatency;
+        this.intervalLatencyAvgNanos = intervalAvgLatency;
+        this.intervalLatencyMaxNanos = intervalMaxLatency;
 
         this.intervalOperationCount = intervalOperationCount;
         this.totalOperationCount += intervalOperationCount;
@@ -157,7 +157,7 @@ final class TestPerformanceTracker {
 
     PerformanceState createPerformanceState() {
         return new PerformanceState(totalOperationCount, intervalThroughput, totalThroughput,
-                intervalAvgLatency, intervalPercentileLatency, intervalMaxLatency);
+                intervalLatencyAvgNanos, intervalLatency999PercentileNanos, intervalLatencyMaxNanos);
     }
 
     static HistogramLogWriter createHistogramLogWriter(String testId, String probeName, long baseTime) {

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/PerformanceStateContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/PerformanceStateContainerTest.java
@@ -8,8 +8,9 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -67,7 +68,8 @@ public class PerformanceStateContainerTest {
         SimulatorAddress worker = new SimulatorAddress(AddressLevel.WORKER, 3, 1, 0);
 
         Map<String, PerformanceState> performanceStates = new HashMap<String, PerformanceState>();
-        performanceStates.put(TEST_CASE_ID_1, new PerformanceState(800, 100, 300, TimeUnit.SECONDS.toMicros(3), 2400, 2500));
+        performanceStates.put(TEST_CASE_ID_1, new PerformanceState(
+                800, 100, 300, SECONDS.toNanos(3), MICROSECONDS.toNanos(2400), MICROSECONDS.toNanos(2500)));
 
         performanceStateContainer.update(worker, performanceStates);
 
@@ -94,9 +96,9 @@ public class PerformanceStateContainerTest {
         assertEquals(2300, performanceState.getOperationCount());
         assertEquals(300.0, performanceState.getIntervalThroughput(), ASSERT_EQUALS_DELTA);
         assertEquals(850.0, performanceState.getTotalThroughput(), ASSERT_EQUALS_DELTA);
-        assertEquals(2400, performanceState.getIntervalPercentileLatency());
-        assertEquals(2200.0d, performanceState.getIntervalAvgLatency(), 0.001);
-        assertEquals(2800, performanceState.getIntervalMaxLatency());
+        assertEquals(2400, performanceState.getIntervalLatency999PercentileNanos());
+        assertEquals(2200.0d, performanceState.getIntervalLatencyAvgNanos(), 0.001);
+        assertEquals(2800, performanceState.getIntervalLatencyMaxNanos());
     }
 
     @Test
@@ -135,22 +137,22 @@ public class PerformanceStateContainerTest {
         assertEquals(3500, performanceStateAgent1.getOperationCount());
         assertEquals(1100, performanceStateAgent1.getIntervalThroughput(), ASSERT_EQUALS_DELTA);
         assertEquals(1400, performanceStateAgent1.getTotalThroughput(), ASSERT_EQUALS_DELTA);
-        assertEquals(2100, performanceStateAgent1.getIntervalPercentileLatency());
-        assertEquals(2800, performanceStateAgent1.getIntervalMaxLatency());
+        assertEquals(2100, performanceStateAgent1.getIntervalLatency999PercentileNanos());
+        assertEquals(2800, performanceStateAgent1.getIntervalLatencyMaxNanos());
 
         PerformanceState performanceStateAgent2 = agentPerformanceStateMap.get(agentAddress2);
         assertEquals(2000, performanceStateAgent2.getOperationCount());
         assertEquals(800, performanceStateAgent2.getIntervalThroughput(), ASSERT_EQUALS_DELTA);
         assertEquals(900, performanceStateAgent2.getTotalThroughput(), ASSERT_EQUALS_DELTA);
-        assertEquals(2600, performanceStateAgent2.getIntervalPercentileLatency());
-        assertEquals(2900, performanceStateAgent2.getIntervalMaxLatency());
+        assertEquals(2600, performanceStateAgent2.getIntervalLatency999PercentileNanos());
+        assertEquals(2900, performanceStateAgent2.getIntervalLatencyMaxNanos());
 
         assertFalse(totalPerformanceState.isEmpty());
         assertEquals(5500, totalPerformanceState.getOperationCount());
         assertEquals(1900, totalPerformanceState.getIntervalThroughput(), ASSERT_EQUALS_DELTA);
         assertEquals(2300, totalPerformanceState.getTotalThroughput(), ASSERT_EQUALS_DELTA);
-        assertEquals(2600, totalPerformanceState.getIntervalPercentileLatency());
-        assertEquals(2900, totalPerformanceState.getIntervalMaxLatency());
+        assertEquals(2600, totalPerformanceState.getIntervalLatency999PercentileNanos());
+        assertEquals(2900, totalPerformanceState.getIntervalLatencyMaxNanos());
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/probes/ProbeTestUtils.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/probes/ProbeTestUtils.java
@@ -5,13 +5,7 @@ import org.HdrHistogram.Histogram;
 
 import java.util.Random;
 
-import static com.hazelcast.simulator.probes.impl.HdrProbe.LATENCY_PRECISION;
-import static com.hazelcast.simulator.probes.impl.HdrProbe.MAXIMUM_LATENCY;
-import static com.hazelcast.simulator.utils.TestUtils.assertEqualsStringFormat;
-import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static com.hazelcast.simulator.probes.impl.HdrProbe.HIGHEST_TRACKABLE_VALUE;
 
 public final class ProbeTestUtils {
 
@@ -20,7 +14,6 @@ public final class ProbeTestUtils {
 
     private static final int HISTOGRAM_RECORD_COUNT = 5000;
     private static final int MAX_LATENCY = 30000;
-    private static final int TOLERANCE_MILLIS = 1000;
 
     private static final Random RANDOM = new Random();
 
@@ -34,7 +27,7 @@ public final class ProbeTestUtils {
     }
 
     public static Histogram createRandomHistogram(int recordCount) {
-        Histogram histogram = new Histogram(MAXIMUM_LATENCY, LATENCY_PRECISION);
+        Histogram histogram = new Histogram(HIGHEST_TRACKABLE_VALUE, 3);
         for (int record = 0; record < recordCount; record++) {
             histogram.recordValue(getRandomLatency());
         }
@@ -43,32 +36,5 @@ public final class ProbeTestUtils {
 
     public static int getRandomLatency() {
         return RANDOM.nextInt(MAX_LATENCY);
-    }
-
-    public static void assertHistogram(Histogram histogram, long expectedCount, long expectedMinValueMillis,
-                                       long expectedMaxValueMillis, long expectedMeanValueMillis) {
-        long toleranceMicros = MILLISECONDS.toMicros(TOLERANCE_MILLIS);
-
-        long minValue = histogram.getMinValue();
-        long maxValue = histogram.getMaxValue();
-
-        if (expectedMinValueMillis != expectedMaxValueMillis) {
-            assertNotEquals("Expected minValue and maxValue to differ", minValue, maxValue);
-        }
-
-        assertWithinTolerance("minValue", MILLISECONDS.toMicros(expectedMinValueMillis), minValue, toleranceMicros);
-        assertWithinTolerance("maxValue", MILLISECONDS.toMicros(expectedMaxValueMillis), maxValue, toleranceMicros);
-
-        long meanValue = (long) histogram.getMean();
-        assertWithinTolerance("meanValue", MILLISECONDS.toMicros(expectedMeanValueMillis), meanValue, toleranceMicros);
-
-        assertEqualsStringFormat("Expected %d records, but was %d", expectedCount, histogram.getTotalCount());
-    }
-
-    public static void assertWithinTolerance(String fieldName, long expected, long actual, long tolerance) {
-        assertTrue(format("Expected %s >= %d, but was %d", fieldName, expected - tolerance, actual),
-                actual >= expected - tolerance);
-        assertTrue(format("Expected %s <= %d, but was %d", fieldName, expected + tolerance, actual),
-                actual <= expected + tolerance);
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
@@ -176,7 +176,7 @@ public class CoordinatorOperationProcessorTest implements FailureListener {
     @Test
     public void processPerformanceState() {
         PerformanceStateOperation operation = new PerformanceStateOperation();
-        operation.addPerformanceState("testId", new PerformanceState(1000, 50.0, 1234.56, 33.0d, 23, 42));
+        operation.addPerformanceState("testId", new PerformanceState(1000, 50.0, 1234.56, 33000.0d, 23000, 42000));
 
         ResponseType responseType = processor.process(operation, workerAddress);
         assertEquals(SUCCESS, responseType);

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/performance/PerformanceStateTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/performance/PerformanceStateTest.java
@@ -22,9 +22,9 @@ public class PerformanceStateTest {
         assertEquals(250, addState.getOperationCount());
         assertEquals(11.0, addState.getIntervalThroughput(), 0.00001);
         assertEquals(22.0, addState.getTotalThroughput(), 0.00001);
-        assertEquals(150, addState.getIntervalPercentileLatency());
-        assertEquals(175.0d, addState.getIntervalAvgLatency(), 0.00001);
-        assertEquals(200, addState.getIntervalMaxLatency());
+        assertEquals(150, addState.getIntervalLatency999PercentileNanos());
+        assertEquals(175.0d, addState.getIntervalLatencyAvgNanos(), 0.00001);
+        assertEquals(200, addState.getIntervalLatencyMaxNanos());
     }
 
     @Test
@@ -36,9 +36,9 @@ public class PerformanceStateTest {
         assertEquals(100, addState.getOperationCount());
         assertEquals(5.0, addState.getIntervalThroughput(), 0.00001);
         assertEquals(10.0, addState.getTotalThroughput(), 0.00001);
-        assertEquals(300, addState.getIntervalPercentileLatency());
-        assertEquals(550.0d, addState.getIntervalAvgLatency(), 0.00001);
-        assertEquals(800, addState.getIntervalMaxLatency());
+        assertEquals(300, addState.getIntervalLatency999PercentileNanos());
+        assertEquals(550.0d, addState.getIntervalLatencyAvgNanos(), 0.00001);
+        assertEquals(800, addState.getIntervalLatencyMaxNanos());
     }
 
     @Test
@@ -50,9 +50,9 @@ public class PerformanceStateTest {
         assertEquals(100, addState.getOperationCount());
         assertEquals(5.0, addState.getIntervalThroughput(), 0.00001);
         assertEquals(10.0, addState.getTotalThroughput(), 0.00001);
-        assertEquals(400, addState.getIntervalPercentileLatency());
-        assertEquals(450.0d, addState.getIntervalAvgLatency(), 0.00001);
-        assertEquals(500, addState.getIntervalMaxLatency());
+        assertEquals(400, addState.getIntervalLatency999PercentileNanos());
+        assertEquals(450.0d, addState.getIntervalLatencyAvgNanos(), 0.00001);
+        assertEquals(500, addState.getIntervalLatencyMaxNanos());
     }
 
     @Test
@@ -64,9 +64,9 @@ public class PerformanceStateTest {
         assertEquals(150, addState.getOperationCount());
         assertEquals(6.0, addState.getIntervalThroughput(), 0.00001);
         assertEquals(12.0, addState.getTotalThroughput(), 0.00001);
-        assertEquals(150, addState.getIntervalPercentileLatency());
-        assertEquals(175.0d, addState.getIntervalAvgLatency(), 0.00001);
-        assertEquals(200, addState.getIntervalMaxLatency());
+        assertEquals(150, addState.getIntervalLatency999PercentileNanos());
+        assertEquals(175.0d, addState.getIntervalLatencyAvgNanos(), 0.00001);
+        assertEquals(200, addState.getIntervalLatencyMaxNanos());
     }
 
     @Test
@@ -78,9 +78,9 @@ public class PerformanceStateTest {
         assertEquals(100, addState.getOperationCount());
         assertEquals(5.0, addState.getIntervalThroughput(), 0.00001);
         assertEquals(10.0, addState.getTotalThroughput(), 0.00001);
-        assertEquals(300, addState.getIntervalPercentileLatency());
-        assertEquals(550.0d, addState.getIntervalAvgLatency(), 0.00001);
-        assertEquals(800, addState.getIntervalMaxLatency());
+        assertEquals(300, addState.getIntervalLatency999PercentileNanos());
+        assertEquals(550.0d, addState.getIntervalLatencyAvgNanos(), 0.00001);
+        assertEquals(800, addState.getIntervalLatencyMaxNanos());
     }
 
     @Test
@@ -92,9 +92,9 @@ public class PerformanceStateTest {
         assertEquals(100, addState.getOperationCount());
         assertEquals(5.0, addState.getIntervalThroughput(), 0.00001);
         assertEquals(10.0, addState.getTotalThroughput(), 0.00001);
-        assertEquals(400, addState.getIntervalPercentileLatency());
-        assertEquals(450.0d, addState.getIntervalAvgLatency(), 0.00001);
-        assertEquals(500, addState.getIntervalMaxLatency());
+        assertEquals(400, addState.getIntervalLatency999PercentileNanos());
+        assertEquals(450.0d, addState.getIntervalLatencyAvgNanos(), 0.00001);
+        assertEquals(500, addState.getIntervalLatencyMaxNanos());
     }
 
     @Test


### PR DESCRIPTION
The HDRProbe measures in microseconds (so it convers nanos to micro's). But this makes tooling like the HistogramLogProcessor not intuitive to use.

So the Recorder in the HDRProbe now stores the measured data in nanos, but it is configured that it can drop nano second detail. 