### PR TITLE
Introduced BashCommand

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/utils/Bash.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/Bash.java
@@ -34,7 +34,7 @@ public class Bash {
     }
 
     public StringBuilder execute(String command) {
-        return NativeUtils.execute(command);
+        return new BashCommand(command).execute();
     }
 
     public StringBuilder executeQuiet(String command) {
@@ -47,7 +47,7 @@ public class Bash {
 
     public StringBuilder ssh(String ip, String command, boolean throwException) {
         String sshCommand = format("ssh %s %s@%s \"%s\"", sshOptions, user, ip, command);
-        return NativeUtils.execute(sshCommand, throwException);
+        return new BashCommand(sshCommand).setThrowsException(throwException).execute();
     }
 
     public void sshQuiet(String ip, String command) {
@@ -87,3 +87,4 @@ public class Bash {
         execute(command);
     }
 }
+

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ComplexDomainObject.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/map/helpers/ComplexDomainObject.java
@@ -188,10 +188,7 @@ public class ComplexDomainObject implements Portable {
                                int num_instruction_approval_not_performed,
                                long download_speed, int mismatch, boolean mismatch_ignored,
                                int invoice_account_demand) {
-        super();
-
         this.UUID = UUID;
-
         this.locality_id = locality_id;
         this.locality_name = locality_name;
         this.division_id = division_id;

--- a/utils/src/main/java/com/hazelcast/simulator/utils/BashCommand.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/BashCommand.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.utils;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
+import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
+import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
+import static com.hazelcast.simulator.utils.FormatUtils.NEW_LINE;
+import static com.hazelcast.simulator.utils.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+public class BashCommand {
+    private static final Logger LOGGER = Logger.getLogger(BashCommand.class);
+
+    private final String command;
+    private final List<Object> params = new LinkedList<Object>();
+    private Map<String, Object> environment = new HashMap<String, Object>();
+    private boolean throwException;
+
+    public BashCommand(String command) {
+        this.command = checkNotNull(command, "command can't be null");
+    }
+
+    public BashCommand addParam(Object param) {
+        params.add(checkNotNull(param, "param can't be null"));
+        return this;
+    }
+
+    public BashCommand setEnvironment(Map<String, Object> environment) {
+        this.environment = checkNotNull(environment, "environment can't be null");
+        return this;
+    }
+
+    public BashCommand setThrowsException(boolean throwException) {
+        this.throwException = throwException;
+        return this;
+    }
+
+    public StringBuilder execute() {
+        StringBuilder sb = new StringBuilder();
+
+        String command = getCommand();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Executing bash command: " + command);
+        }
+
+        try {
+            // create a process for the shell
+            ProcessBuilder pb = new ProcessBuilder("bash", "-c", command);
+
+            // fix the environment
+            for (Map.Entry<String, Object> entry : environment.entrySet()) {
+                pb.environment().put(entry.getKey(), entry.getValue().toString());
+            }
+            pb = pb.redirectErrorStream(true);
+
+            Process shell = pb.start();
+            new BashStreamGobbler(shell.getInputStream(), sb).start();
+
+            // wait for the shell to finish and get the return code
+            int shellExitStatus = shell.waitFor();
+
+            if (shellExitStatus != 0) {
+                if (throwException) {
+                    throw new CommandLineExitException(format("Failed to execute [%s]", command),
+                            new CommandLineExitException(sb.toString()));
+                }
+                LOGGER.error(format("Failed to execute [%s]", command));
+                LOGGER.error(sb.toString());
+                exitWithError();
+            } else {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Bash output: " + NEW_LINE + sb);
+                }
+            }
+
+            return sb;
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    private String getCommand() {
+        if (params.isEmpty()) {
+            return command;
+        }
+
+        StringBuilder sb = new StringBuilder(command);
+        for (Object param : params) {
+            sb.append(' ').append(param);
+        }
+        return sb.toString();
+    }
+
+    private static class BashStreamGobbler extends Thread {
+
+        private final InputStreamReader inputStreamReader;
+        private final BufferedReader reader;
+        private final StringBuilder stringBuilder;
+
+        @SuppressFBWarnings("DM_DEFAULT_ENCODING")
+        public BashStreamGobbler(InputStream in, StringBuilder stringBuilder) {
+            this.inputStreamReader = new InputStreamReader(in);
+            this.reader = new BufferedReader(inputStreamReader);
+            this.stringBuilder = stringBuilder;
+        }
+
+        @Override
+        public void run() {
+            try {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    stringBuilder.append(line).append(NEW_LINE);
+                }
+            } catch (IOException ignored) {
+                EmptyStatement.ignore(ignored);
+            } finally {
+                closeQuietly(reader);
+                closeQuietly(inputStreamReader);
+            }
+        }
+    }
+}

--- a/utils/src/main/java/com/hazelcast/simulator/utils/helper/ExitException.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/helper/ExitException.java
@@ -20,7 +20,6 @@ public final class ExitException extends SecurityException {
     private final int status;
 
     public ExitException(int status) {
-        super();
         this.status = status;
     }
 

--- a/utils/src/main/java/com/hazelcast/simulator/utils/helper/ExitStatusOneException.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/helper/ExitStatusOneException.java
@@ -18,6 +18,5 @@ package com.hazelcast.simulator.utils.helper;
 public final class ExitStatusOneException extends SecurityException {
 
     public ExitStatusOneException() {
-        super();
     }
 }

--- a/utils/src/main/java/com/hazelcast/simulator/utils/helper/ExitStatusZeroException.java
+++ b/utils/src/main/java/com/hazelcast/simulator/utils/helper/ExitStatusZeroException.java
@@ -18,6 +18,5 @@ package com.hazelcast.simulator.utils.helper;
 public final class ExitStatusZeroException extends SecurityException {
 
     public ExitStatusZeroException() {
-        super();
     }
 }

--- a/utils/src/test/java/com/hazelcast/simulator/utils/BashCommandTest.java
+++ b/utils/src/test/java/com/hazelcast/simulator/utils/BashCommandTest.java
@@ -1,0 +1,39 @@
+package com.hazelcast.simulator.utils;
+
+import com.hazelcast.simulator.utils.helper.ExitExceptionSecurityManager;
+import com.hazelcast.simulator.utils.helper.ExitStatusOneException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BashCommandTest {
+
+    private SecurityManager oldSecurityManager;
+
+    @Before
+    public void setUp() {
+        oldSecurityManager = System.getSecurityManager();
+        System.setSecurityManager(new ExitExceptionSecurityManager(true));
+    }
+
+    @After
+    public void tearDown() {
+        System.setSecurityManager(oldSecurityManager);
+    }
+
+
+    @Test
+    public void testExecute() {
+        new BashCommand("pwd").execute();
+    }
+
+    @Test(expected = ExitStatusOneException.class)
+    public void testExecute_exitStatus() {
+        new BashCommand("pwd && false").execute();
+    }
+
+    @Test(expected = CommandLineExitException.class)
+    public void testExecute_withException() {
+        new BashCommand("pwd && false").setThrowsException(true).execute();
+    }
+}


### PR DESCRIPTION
Instead of ending up with a huge set of overloaded execute methods in
the NativeUtils, a more builder like approach is used.

This change is needed for pulling out the hazelcast installation into a bash script.