### PR TITLE
Removed the switch to set a worker script

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -168,12 +168,6 @@ final class CoordinatorCli {
                     PROPERTIES_FILE_NAME, PROPERTIES_FILE_NAME))
             .withRequiredArg().ofType(String.class);
 
-    private final OptionSpec<String> workerScriptFileSpec = parser.accepts("workerScript",
-            "The worker startup shell script. If no file is explicitly configured,"
-                    + " first the 'worker.sh' in the working directory is loaded."
-                    + " If that doesn't exist then SIMULATOR_HOME/conf/worker.sh is loaded.")
-            .withRequiredArg().ofType(String.class).defaultsTo(getDefaultConfigurationFile("worker.sh"));
-
     private final OptionSpec<String> memberHzConfigFileSpec = parser.accepts("hzFile",
             "The Hazelcast XML configuration file for the Worker. If no file is explicitly configured,"
                     + " first the 'hazelcast.xml' in the working directory is loaded."
@@ -270,7 +264,7 @@ final class CoordinatorCli {
                 initMemberHzConfig(memberHzConfig, componentRegistry, defaultHzPort, licenseKey, simulatorProperties),
                 initClientHzConfig(clientHzConfig, componentRegistry, defaultHzPort, licenseKey),
                 loadLog4jConfig(),
-                loadWorkerScript(options, cli),
+                loadWorkerScript(),
                 options.has(cli.monitorPerformanceSpec)
         );
 
@@ -362,8 +356,8 @@ final class CoordinatorCli {
         return fileAsText(file);
     }
 
-    private static String loadWorkerScript(OptionSet options, CoordinatorCli cli) {
-        File file = getFileOrExit(cli.workerScriptFileSpec, options, "Hazelcast worker.sh");
+    private static String loadWorkerScript() {
+        File file = new File(getDefaultConfigurationFile("worker.sh"));
         LOGGER.info("Loading Hazelcast worker script: " + file.getAbsolutePath());
         return fileAsText(file);
     }


### PR DESCRIPTION
If file named worker.sh is in the working dir, it is selected otherwise
go to the simulator_home. No need to add another switch.