### PR TITLE
Pulled out FailureSender interface

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/FailureSender.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/FailureSender.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.agent.workerprocess;
+
+import com.hazelcast.simulator.common.FailureType;
+
+interface FailureSender {
+
+    boolean sendFailureOperation(String message, FailureType type, WorkerProcess workerProcess, String testId, String cause);
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/FailureSenderImpl.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/FailureSenderImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.agent.workerprocess;
+
+import com.hazelcast.simulator.common.FailureType;
+import com.hazelcast.simulator.common.TestSuite;
+import com.hazelcast.simulator.protocol.connector.AgentConnector;
+import com.hazelcast.simulator.protocol.core.Response;
+import com.hazelcast.simulator.protocol.core.ResponseType;
+import com.hazelcast.simulator.protocol.core.SimulatorAddress;
+import com.hazelcast.simulator.protocol.core.SimulatorProtocolException;
+import com.hazelcast.simulator.protocol.operation.FailureOperation;
+import org.apache.log4j.Logger;
+
+import static com.hazelcast.simulator.common.FailureType.WORKER_FINISHED;
+import static java.lang.String.format;
+
+public class FailureSenderImpl implements FailureSender {
+
+    private static final Logger LOGGER = Logger.getLogger(FailureSenderImpl.class);
+
+    private final String agentAddress;
+    private final AgentConnector agentConnector;
+
+    private volatile TestSuite testSuite;
+
+    private int failureCount;
+
+    public FailureSenderImpl(String agentAddress, AgentConnector agentConnector) {
+        this.agentAddress = agentAddress;
+        this.agentConnector = agentConnector;
+    }
+
+    public void setTestSuite(TestSuite testSuite) {
+        this.testSuite = testSuite;
+    }
+
+    @Override
+    public boolean sendFailureOperation(String message, FailureType type, WorkerProcess workerProcess,
+                                        String testId, String cause) {
+        boolean sentSuccessfully = true;
+        boolean isFailure = type != WORKER_FINISHED;
+        SimulatorAddress workerAddress = workerProcess.getAddress();
+        FailureOperation operation = new FailureOperation(message, type, workerAddress, agentAddress,
+                workerProcess.getHazelcastAddress(), workerProcess.getId(), testId, testSuite, cause);
+
+        if (isFailure) {
+            LOGGER.error(format("Detected failure on Worker %s (%s): %s", workerProcess.getId(), workerProcess.getAddress(),
+                    operation.getLogMessage(++failureCount)));
+        } else {
+            LOGGER.info(format("Worker %s (%s) finished.", workerProcess.getId(), workerProcess.getAddress()));
+        }
+
+        try {
+            Response response = agentConnector.write(SimulatorAddress.COORDINATOR, operation);
+            ResponseType firstErrorResponseType = response.getFirstErrorResponseType();
+            if (firstErrorResponseType != ResponseType.SUCCESS) {
+                LOGGER.error(format("Could not send failure to coordinator: %s", firstErrorResponseType));
+                sentSuccessfully = false;
+            } else if (isFailure) {
+                LOGGER.info("Failure successfully sent to Coordinator!");
+            }
+        } catch (SimulatorProtocolException e) {
+            if (!(e.getCause() instanceof InterruptedException)) {
+                LOGGER.error(format("Could not send failure to coordinator! %s", operation.getFileMessage()), e);
+                sentSuccessfully = false;
+            }
+        }
+
+        if (type.isWorkerFinishedFailure()) {
+            String finishedType = (isFailure) ? "failed" : "finished";
+            LOGGER.info(format("Removing %s Worker %s from configuration...", finishedType, workerAddress));
+            agentConnector.removeWorker(workerAddress.getWorkerIndex());
+        }
+
+        return sentSuccessfully;
+    }
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/workerprocess/FailureSenderImplTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/workerprocess/FailureSenderImplTest.java
@@ -1,0 +1,85 @@
+package com.hazelcast.simulator.agent.workerprocess;
+
+import com.hazelcast.simulator.common.TestSuite;
+import com.hazelcast.simulator.protocol.connector.AgentConnector;
+import com.hazelcast.simulator.protocol.core.AddressLevel;
+import com.hazelcast.simulator.protocol.core.Response;
+import com.hazelcast.simulator.protocol.core.SimulatorAddress;
+import com.hazelcast.simulator.protocol.core.SimulatorProtocolException;
+import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.simulator.common.FailureType.WORKER_EXCEPTION;
+import static com.hazelcast.simulator.common.FailureType.WORKER_FINISHED;
+import static com.hazelcast.simulator.protocol.core.ResponseType.FAILURE_COORDINATOR_NOT_FOUND;
+import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FailureSenderImplTest {
+
+    private static final String FAILURE_MESSAGE = "failure message";
+    private static final String TEST_ID = "FailureSenderImplTest";
+    private static final String CAUSE = "any stacktrace";
+
+    private SimulatorAddress workerAddress;
+    private WorkerProcess workerProcess;
+
+    private AgentConnector agentConnector;
+
+    private FailureSenderImpl failureSender;
+
+    @Before
+    public void setUp() {
+        workerAddress = new SimulatorAddress(AddressLevel.WORKER, 1, 1, 0);
+        workerProcess = new WorkerProcess(workerAddress, workerAddress.toString(), null);
+
+        Response response = new Response(1, SimulatorAddress.COORDINATOR, workerAddress, SUCCESS);
+
+        agentConnector = mock(AgentConnector.class);
+        when(agentConnector.write(any(SimulatorAddress.class), any(SimulatorOperation.class))).thenReturn(response);
+
+        TestSuite testSuite = new TestSuite(TEST_ID);
+
+        failureSender = new FailureSenderImpl("127.0.0.1", agentConnector);
+        failureSender.setTestSuite(testSuite);
+    }
+
+    @Test
+    public void testSendFailureOperation() {
+        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_EXCEPTION, workerProcess, TEST_ID, CAUSE);
+
+        assertTrue(success);
+    }
+
+    @Test
+    public void testSendFailureOperation_withWorkerFinished() {
+        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_FINISHED, workerProcess, TEST_ID, CAUSE);
+
+        assertTrue(success);
+    }
+
+    @Test
+    public void testSendFailureOperation_withFailureResponse() {
+        Response failureResponse = new Response(1, SimulatorAddress.COORDINATOR, workerAddress, FAILURE_COORDINATOR_NOT_FOUND);
+        when(agentConnector.write(any(SimulatorAddress.class), any(SimulatorOperation.class))).thenReturn(failureResponse);
+
+        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_FINISHED, workerProcess, TEST_ID, CAUSE);
+
+        assertFalse(success);
+    }
+
+    @Test
+    public void testSendFailureOperation_withProtocolException() {
+        when(agentConnector.write(any(SimulatorAddress.class), any(SimulatorOperation.class)))
+                .thenThrow(new SimulatorProtocolException("expected exception"));
+
+        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_FINISHED, workerProcess, TEST_ID, CAUSE);
+
+        assertFalse(success);
+    }
+}


### PR DESCRIPTION
Pulled out `FailureSender` to decouple `WorkerProcessFailureMonitor` from `Agent` and `AgentConnector`