### PR TITLE
Replaced warmup by prepare

### DIFF
--- a/archetype/src/main/resources/archetype-resources/src/main/java/ExampleTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/main/java/ExampleTest.java
@@ -18,11 +18,12 @@ package ${package};
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
+
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,8 +42,8 @@ public class ExampleTest extends AbstractTest {
         logger.info("Map name is: " + map.getName());
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         logger.info("======== WARMUP =========");
         logger.info("Map size is: " + map.size());
     }

--- a/dist/src/main/dist/tests/special/mapheaphogwarmup.properties
+++ b/dist/src/main/dist/tests/special/mapheaphogwarmup.properties
@@ -1,4 +1,4 @@
-class = com.hazelcast.simulator.tests.special.MapHeapHogWarmupTest
+class = com.hazelcast.simulator.tests.special.MapHeapHogPrepareTest
 threadCount = 10
 ttlHours = 24
 approxHeapUsageFactor = 0.9

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -38,11 +38,11 @@ import java.util.concurrent.CountDownLatch;
 import static com.hazelcast.simulator.test.TestPhase.GLOBAL_AFTER_WARMUP;
 import static com.hazelcast.simulator.test.TestPhase.GLOBAL_TEARDOWN;
 import static com.hazelcast.simulator.test.TestPhase.GLOBAL_VERIFY;
-import static com.hazelcast.simulator.test.TestPhase.GLOBAL_WARMUP;
+import static com.hazelcast.simulator.test.TestPhase.GLOBAL_PREPARE;
 import static com.hazelcast.simulator.test.TestPhase.LOCAL_AFTER_WARMUP;
 import static com.hazelcast.simulator.test.TestPhase.LOCAL_TEARDOWN;
 import static com.hazelcast.simulator.test.TestPhase.LOCAL_VERIFY;
-import static com.hazelcast.simulator.test.TestPhase.LOCAL_WARMUP;
+import static com.hazelcast.simulator.test.TestPhase.LOCAL_PREPARE;
 import static com.hazelcast.simulator.test.TestPhase.RUN;
 import static com.hazelcast.simulator.test.TestPhase.SETUP;
 import static com.hazelcast.simulator.test.TestPhase.WARMUP;
