### PR TITLE
Fixed install script in local mode

### DIFF
--- a/dist/src/main/dist/conf/install-hazelcast-enterprise.sh
+++ b/dist/src/main/dist/conf/install-hazelcast-enterprise.sh
@@ -3,8 +3,8 @@
 . $SIMULATOR_HOME/conf/install-hazelcast-support.sh
 
 testsuite_id=$1
-public_ips=$2
-version_spec=$3
+version_spec=$2
+public_ips=$3
 
 prepare()
 {

--- a/dist/src/main/dist/conf/install-hazelcast.sh
+++ b/dist/src/main/dist/conf/install-hazelcast.sh
@@ -34,8 +34,8 @@
 . $SIMULATOR_HOME/conf/install-hazelcast-support.sh
 
 testsuite_id=$1
-public_ips=$2
-version_spec=$3
+version_spec=$2
+public_ips=$3
 
 # building of hazelcast using mvn/git if needed
 prepare()

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -249,7 +249,7 @@ public final class Coordinator {
         for (String versionSpec : clusterLayout.getVersionSpecs()) {
             LOGGER.info("Installing '" + vendor + "' '" + versionSpec + "' on Agents using " + installFile);
             new BashCommand(installFile)
-                    .addParams(testSuite.getId(), agentPublicIps.toString(), versionSpec)
+                    .addParams(testSuite.getId(), versionSpec, agentPublicIps.toString())
                     .addEnvironment(simulatorProperties.asMap())
                     .execute();
 


### PR DESCRIPTION
```
INFO  12:19:42 Installing 'hazelcast' 'outofthebox' on Agents using /home/david/bin/hazelcast-simulator/conf/install-hazelcast.sh
ERROR 12:19:42 Failed to execute [/home/david/bin/hazelcast-simulator/conf/install-hazelcast.sh 2016-08-09__12_19_42  outofthebox]
ERROR 12:19:42 Aborting, invalid VERSION_SPEC 
```
Public IPs are empty in local mode, so the variables in the bash script get shifted the `$version_spec` is empty. Since the `VERSION_SPEC` is always set, the easy is solution is to swap the order of the parameters.

Seems to work flawless after the fix:
```
INFO  12:40:50 Installing 'hazelcast' 'outofthebox' on Agents using /home/david/bin/hazelcast-simulator/conf/install-hazelcast.sh
INFO  12:40:50 Successfully installed 'hazelcast'
```