### PR TITLE
TestContext.getHazelcastInstance removed

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/test/PropertyBinding.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/PropertyBinding.java
@@ -70,7 +70,7 @@ public class PropertyBinding {
 
     private final Class<? extends Probe> probeClass;
     private final Class<? extends Metronome> metronomeClass;
-    private TestContext testContext;
+    private TestContextImpl testContext;
     private final Map<String, Probe> probeMap = new ConcurrentHashMap<String, Probe>();
     private final TestCase testCase;
     private final Set<String> unusedProperties = new HashSet<String>();
@@ -87,7 +87,7 @@ public class PropertyBinding {
         this.probeClass = loadProbeClass();
     }
 
-    public PropertyBinding setTestContext(TestContext testContext) {
+    public PropertyBinding setTestContext(TestContextImpl testContext) {
         this.testContext = testContext;
         return this;
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
@@ -15,22 +15,12 @@
  */
 package com.hazelcast.simulator.test;
 
-import com.hazelcast.core.HazelcastInstance;
-
 public interface TestContext {
 
     /**
      * Default IP address which is used if no public IP address is defined.
      */
     String LOCALHOST = "127.0.0.1";
-
-    /**
-     * Returns the {@link HazelcastInstance} of the Test.
-     *
-     * @return The {@link HazelcastInstance} of the Test.
-     * @deprecated since 0.8. Use {@link com.hazelcast.simulator.test.annotations.InjectHazelcastInstance}.
-     */
-    HazelcastInstance getTargetInstance();
 
     String getTestId();
 

--- a/simulator/src/main/java/com/hazelcast/simulator/test/TestContextImpl.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/TestContextImpl.java
@@ -39,7 +39,6 @@ public class TestContextImpl implements TestContext {
         this.publicIpAddress = publicIpAddress;
     }
 
-    @Override
     public HazelcastInstance getTargetInstance() {
         return hazelcastInstance;
     }


### PR DESCRIPTION
We have @InjectHazelcastInstance. The goal of this removal is to make
simulator less provider dependent.

This method was already deprecated in 0.8