@@ -135,8 +135,8 @@ final class TestCaseRunner implements TestPhaseListener {
             createTest();
             executePhase(SETUP);
 
-            executePhase(LOCAL_WARMUP);
-            executePhase(GLOBAL_WARMUP);
+            executePhase(LOCAL_PREPARE);
+            executePhase(GLOBAL_PREPARE);
 
             if (testSuite.getWarmupDurationSeconds() > 0) {
                 executeWarmup();

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestPhase.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestPhase.java
@@ -23,8 +23,8 @@ public enum TestPhase {
 
     SETUP("setup", false),
     WARMUP("warmup", false),
-    LOCAL_WARMUP("local warmup", false),
-    GLOBAL_WARMUP("global warmup", true),
+    LOCAL_PREPARE("local prepare", false),
+    GLOBAL_PREPARE("global prepare", true),
     LOCAL_AFTER_WARMUP("local after warmup", false),
     GLOBAL_AFTER_WARMUP("global after warmup", true),
     RUN("run", false),

--- a/simulator/src/main/java/com/hazelcast/simulator/test/annotations/Prepare.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/annotations/Prepare.java
@@ -20,13 +20,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * @deprecated since Simulator 0.9. Use {@link Prepare} instead. This reason this class is deprecated, is that the name warmup
- * is confusing since it is being used to heat up the jit, but also it is used to fill the data-structures.
- */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Warmup {
+public @interface Prepare {
 
     /**
      * Global indicates that a single member in the cluster is responsible for the warmup. If not global, then

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/AnnotationFilter.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/AnnotationFilter.java
@@ -16,6 +16,7 @@
 package com.hazelcast.simulator.utils;
 
 import com.hazelcast.simulator.test.annotations.AfterWarmup;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.test.annotations.Warmup;
@@ -60,6 +61,19 @@ public interface AnnotationFilter<A extends Annotation> {
 
         @Override
         public boolean allowed(Warmup verify) {
+            return verify.global() == isGlobal;
+        }
+    }
+
+    class PrepareFilter implements AnnotationFilter<Prepare> {
+        private final boolean isGlobal;
+
+        public PrepareFilter(boolean isGlobal) {
+            this.isGlobal = isGlobal;
+        }
+
+        @Override
+        public boolean allowed(Prepare verify) {
             return verify.global() == isGlobal;
         }
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -184,8 +184,8 @@ public class AgentSmokeTest implements FailureListener {
 
             runPhase(testPhaseListener, testCase, TestPhase.SETUP);
 
-            runPhase(testPhaseListener, testCase, TestPhase.LOCAL_WARMUP);
-            runPhase(testPhaseListener, testCase, TestPhase.GLOBAL_WARMUP);
+            runPhase(testPhaseListener, testCase, TestPhase.LOCAL_PREPARE);
+            runPhase(testPhaseListener, testCase, TestPhase.GLOBAL_PREPARE);
 
             LOGGER.info("Starting run phase...");
             remoteClient.sendToTestOnAllWorkers(testId, new StartTestOperation());

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -4,7 +4,6 @@ import com.hazelcast.simulator.protocol.registry.AgentData;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.test.TestPhase;
 import com.hazelcast.simulator.test.TestSuite;
-import com.hazelcast.simulator.test.annotations.BeforeRun;
 import com.hazelcast.simulator.utils.CloudProviderUtils;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.junit.After;
@@ -320,13 +319,13 @@ public class CoordinatorCliTest {
     }
 
     @Test
-    public void testInit_syncToTestPhase_globalWarmup() {
+    public void testInit_syncToTestPhase_globalPrepare() {
         args.add("--syncToTestPhase");
-        args.add("GLOBAL_WARMUP");
+        args.add("GLOBAL_PREPARE");
 
         Coordinator coordinator = createCoordinator();
 
-        assertEquals(TestPhase.GLOBAL_WARMUP, coordinator.getCoordinatorParameters().getLastTestPhaseToSync());
+        assertEquals(TestPhase.GLOBAL_PREPARE, coordinator.getCoordinatorParameters().getLastTestPhaseToSync());
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/TestPhaseListenersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/TestPhaseListenersTest.java
@@ -36,9 +36,9 @@ public class TestPhaseListenersTest {
         UnitTestPhaseListener listener = new UnitTestPhaseListener();
         testPhaseListeners.addListener(1, listener);
 
-        testPhaseListeners.updatePhaseCompletion(1, TestPhase.GLOBAL_WARMUP, null);
+        testPhaseListeners.updatePhaseCompletion(1, TestPhase.GLOBAL_PREPARE, null);
 
-        assertEquals(TestPhase.GLOBAL_WARMUP, listener.lastTestPhase);
+        assertEquals(TestPhase.GLOBAL_PREPARE, listener.lastTestPhase);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class TestPhaseListenersTest {
         UnitTestPhaseListener listener = new UnitTestPhaseListener();
         testPhaseListeners.addListener(1, listener);
 
-        testPhaseListeners.updatePhaseCompletion(2, TestPhase.GLOBAL_WARMUP, null);
+        testPhaseListeners.updatePhaseCompletion(2, TestPhase.GLOBAL_PREPARE, null);
 
         assertEquals(null, listener.lastTestPhase);
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/test/TestContainer_WarmupTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/TestContainer_WarmupTest.java
@@ -1,6 +1,6 @@
 package com.hazelcast.simulator.test;
 
-import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -12,35 +12,35 @@ public class TestContainer_WarmupTest extends AbstractTestContainerTest {
     public void testLocalWarmup() throws Exception {
         WarmupTest test = new WarmupTest();
         testContainer = createTestContainer(test);
-        testContainer.invoke(TestPhase.LOCAL_WARMUP);
+        testContainer.invoke(TestPhase.LOCAL_PREPARE);
 
-        assertTrue(test.localWarmupCalled);
-        assertFalse(test.globalWarmupCalled);
+        assertTrue(test.localPrepareCalled);
+        assertFalse(test.globalPrepareCalled);
     }
 
     @Test
     public void testGlobalWarmup() throws Exception {
         WarmupTest test = new WarmupTest();
         testContainer = createTestContainer(test);
-        testContainer.invoke(TestPhase.GLOBAL_WARMUP);
+        testContainer.invoke(TestPhase.GLOBAL_PREPARE);
 
-        assertFalse(test.localWarmupCalled);
-        assertTrue(test.globalWarmupCalled);
+        assertFalse(test.localPrepareCalled);
+        assertTrue(test.globalPrepareCalled);
     }
 
     private static class WarmupTest extends BaseTest {
 
-        private boolean localWarmupCalled;
-        private boolean globalWarmupCalled;
+        private boolean localPrepareCalled;
+        private boolean globalPrepareCalled;
 
-        @Warmup
-        public void localTeardown() {
-            localWarmupCalled = true;
+        @Prepare
+        public void localPrepare() {
+            localPrepareCalled = true;
         }
 
-        @Warmup(global = true)
-        public void globalTeardown() {
-            globalWarmupCalled = true;
+        @Prepare(global = true)
+        public void globalPrepare() {
+            globalPrepareCalled = true;
         }
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/test/TestPhaseTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/test/TestPhaseTest.java
@@ -16,8 +16,8 @@ public class TestPhaseTest {
         Map<TestPhase, CountDownLatch> testPhaseSyncMap = getTestPhaseSyncMap(5, true, TestPhase.RUN);
 
         assertEquals(5, testPhaseSyncMap.get(TestPhase.SETUP).getCount());
-        assertEquals(5, testPhaseSyncMap.get(TestPhase.LOCAL_WARMUP).getCount());
-        assertEquals(5, testPhaseSyncMap.get(TestPhase.GLOBAL_WARMUP).getCount());
+        assertEquals(5, testPhaseSyncMap.get(TestPhase.LOCAL_PREPARE).getCount());
+        assertEquals(5, testPhaseSyncMap.get(TestPhase.GLOBAL_PREPARE).getCount());
         assertEquals(5, testPhaseSyncMap.get(TestPhase.RUN).getCount());
         assertEquals(0, testPhaseSyncMap.get(TestPhase.GLOBAL_VERIFY).getCount());
         assertEquals(0, testPhaseSyncMap.get(TestPhase.LOCAL_VERIFY).getCount());

--- a/simulator/src/test/java/com/hazelcast/simulator/tests/FailingTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/tests/FailingTest.java
@@ -17,10 +17,10 @@ package com.hazelcast.simulator.tests;
 
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static org.junit.Assert.fail;
@@ -34,8 +34,8 @@ public class FailingTest {
         this.context = context;
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         sleepSeconds(1);
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/tests/SuccessTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/tests/SuccessTest.java
@@ -16,11 +16,11 @@
 package com.hazelcast.simulator.tests;
 
 import com.hazelcast.simulator.test.TestContext;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 
@@ -41,13 +41,13 @@ public class SuccessTest {
     public void globalTearDown() {
     }
 
-    @Warmup(global = false)
-    public void localWarmup() {
+    @Prepare(global = false)
+    public void localPrepare() {
         sleepSeconds(1);
     }
 
-    @Warmup(global = true)
-    public void globalWarmup() {
+    @Prepare(global = true)
+    public void globalPrepare() {
         sleepSeconds(1);
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotatedMethodRetrieverTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotatedMethodRetrieverTest.java
@@ -1,11 +1,11 @@
 package com.hazelcast.simulator.utils;
 
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -19,7 +19,7 @@ public class AnnotatedMethodRetrieverTest {
 
     @Test
     public void testGetAtMostOneVoidMethodSkipArgsCheck() {
-        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Warmup.class)
+        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Prepare.class)
                 .withVoidReturnType()
                 .find();
         assertEquals("voidMethod", method.getName());
@@ -27,7 +27,7 @@ public class AnnotatedMethodRetrieverTest {
 
     @Test
     public void testGetAtMostOneVoidMethodWithoutArgs() {
-        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Warmup.class)
+        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Prepare.class)
                 .withVoidReturnType()
                 .withoutArgs()
                 .find();
@@ -37,7 +37,7 @@ public class AnnotatedMethodRetrieverTest {
 
     @Test
     public void testGetAtMostOneVoidMethodWithoutArgs_AnnotationFilter() {
-        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Warmup.class)
+        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Prepare.class)
                 .withFilter(ALWAYS_FILTER)
                 .withVoidReturnType()
                 .withoutArgs()
@@ -92,7 +92,7 @@ public class AnnotatedMethodRetrieverTest {
 
     @Test(expected = ReflectionException.class)
     public void testGetAtMostOneVoidMethodWithoutArgs_wrongReturnTypeArgsFound() {
-        new AnnotatedMethodRetriever(AnnotationTestClass.class, Warmup.class)
+        new AnnotatedMethodRetriever(AnnotationTestClass.class, Prepare.class)
                 .withReturnType(String.class)
                 .withoutArgs()
                 .find();
@@ -166,7 +166,7 @@ public class AnnotatedMethodRetrieverTest {
             return null;
         }
 
-        @Warmup
+        @Prepare
         public void voidMethod() {
         }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotationFilterTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/AnnotationFilterTest.java
@@ -1,12 +1,12 @@
 package com.hazelcast.simulator.utils;
 
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
+import com.hazelcast.simulator.utils.AnnotationFilter.PrepareFilter;
 import com.hazelcast.simulator.utils.AnnotationFilter.TeardownFilter;
 import com.hazelcast.simulator.utils.AnnotationFilter.VerifyFilter;
-import com.hazelcast.simulator.utils.AnnotationFilter.WarmupFilter;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -20,7 +20,6 @@ public class AnnotationFilterTest {
     public void testAlwaysFilter() {
         Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Setup.class)
                 .withVoidReturnType()
-                .withVoidReturnType()
                 .withFilter(ALWAYS_FILTER)
                 .find();
         assertEquals("setupMethod", method.getName());
@@ -29,7 +28,6 @@ public class AnnotationFilterTest {
     @Test
     public void testLocalTeardownFilter() {
         Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Teardown.class)
-                .withVoidReturnType()
                 .withVoidReturnType()
                 .withFilter(new TeardownFilter(false))
                 .find();
@@ -41,7 +39,6 @@ public class AnnotationFilterTest {
     public void testGlobalTeardownFilter() {
         Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Teardown.class)
                 .withVoidReturnType()
-                .withVoidReturnType()
                 .withFilter(new TeardownFilter(true))
                 .find();
         assertEquals("globalTearDown", method.getName());
@@ -49,29 +46,26 @@ public class AnnotationFilterTest {
 
     @Test
     public void testLocalWarmupFilter() {
-        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Warmup.class)
+        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Prepare.class)
                 .withVoidReturnType()
-                .withVoidReturnType()
-                .withFilter(new WarmupFilter(false))
+                .withFilter(new PrepareFilter(false))
                 .find();
 
-        assertEquals("localWarmup", method.getName());
+        assertEquals("localPrepare", method.getName());
     }
 
     @Test
     public void testGlobalWarmupFilter() {
-        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Warmup.class)
+        Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Prepare.class)
                 .withVoidReturnType()
-                .withVoidReturnType()
-                .withFilter(new WarmupFilter(true))
+                .withFilter(new PrepareFilter(true))
                 .find();
-        assertEquals("globalWarmup", method.getName());
+        assertEquals("globalPrepare", method.getName());
     }
 
     @Test
     public void testLocalVerifyFilter() {
         Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Verify.class)
-                .withVoidReturnType()
                 .withVoidReturnType()
                 .withFilter(new VerifyFilter(false))
                 .find();
@@ -81,7 +75,6 @@ public class AnnotationFilterTest {
     @Test
     public void testGlobalVerifyFilter() {
         Method method = new AnnotatedMethodRetriever(AnnotationTestClass.class, Verify.class)
-                .withVoidReturnType()
                 .withVoidReturnType()
                 .withFilter(new VerifyFilter(true))
                 .find();
@@ -104,12 +97,12 @@ public class AnnotationFilterTest {
         public void globalTearDown() {
         }
 
-        @Warmup(global = false)
-        public void localWarmup() {
+        @Prepare(global = false)
+        public void localPrepare() {
         }
 
-        @Warmup(global = true)
-        public void globalWarmup() {
+        @Prepare(global = true)
+        public void globalPrepare() {
         }
 
         @Verify(global = false)

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/TimeStepRunStrategyIntegrationTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/TimeStepRunStrategyIntegrationTest.java
@@ -114,7 +114,7 @@ public class TimeStepRunStrategyIntegrationTest {
         testContext.stop();
         warmupFuture.get();
         container.invoke(TestPhase.LOCAL_AFTER_WARMUP);
-        container.invoke(TestPhase.GLOBAL_WARMUP);
+        container.invoke(TestPhase.GLOBAL_PREPARE);
 
         Future runFuture = spawn(new Callable() {
             @Override

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/ExampleTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/ExampleTest.java
@@ -18,11 +18,11 @@ package com.hazelcast.simulator.tests;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,9 +41,9 @@ public class ExampleTest extends AbstractTest {
         logger.info("Map name is: " + map.getName());
     }
 
-    @Warmup
-    public void warmup() {
-        logger.info("======== WARMUP =========");
+    @Prepare
+    public void prepare() {
+        logger.info("======== PREPARE =========");
         logger.info("Map size is: " + map.size());
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/GenericOperationTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/GenericOperationTest.java
@@ -21,10 +21,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.OperationService;
@@ -52,8 +52,8 @@ public class GenericOperationTest extends AbstractTest {
         operationService = getOperationService(targetInstance);
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         Set<Member> memberSet = targetInstance.getCluster().getMembers();
         memberAddresses = new Address[memberSet.size()];
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockConflictTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockConflictTest.java
@@ -20,10 +20,10 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyIncrementPair;
 
 import java.util.ArrayList;
@@ -56,8 +56,8 @@ public class LockConflictTest extends AbstractTest {
         globalCounter = targetInstance.getList(name + "report");
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             list.add(0L);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/LockTest.java
@@ -20,11 +20,11 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.TestException;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -45,8 +45,8 @@ public class LockTest extends AbstractTest {
         lockCounter = targetInstance.getAtomicLong(name + ":LockCounter");
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < lockCount; i++) {
             long key = lockCounter.getAndIncrement();
             targetInstance.getLock(getLockId(key));

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/SimpleLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/SimpleLockTest.java
@@ -19,9 +19,9 @@ import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ILock;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -36,8 +36,8 @@ public class SimpleLockTest extends AbstractTest {
 
     private int totalValue = 0;
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < maxAccounts; i++) {
             IAtomicLong account = targetInstance.getAtomicLong(name + i);
             account.set(INITIAL_VALUE);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/TryLockTimeOutTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/concurrent/lock/TryLockTimeOutTest.java
@@ -20,9 +20,9 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
@@ -44,8 +44,8 @@ public class TryLockTimeOutTest extends AbstractTest {
 
     private long totalInitialValue;
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         IList<Long> accounts = targetInstance.getList(name);
         for (int i = 0; i < maxAccounts; i++) {
             accounts.add(initialAccountValue);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/AddRemoveListenerICacheTest.java
@@ -19,10 +19,10 @@ import com.hazelcast.core.IList;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryEventFilter;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheEntryListener;
 import com.hazelcast.simulator.tests.icache.helpers.ICacheListenerOperationCounter;
@@ -36,7 +36,7 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
 
 /**
  * In this test we concurrently add remove cache listeners while putting and getting from the cache.
- *
+ * <p>
  * This test is out side of normal usage, however has found problems where put operations hang.
  * This type of test could uncover memory leaks in the process of adding and removing listeners.
  * The max size of the cache used in this test is keyCount int key/value pairs.
@@ -60,8 +60,8 @@ public class AddRemoveListenerICacheTest extends AbstractTest {
         cacheManager.getCache(name);
     }
 
-    @Warmup(global = false)
-    public void warmup() {
+    @Prepare(global = false)
+    public void prepare() {
         cache = cacheManager.getCache(name);
 
         listenerConfiguration = new MutableCacheEntryListenerConfiguration<Integer, Long>(

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/BatchingICacheTest.java
@@ -19,10 +19,10 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -34,10 +34,10 @@ import static com.hazelcast.simulator.tests.icache.helpers.CacheUtils.createCach
 
 /**
  * Demonstrates the effect of batching.
- *
+ * <p>
  * It uses async methods to invoke operation and wait for future to complete every {@code batchSize} invocations.
  * Hence setting {@link #batchSize} to 1 is effectively the same as using sync operations.
- *
+ * <p>
  * Setting {@link #batchSize} to values greater than 1 causes the batch-effect to kick-in, pipe-lines are utilized better
  * and overall throughput goes up.
  */
@@ -55,8 +55,8 @@ public class BatchingICacheTest extends AbstractTest {
         cache = (ICache<Object, Object>) cacheManager.getCache(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<Object, Object> streamer = StreamerFactory.getInstance(cache);
         for (int i = 0; i < keyCount; i++) {
             streamer.pushEntry(i, 0);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CacheLoaderTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CacheLoaderTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.icache;
 import com.hazelcast.core.IList;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.icache.helpers.RecordingCacheLoader;
 
 import javax.cache.Cache;
@@ -39,12 +39,12 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * This tests concurrent load all calls to {@link javax.cache.integration.CacheLoader}.
- *
+ * <p>
  * We can configure a delay in {@link javax.cache.integration.CacheLoader#loadAll(Iterable)} or to wait for completion.
- *
+ * <p>
  * A large delay and high concurrent calls to {@link javax.cache.integration.CacheLoader#loadAll(Iterable)} could overflow some
  * internal queues. The same can happen if {@link #waitForLoadAllFutureCompletion} is false.
- *
+ * <p>
  * We verify that the cache contains all keys and that the keys have been loaded through a the cache instance.
  */
 public class CacheLoaderTest extends AbstractTest {
@@ -74,8 +74,8 @@ public class CacheLoaderTest extends AbstractTest {
         cache = cacheManager.getCache(name);
     }
 
-    @Warmup(global = false)
-    public void warmup() {
+    @Prepare(global = false)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             keySet.add(i);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/CasICacheTest.java
@@ -19,11 +19,11 @@ import com.hazelcast.core.IList;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the cas method {@link Cache#replace(Object, Object, Object)} for optimistic concurrency control.
- *
+ * <p>
  * With a collection of predefined keys we concurrently increment the value.
  * We protect ourselves against lost updates using the cas method {@link Cache#replace(Object, Object, Object)}.
- *
+ * <p>
  * Locally we keep track of all increments. We verify if the sum of these local increments matches the global increment.
  */
 public class CasICacheTest extends AbstractTest {
@@ -56,8 +56,8 @@ public class CasICacheTest extends AbstractTest {
         cache = cacheManager.getCache(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<Integer, Long> streamer = StreamerFactory.getInstance(cache);
         for (int i = 0; i < keyCount; i++) {
             streamer.pushEntry(i, 0L);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/EntryProcessorICacheTest.java
@@ -20,11 +20,11 @@ import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
 import com.hazelcast.simulator.test.annotations.BeforeRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -58,8 +58,8 @@ public class EntryProcessorICacheTest extends AbstractTest {
         cache = cacheManager.getCache(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<Integer, Long> streamer = StreamerFactory.getInstance(cache);
         for (int i = 0; i < keyCount; i++) {
             streamer.pushEntry(i, 0L);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/PerformanceICacheTest.java
@@ -17,10 +17,10 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -45,8 +45,8 @@ public class PerformanceICacheTest extends AbstractTest {
         cache = cacheManager.getCache(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<Object, Object> streamer = StreamerFactory.getInstance(cache);
         for (int i = 0; i < keyCount; i++) {
             streamer.pushEntry(i, 0);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/icache/StringICacheTest.java
@@ -17,10 +17,10 @@ package com.hazelcast.simulator.tests.icache;
 
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -56,8 +56,8 @@ public class StringICacheTest extends AbstractTest {
         cache = cacheManager.getCache(name);
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         waitClusterSize(logger, targetInstance, minNumberOfMembers);
 
         keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/jmx/PartitionServiceMBeanTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/jmx/PartitionServiceMBeanTest.java
@@ -16,10 +16,10 @@
 package com.hazelcast.simulator.tests.jmx;
 
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -43,8 +43,8 @@ public class PartitionServiceMBeanTest extends AbstractTest {
                 + ",name=" + targetInstance.getName() + ",type=HazelcastInstance.PartitionServiceMBean");
    }
 
-    @Warmup(global = false)
-    public void warmup() {
+    @Prepare(global = false)
+    public void prepare() {
         waitClusterSize(logger, targetInstance, minNumberOfMembers);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllEntrySetTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllEntrySetTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -54,8 +54,8 @@ public class AllEntrySetTest extends AbstractTest {
         this.map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<String, String> streamer = StreamerFactory.getInstance(map);
         for (int i = 0; i < entryCount; i++) {
             String key = generateString(keyLength);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllKeySetTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllKeySetTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -53,8 +53,8 @@ public class AllKeySetTest extends AbstractTest {
         this.map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<String, String> streamer = StreamerFactory.getInstance(map);
         for (int i = 0; i < entryCount; i++) {
             String key = generateString(keyLength);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllValuesTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/AllValuesTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -53,8 +53,8 @@ public class AllValuesTest extends AbstractTest {
         this.map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<String, String> streamer = StreamerFactory.getInstance(map);
         for (int i = 0; i < entryCount; i++) {
             String key = generateString(keyLength);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/ExtractorMapTest.java
@@ -29,10 +29,10 @@ import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueExtractor;
 import com.hazelcast.query.extractor.ValueReader;
 import com.hazelcast.simulator.probes.Probe;
+import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
-import com.hazelcast.simulator.test.annotations.Warmup;
-import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -77,8 +77,8 @@ public class ExtractorMapTest extends AbstractTest {
                 .addDefaultOperation(Operation.QUERY);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void globalPrepare() {
         if (useIndex) {
             for (int i = 0; i < indexValuesCount; i++) {
                 map.addIndex(format("payloadFromExtractor[%d]", i), true);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -54,8 +54,8 @@ public class IntByteMapTest extends AbstractTest {
         }
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         Random random = new Random();
         values = new byte[valueCount][];
         for (int i = 0; i < values.length; i++) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/IntIntMapTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -48,8 +48,8 @@ public class IntIntMapTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = false)
-    public void warmup() {
+    @Prepare(global = false)
+    public void prepare() {
         waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateIntKeys(keyCount, keyLocality, targetInstance);
         Streamer<Integer, Integer> streamer = StreamerFactory.getInstance(map);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapCasTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapCasTest.java
@@ -21,11 +21,11 @@ import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.annotations.AfterRun;
 import com.hazelcast.simulator.test.annotations.BeforeRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * This tests the cas method: replace. So for optimistic concurrency control.
- *
+ * <p>
  * We have a bunch of predefined keys, and we are going to concurrently increment the value and we protect ourselves against lost
  * updates using cas method replace.
- *
+ * <p>
  * Locally we keep track of all increments, and if the sum of these local increments matches the global increment, we are done.
  */
 public class MapCasTest extends AbstractTest {
@@ -55,8 +55,8 @@ public class MapCasTest extends AbstractTest {
         resultsPerWorker = targetInstance.getMap(name + ":ResultMap");
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);
         }
@@ -67,7 +67,7 @@ public class MapCasTest extends AbstractTest {
         int size = map.size();
         if (size != keyCount) {
             throw new TestException(
-                    "Warmup has not run since the map is not filled correctly, found size: %s, expected size: %s",
+                    "Prepare has not run since the map is not filled correctly, found size: %s, expected size: %s",
                     size, keyCount);
         }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapComplexPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapComplexPredicateTest.java
@@ -21,9 +21,9 @@ import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.BeforeRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.ComplexDomainObject;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
@@ -301,8 +301,8 @@ public class MapComplexPredicateTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = true)
-    public void warmUp() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<String, ComplexDomainObject> streamer = StreamerFactory.getInstance(map);
         for (int i = 0; i < mapSize; i++) {
             ComplexDomainObject value = createQuickSearchObject(i);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEntryListenerTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEntryListenerTest.java
@@ -18,11 +18,11 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.EntryListenerImpl;
 import com.hazelcast.simulator.tests.map.helpers.EventCount;
 import com.hazelcast.simulator.tests.map.helpers.ScrambledZipfianGenerator;
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * This test is using a map to generate map entry events. We use an {@link com.hazelcast.core.EntryListener} implementation to
  * count the received events. We are generating and counting add, remove, update and evict events.
- *
+ * <p>
  * As currently the event system of Hazelcast is on a "best effort" basis, it is possible that the number of generated events will
  * not equal the number of events received. In the future the Hazelcast event system could change. For now we can say the number
  * of events received can not be greater than the number of events generated.
@@ -111,9 +111,8 @@ public class MapEntryListenerTest extends AbstractTest {
                 .addDefaultOperation(MapPutOperation.PUT);
     }
 
-
-    @Warmup(global = true)
-    public void globalWarmup() {
+    @Prepare(global = true)
+    public void globalPrepare() {
         EventCount initCounter = new EventCount();
 
         for (int i = 0; i < keyCount; i++) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEntryProcessorTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapEntryProcessorTest.java
@@ -21,11 +21,11 @@ import com.hazelcast.map.AbstractEntryProcessor;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.tests.helpers.KeyUtils;
 
@@ -59,8 +59,8 @@ public class MapEntryProcessorTest extends AbstractTest {
         keys = KeyUtils.generateIntKeys(keyCount, keyLocality, targetInstance);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapLockTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapLockTest.java
@@ -20,17 +20,17 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
 /**
  * Test for the {@link IMap#lock(Object)} method.
- *
+ * <p>
  * We use {@link IMap#lock(Object)} to control concurrent access to map key/value pairs. There are a total of {@link #keyCount}
  * keys stored in a map which are initialized to zero, we concurrently increment the value of a random key. We keep track of all
  * increments to each key and verify the value in the map for each key is equal to the total increments done on each key.
@@ -49,8 +49,8 @@ public class MapLockTest extends AbstractTest {
         incrementsList = targetInstance.getList(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapLongPerformanceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapLongPerformanceTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -37,8 +37,8 @@ public class MapLongPerformanceTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Streamer<Integer, Long> streamer = StreamerFactory.getInstance(map);
         for (int i = 0; i < keyCount; i++) {
             streamer.pushEntry(i, 0L);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPredicateTest.java
@@ -24,10 +24,10 @@ import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.Employee;
 import com.hazelcast.simulator.tests.map.helpers.PredicateOperationCounter;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * In this test we are using different predicate methods to execute a query on a map of {@link Employee} objects.
- *
+ * <p>
  * This test also concurrently updates and modifies the employee objects in the map while the predicate queries are executing. The
  * test may also destroy the map while while predicate are executing. We verify the result of every query to ensure that the
  * objects returned fit the requirements of the query.
@@ -93,8 +93,8 @@ public class MapPredicateTest extends AbstractTest {
                 .addOperation(Operation.DESTROY_MAP, destroyProb);
     }
 
-    @Warmup(global = true)
-    public void globalWarmup() {
+    @Prepare(global = true)
+    public void globalPrepare() {
         initMap();
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllOnTheFlyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllOnTheFlyTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +33,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntegerKeys
 
 /**
  * Test for {@link IMap#putAll(java.util.Map)} which creates the input values on the fly during the RUN phase.
- *
+ * <p>
  * You can configure the {@link #batchSize} to determine the number of inserted values per operation.
  * You can configure the {@link #keyRange} to determine the key range for inserted values.
  */
@@ -53,9 +53,9 @@ public class MapPutAllOnTheFlyTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup
+    @Prepare
     @SuppressWarnings("unchecked")
-    public void warmup() {
+    public void prepare() {
         if (mapCount > 0) {
             // prepare the input maps
             Integer[] keys = generateIntegerKeys(keyRange, SHARED, targetInstance);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapPutAllTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.GenericTypes;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 
@@ -36,7 +36,7 @@ import static com.hazelcast.simulator.tests.helpers.KeyLocality.SHARED;
 
 /**
  * Test for {@link IMap#putAll(Map)} which uses a set of prepared maps with input values during the RUN phase.
- *
+ * <p>
  * You can configure the {@link #keyType} and {@link #valueType} for the used maps.
  */
 public class MapPutAllTest extends AbstractTest {
@@ -66,9 +66,9 @@ public class MapPutAllTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup
+    @Prepare
     @SuppressWarnings("unchecked")
-    public void warmup() {
+    public void prepare() {
         Object[] keys = keyType.generateKeys(targetInstance, keyLocality, keyCount, keySize);
 
         inputMaps = new Map[mapCount];

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapRaceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapRaceTest.java
@@ -20,11 +20,11 @@ import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
 import com.hazelcast.simulator.test.annotations.BeforeRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * This test verifies that there are race problems if the {@link IMap} is not used correctly.
- *
+ * <p>
  * This test is expected to fail.
  */
 public class MapRaceTest extends AbstractTest {
@@ -51,8 +51,8 @@ public class MapRaceTest extends AbstractTest {
         resultMap = targetInstance.getMap(name + ":ResultMap");
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapReduceTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapReduceTest.java
@@ -31,10 +31,10 @@ import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.Employee;
 import com.hazelcast.simulator.tests.map.helpers.MapReduceOperationCounter;
 
@@ -59,8 +59,8 @@ public class MapReduceTest extends AbstractTest {
         operationCounterList = targetInstance.getList(name + "OperationCounter");
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int id = 0; id < keyCount; id++) {
             map.put(id, new Employee(id));
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextConflictTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionContextConflictTest.java
@@ -19,9 +19,9 @@ import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyIncrementPair;
 import com.hazelcast.simulator.tests.helpers.TxnCounter;
 import com.hazelcast.simulator.utils.ThreadSpawner;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Testing transaction context with multi keys.
- *
+ * <p>
  * A number of map keys (maxKeysPerTxn) are chosen at random to take part in the transaction. As maxKeysPerTxn increases as a
  * proportion of keyCount, more conflict will occur between the transactions, less transactions will be committed successfully and
  * more transactions are rolled back.
@@ -52,8 +52,8 @@ public class MapTransactionContextConflictTest extends AbstractTest {
     public boolean throwCommitException = false;
     public boolean throwRollBackException = false;
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         IMap<Integer, Long> map = targetInstance.getMap(name);
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionGetForUpdateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionGetForUpdateTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
-import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.tests.helpers.TxnCounter;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 import com.hazelcast.transaction.TransactionContext;
@@ -48,8 +48,8 @@ public class MapTransactionGetForUpdateTest extends AbstractTest {
     public TransactionOptions.TransactionType transactionType = TransactionOptions.TransactionType.TWO_PHASE;
     public int durability = 1;
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         IMap<Integer, Long> map = targetInstance.getMap(name);
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionReadWriteTest.java
@@ -19,10 +19,10 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -54,8 +54,8 @@ public class MapTransactionReadWriteTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = false)
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateIntKeys(keyCount, keyLocality, targetInstance);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MapTransactionTest.java
@@ -21,10 +21,10 @@ import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionOptions.TransactionType;
@@ -63,8 +63,8 @@ public class MapTransactionTest extends AbstractTest {
         transactionOptions.setTransactionType(transactionType).setDurability(durability);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         for (int i = 0; i < keyCount; i++) {
             map.put(i, 0L);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MultiValueMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/MultiValueMapTest.java
@@ -26,10 +26,10 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.simulator.probes.Probe;
+import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
-import com.hazelcast.simulator.test.annotations.Warmup;
-import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -72,8 +72,8 @@ public class MultiValueMapTest extends AbstractTest {
                 .addDefaultOperation(Operation.QUERY);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         if (useIndex) {
             map.addIndex("payloadField[any]", true);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/PagingPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/PagingPredicateTest.java
@@ -19,9 +19,9 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.Employee;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -31,13 +31,13 @@ import com.hazelcast.simulator.worker.tasks.IWorker;
 /**
  * Test to exercising PagingPredicate.
  * It's intended to be used for benchmarking purposes, it doesn't validate correctness of results.
- *
+ * <p>
  * It has 2 working modes:
  * <ol>
  * <li>Sequential Mode - where workers are paging in a sequential orders. Ie. Page1, Page2, PageN, PageN+1, etc</li>
  * <li>Random Mode - where workers are selecting arbitrary pages</li>
  * </ol>
- *
+ * <p>
  * Implementation note: There is a small code duplication in worker implementations - it could be eliminated by
  * introducing a common superclass, but I believe it would just make things more complicated.
  */
@@ -61,8 +61,8 @@ public class PagingPredicateTest extends AbstractTest {
         innerPredicate = new SqlPredicate(innerPredicateQuery);
     }
 
-    @Warmup(global = true)
-    public void globalWarmup() {
+    @Prepare(global = true)
+    public void globalPrepare() {
         if (useIndex) {
             map.addIndex("salary", true);
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SerializationStrategyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SerializationStrategyTest.java
@@ -21,9 +21,9 @@ import com.hazelcast.query.Predicates;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.BeforeRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.domain.DomainObject;
 import com.hazelcast.simulator.tests.map.domain.DomainObjectFactory;
 import com.hazelcast.simulator.utils.ThrottlingLogger;
@@ -66,8 +66,8 @@ public class SerializationStrategyTest extends AbstractTest {
         uniqueStrings = targetInstance.getSet(name);
     }
 
-    @Warmup(global = true)
-    public void initDataLoad() {
+    @Prepare(global = true)
+    public void prepare() {
         int uniqueStringsCount = itemCount / recordsPerUnique;
         String[] strings = generateUniqueStrings(uniqueStringsCount);
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SplitClusterDataTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SplitClusterDataTest.java
@@ -16,11 +16,11 @@
 package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.core.IMap;
+import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Run;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
-import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.waitClusterSize;
@@ -45,8 +45,8 @@ public class SplitClusterDataTest extends AbstractTest {
         }
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         waitClusterSize(logger, targetInstance, clusterSize);
 
         for (int i = 0; i < maxItems; i++) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/SqlPredicateTest.java
@@ -19,10 +19,10 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.map.helpers.DataSerializableEmployee;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -50,8 +50,8 @@ public class SqlPredicateTest extends AbstractTest {
         this.map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = true)
-    public void warmup() {
+    @Prepare(global = true)
+    public void prepare() {
         Random random = new Random();
         Streamer<String, DataSerializableEmployee> streamer = StreamerFactory.getInstance(map);
         for (int i = 0; i < keyCount; i++) {

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/StringStringMapTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.map;
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
@@ -52,8 +52,8 @@ public class StringStringMapTest extends AbstractTest {
         map = targetInstance.getMap(name);
     }
 
-    @Warmup(global = false)
-    public void warmup() {
+    @Prepare(global = false)
+    public void prepare() {
         waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);
         values = generateStrings(valueCount, valueLength);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/AbstractMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/AbstractMapTest.java
@@ -82,7 +82,7 @@ abstract class AbstractMapTest extends AbstractTest {
 
     abstract long getGlobalKeyCount(Integer minResultSizeLimit, Float resultLimitFactor);
 
-    void baseWarmup(String keyType) {
+    void basePrepare(String keyType) {
         if (!isMemberNode(targetInstance)) {
             return;
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapLatencyTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapLatencyTest.java
@@ -15,23 +15,23 @@
  */
 package com.hazelcast.simulator.tests.map.queryresultsize;
 
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.tasks.IWorker;
 
 /**
  * This test creates latency probe results for {@link com.hazelcast.core.IMap#values()}, {@link com.hazelcast.core.IMap#keySet()}
  * and {@link com.hazelcast.core.IMap#entrySet()}. It is used to ensure that the query result size limit has no bad impact on the
  * latency of those method calls.
- *
+ * <p>
  * To achieve this we fill a map slightly below the trigger limit of the query result size limit, so we are sure it will never
  * trigger the exception. Then we call the map methods and measure their latency.
- *
+ * <p>
  * The test can be configured to use {@link String} or {@link Integer} keys. You can also override the number of filled items
  * with the {@link #keyCount} property, e.g. to test the latency impact of this feature with an empty map.
- *
+ * <p>
  * This test works fine with all Hazelcast versions, since it does not use any new functionality. Just be sure the default
  * values in {@link AbstractMapTest} match with the default values of the query result size limit in Hazelcast 3.5. Otherwise
  * the map will be filled with a different number of keys and the latency results may not be comparable.
@@ -56,9 +56,9 @@ public class MapLatencyTest extends AbstractMapTest {
         return Math.round(minResultSizeLimit * resultLimitFactor * 0.9);
     }
 
-    @Warmup
-    public void warmup() {
-        baseWarmup(keyType);
+    @Prepare
+    public void prepare() {
+        basePrepare(keyType);
     }
 
     @Verify

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapResultSizeLimitTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/queryresultsize/MapResultSizeLimitTest.java
@@ -15,22 +15,22 @@
  */
 package com.hazelcast.simulator.tests.map.queryresultsize;
 
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.worker.tasks.IWorker;
 
 /**
  * This test verifies that {@link com.hazelcast.core.IMap#values()}, {@link com.hazelcast.core.IMap#keySet()} and
  * {@link com.hazelcast.core.IMap#entrySet()} throw an exception if the configured result size limit is exceeded.
- *
+ * <p>
  * To achieve this we fill a map slightly above the trigger limit of the query result size limit, so we are sure it will always
  * trigger the exception. Then we call the map methods and verify that each call created an exception.
- *
+ * <p>
  * The test can be configured to use {@link String} or {@link Integer} keys. You can also override the number of filled items
  * with the {@link #keyCount} property, e.g. to test for missing exceptions with enabled result size limit and an empty map.
- *
+ * <p>
  * You have to activate the query result size limit by providing a custom hazelcast.xml with the following setting:
  * <pre>
  *   {@code
@@ -64,9 +64,9 @@ public class MapResultSizeLimitTest extends AbstractMapTest {
         return Math.round(minResultSizeLimit * resultLimitFactor * 1.1);
     }
 
-    @Warmup
-    public void warmup() {
-        baseWarmup(keyType);
+    @Prepare
+    public void prepare() {
+        basePrepare(keyType);
     }
 
     @Verify

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/replicatedmap/ReplicatedMapTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.simulator.tests.replicatedmap;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateStrings;
@@ -42,8 +42,8 @@ public class ReplicatedMapTest extends AbstractTest {
         map = targetInstance.getReplicatedMap(name + "-" + testContext.getTestId());
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         values = generateStrings(valueCount, valueLength);
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/slow/SlowOperationMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/slow/SlowOperationMapTest.java
@@ -18,11 +18,11 @@ package com.hazelcast.simulator.tests.slow;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.RunWithWorker;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 import com.hazelcast.simulator.worker.selector.OperationSelectorBuilder;
 import com.hazelcast.simulator.worker.tasks.AbstractWorker;
@@ -47,7 +47,7 @@ import static org.junit.Assert.fail;
 
 /**
  * This test invokes slowed down map operations on a Hazelcast instance to provoke slow operation logs.
- *
+ * <p>
  * In the verification phase we check for the correct number of slow operation logs (one per operation type).
  *
  * @since Hazelcast 3.5
@@ -92,8 +92,8 @@ public class SlowOperationMapTest extends AbstractTest {
         }
     }
 
-    @Warmup
-    public void localWarmup() {
+    @Prepare
+    public void localPrepare() {
         if (isClient) {
             return;
         }
@@ -104,9 +104,9 @@ public class SlowOperationMapTest extends AbstractTest {
         }
     }
 
-    @Warmup(global = true)
-    public void globalWarmup() {
-        // add the interceptor after local warmup, otherwise that stage will take ages
+    @Prepare(global = true)
+    public void globalPrepare() {
+        // add the interceptor after local prepare, otherwise that stage will take ages
         map.addInterceptor(new SlowMapInterceptor(recursionDepth));
     }
 

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ClusterStatisticsTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/ClusterStatisticsTest.java
@@ -18,9 +18,9 @@ package com.hazelcast.simulator.tests.special;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.PartitionService;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.logPartitionStatistics;
@@ -40,8 +40,8 @@ public class ClusterStatisticsTest extends AbstractTest {
         this.map = targetInstance.getMap(name);
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         if (!isMemberNode(targetInstance)) {
             return;
         }

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/FailingTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/FailingTest.java
@@ -20,11 +20,11 @@ import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.test.TestPhase;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.utils.EmptyStatement;
 import com.hazelcast.simulator.utils.ExceptionReporter;
 
@@ -81,14 +81,14 @@ public class FailingTest extends AbstractTest {
     }
 
 
-    @Warmup
-    public void localWarmup() throws Exception {
-        createFailure(TestPhase.LOCAL_WARMUP);
+    @Prepare
+    public void localPrepare() throws Exception {
+        createFailure(TestPhase.LOCAL_PREPARE);
     }
 
-    @Warmup(global = true)
-    public void globalWarmup() throws Exception {
-        createFailure(TestPhase.GLOBAL_WARMUP);
+    @Prepare(global = true)
+    public void globalPrepare() throws Exception {
+        createFailure(TestPhase.GLOBAL_PREPARE);
     }
 
     @TimeStep

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/LongTestPhasesTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/LongTestPhasesTest.java
@@ -17,20 +17,20 @@ package com.hazelcast.simulator.tests.special;
 
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.TestPhase;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 
 import java.util.Random;
 
+import static com.hazelcast.simulator.test.TestPhase.GLOBAL_PREPARE;
 import static com.hazelcast.simulator.test.TestPhase.GLOBAL_TEARDOWN;
 import static com.hazelcast.simulator.test.TestPhase.GLOBAL_VERIFY;
-import static com.hazelcast.simulator.test.TestPhase.GLOBAL_WARMUP;
+import static com.hazelcast.simulator.test.TestPhase.LOCAL_PREPARE;
 import static com.hazelcast.simulator.test.TestPhase.LOCAL_TEARDOWN;
 import static com.hazelcast.simulator.test.TestPhase.LOCAL_VERIFY;
-import static com.hazelcast.simulator.test.TestPhase.LOCAL_WARMUP;
 import static com.hazelcast.simulator.test.TestPhase.RUN;
 import static com.hazelcast.simulator.test.TestPhase.SETUP;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
@@ -51,14 +51,14 @@ public class LongTestPhasesTest {
         sleep(SETUP);
     }
 
-    @Warmup(global = false)
-    public void localWarmup() {
-        sleep(LOCAL_WARMUP);
+    @Prepare(global = false)
+    public void localPrepare() {
+        sleep(LOCAL_PREPARE);
     }
 
-    @Warmup(global = true)
-    public void globalWarmup() {
-        sleep(GLOBAL_WARMUP);
+    @Prepare(global = true)
+    public void globalPrepare() {
+        sleep(GLOBAL_PREPARE);
     }
 
     @TimeStep

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/MapHeapHogPrepareTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/MapHeapHogPrepareTest.java
@@ -17,10 +17,10 @@ package com.hazelcast.simulator.tests.special;
 
 import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.utils.ThreadSpawner;
 
 import java.util.concurrent.TimeUnit;
@@ -32,11 +32,11 @@ import static com.hazelcast.simulator.utils.FormatUtils.humanReadableByteCount;
 import static java.lang.String.format;
 
 /**
- * Fills up the cluster to a defined heap usage factor during warmup phase.
+ * Fills up the cluster to a defined heap usage factor during prepare phase.
  * <p>
  * This tests intentionally has an empty run phase.
  */
-public class MapHeapHogWarmupTest extends AbstractTest {
+public class MapHeapHogPrepareTest extends AbstractTest {
 
     private static final long APPROX_ENTRY_BYTES_SIZE = 238;
 
@@ -66,8 +66,8 @@ public class MapHeapHogWarmupTest extends AbstractTest {
         maxEntriesPerThread = (long) (maxLocalEntries / (double) threadCount);
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         if (isClient(targetInstance)) {
             return;
         }
@@ -83,7 +83,7 @@ public class MapHeapHogWarmupTest extends AbstractTest {
         }
         threadSpawner.awaitCompletion();
 
-        StringBuilder sb = new StringBuilder(name).append(": After warmup phase the map size is ").append(map.size());
+        StringBuilder sb = new StringBuilder(name).append(": After prepare phase the map size is ").append(map.size());
         addMemoryStatistics(sb);
         logger.info(sb.toString());
     }
@@ -114,7 +114,7 @@ public class MapHeapHogWarmupTest extends AbstractTest {
                 key++;
 
                 if (isLogger && key % logFrequency == 0) {
-                    sb.append(name).append(": In warmup phase the map size is ").append(map.size());
+                    sb.append(name).append(": In prepare phase the map size is ").append(map.size());
                     addMemoryStatistics(sb);
                     logger.info(sb.toString());
                     sb.setLength(0);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -17,10 +17,10 @@ package com.hazelcast.simulator.tests.syntheticmap;
 
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.KeyLocality;
 
 import java.util.Random;
@@ -50,8 +50,8 @@ public class StringStringSyntheticMapTest extends AbstractTest {
         map = targetInstance.getDistributedObject(SyntheticMapService.SERVICE_NAME, "map-" + name);
     }
 
-    @Warmup
-    public void warmup() {
+    @Prepare
+    public void prepare() {
         waitClusterSize(logger, targetInstance, minNumberOfMembers);
         keys = generateStringKeys(keyCount, keyLength, keyLocality, targetInstance);
         values = generateStrings(valueCount, valueLength);

--- a/tests/tests-hz36/src/main/java/com/hazelcast/simulator/tests/network/NetworkTest.java
+++ b/tests/tests-hz36/src/main/java/com/hazelcast/simulator/tests/network/NetworkTest.java
@@ -31,10 +31,10 @@ import com.hazelcast.nio.tcp.spinning.SpinningIOThreadingModel;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.TestException;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.HazelcastTestUtils;
 import com.hazelcast.spi.impl.PacketHandler;
 
@@ -133,8 +133,8 @@ public class NetworkTest extends AbstractTest {
         networkCreateLock = targetInstance.getLock("connectionCreateLock");
     }
 
-    @Warmup
-    public void warmup() throws Exception {
+    @Prepare
+    public void prepare() throws Exception {
         networkCreateLock.lock();
         try {
             logger.info("Starting connections: " + (targetInstance.getCluster().getMembers().size() - 1));

--- a/tests/tests-hz37/src/main/java/com/hazelcast/simulator/tests/network/NetworkTest.java
+++ b/tests/tests-hz37/src/main/java/com/hazelcast/simulator/tests/network/NetworkTest.java
@@ -32,10 +32,10 @@ import com.hazelcast.nio.tcp.spinning.SpinningIOThreadingModel;
 import com.hazelcast.simulator.test.AbstractTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.TestException;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.test.annotations.Warmup;
 import com.hazelcast.simulator.tests.helpers.HazelcastTestUtils;
 import com.hazelcast.spi.impl.PacketHandler;
 
@@ -133,8 +133,8 @@ public class NetworkTest extends AbstractTest {
         networkCreateLock = targetInstance.getLock("connectionCreateLock");
     }
 
-    @Warmup
-    public void warmup() throws Exception {
+    @Prepare
+    public void prepare() throws Exception {
         networkCreateLock.lock();
         try {
             logger.info("Starting connections: " + (targetInstance.getCluster().getMembers().size() - 1));


### PR DESCRIPTION
It causes confusion with the warmupDuration for running a test.

@Warmup can still be used; but it is deprecated. 