### PR TITLE
Moved init testsuite to RunTestSuiteTask

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/RemoteClient.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/RemoteClient.java
@@ -15,13 +15,11 @@
  */
 package com.hazelcast.simulator.coordinator;
 
-import com.hazelcast.simulator.common.TestSuite;
 import com.hazelcast.simulator.protocol.connector.CoordinatorConnector;
 import com.hazelcast.simulator.protocol.core.Response;
 import com.hazelcast.simulator.protocol.core.ResponseType;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.core.SimulatorProtocolException;
-import com.hazelcast.simulator.protocol.operation.InitTestSuiteOperation;
 import com.hazelcast.simulator.protocol.operation.LogOperation;
 import com.hazelcast.simulator.protocol.operation.PingOperation;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
@@ -93,10 +91,6 @@ public class RemoteClient {
 
         int shutdownDelaySeconds = (componentRegistry.hasClientWorkers() ? memberWorkerShutdownDelaySeconds : 0);
         sendToAllWorkers(new TerminateWorkerOperation(shutdownDelaySeconds, true));
-    }
-
-    public void initTestSuite(TestSuite testSuite) {
-        sendToAllAgents(new InitTestSuiteOperation(testSuite));
     }
 
     public void sendToAllAgents(SimulatorOperation operation) {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.simulator.common.SimulatorProperties;
 import com.hazelcast.simulator.common.TestCase;
 import com.hazelcast.simulator.common.TestSuite;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
+import com.hazelcast.simulator.protocol.operation.InitTestSuiteOperation;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.protocol.registry.TargetType;
 import com.hazelcast.simulator.protocol.registry.TestData;
@@ -80,7 +81,7 @@ public class RunTestSuiteTask {
 
     public void run() {
         try {
-            remoteClient.initTestSuite(testSuite);
+            remoteClient.sendToAllAgents(new InitTestSuiteOperation(testSuite));
 
             int testCount = testSuite.size();
             boolean parallel = coordinatorParameters.isParallel() && testCount > 1;

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -18,6 +18,7 @@ import com.hazelcast.simulator.protocol.connector.CoordinatorConnector;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.operation.CreateTestOperation;
 import com.hazelcast.simulator.protocol.operation.FailureOperation;
+import com.hazelcast.simulator.protocol.operation.InitTestSuiteOperation;
 import com.hazelcast.simulator.protocol.operation.StartTestOperation;
 import com.hazelcast.simulator.protocol.operation.StartTestPhaseOperation;
 import com.hazelcast.simulator.protocol.operation.StopTestOperation;
@@ -167,7 +168,7 @@ public class AgentSmokeTest implements FailureListener {
         try {
             String testId = testCase.getId();
             TestSuite testSuite = new TestSuite("AgentSmokeTest-" + testId);
-            remoteClient.initTestSuite(testSuite);
+            remoteClient.sendToAllAgents(new InitTestSuiteOperation(testSuite));
             testSuite.addTest(testCase);
 
             componentRegistry.addTests(testSuite);

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RemoteClientTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RemoteClientTest.java
@@ -93,20 +93,6 @@ public class RemoteClientTest {
         verifyNoMoreInteractions(coordinatorConnector);
     }
 
-
-    @Test
-    public void testInitTestSuite() {
-        initMock(ResponseType.SUCCESS);
-        RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
-
-        TestSuite testSuite = new TestSuite("RemoteClientTest");
-        remoteClient.initTestSuite(testSuite);
-
-        verify(coordinatorConnector).write(eq(ALL_AGENTS), any(InitTestSuiteOperation.class));
-        verifyNoMoreInteractions(coordinatorConnector);
-    }
-
     @Test
     public void testSendToAllAgents() {
         initMock(ResponseType.SUCCESS);


### PR DESCRIPTION
The remote client should just forward 'operations' to the right boxes. It should not be
involved with any simulator specific logic