### PR TITLE
Simplified FailureContainer

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureContainer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureContainer.java
@@ -18,7 +18,6 @@ package com.hazelcast.simulator.coordinator;
 import com.hazelcast.simulator.common.FailureType;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.operation.FailureOperation;
-import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.apache.log4j.Logger;
 
@@ -55,14 +54,10 @@ public class FailureContainer {
     private final ConcurrentMap<String, Boolean> hasCriticalFailuresMap = new ConcurrentHashMap<String, Boolean>();
 
     private final File file;
-    private final ComponentRegistry componentRegistry;
     private final Set<FailureType> nonCriticalFailures;
 
-    public FailureContainer(File outputDirectory,
-                            ComponentRegistry componentRegistry,
-                            Set<FailureType> nonCriticalFailures) {
+    public FailureContainer(File outputDirectory, Set<FailureType> nonCriticalFailures) {
         this.file = new File(outputDirectory, "failures.txt");
-        this.componentRegistry = componentRegistry;
         this.nonCriticalFailures = nonCriticalFailures;
     }
 
@@ -78,7 +73,6 @@ public class FailureContainer {
         if (failureType.isWorkerFinishedFailure()) {
             SimulatorAddress workerAddress = failure.getWorkerAddress();
             finishedWorkers.put(workerAddress, failureType);
-            componentRegistry.removeWorker(workerAddress);
             isFinishedFailure = true;
         }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureListener.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/FailureListener.java
@@ -19,5 +19,5 @@ import com.hazelcast.simulator.protocol.operation.FailureOperation;
 
 public interface FailureListener {
 
-    void onFailure(FailureOperation operation, boolean isFinishedFailure, boolean isCritical);
+    void onFailure(FailureOperation failure, boolean isFinishedFailure, boolean isCritical);
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/CoordinatorConnector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/CoordinatorConnector.java
@@ -104,11 +104,11 @@ public class CoordinatorConnector extends AbstractServerConnector implements Cli
     }
 
     @Override
-    public void onFailure(FailureOperation operation, boolean isFinishedFailure, boolean isCritical) {
+    public void onFailure(FailureOperation failure, boolean isFinishedFailure, boolean isCritical) {
         if (!isFinishedFailure) {
             return;
         }
-        SimulatorAddress workerAddress = operation.getWorkerAddress();
+        SimulatorAddress workerAddress = failure.getWorkerAddress();
         if (workerAddress == null) {
             return;
         }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -93,7 +93,7 @@ public class AgentSmokeTest implements FailureListener {
         testPhaseListeners = new TestPhaseListeners();
         PerformanceStatsContainer performanceStatsContainer = new PerformanceStatsContainer();
         outputDirectory = TestUtils.createTmpDirectory();
-        failureContainer = new FailureContainer(outputDirectory, null, new HashSet<FailureType>());
+        failureContainer = new FailureContainer(outputDirectory, new HashSet<FailureType>());
 
         coordinatorConnector = CoordinatorConnector.createInstance(componentRegistry, failureContainer, testPhaseListeners,
                 performanceStatsContainer, COORDINATOR_PORT);
@@ -124,8 +124,8 @@ public class AgentSmokeTest implements FailureListener {
     }
 
     @Override
-    public void onFailure(FailureOperation operation, boolean isFinishedFailure, boolean isCritical) {
-        failureOperations.add(operation);
+    public void onFailure(FailureOperation failure, boolean isFinishedFailure, boolean isCritical) {
+        failureOperations.add(failure);
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/FailureContainerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/FailureContainerTest.java
@@ -31,7 +31,6 @@ public class FailureContainerTest {
 
     private final static int FINISHED_WORKER_TIMEOUT_SECONDS = 120;
 
-    private ComponentRegistry componentRegistry = mock(ComponentRegistry.class);
     private FailureContainer failureContainer;
 
     private FailureOperation exceptionOperation;
@@ -44,7 +43,7 @@ public class FailureContainerTest {
     public void setUp() {
         outputDirectory = TestUtils.createTmpDirectory();
         failureContainer = new FailureContainer(
-                outputDirectory, componentRegistry, singleton(WORKER_TIMEOUT));
+                outputDirectory, singleton(WORKER_TIMEOUT));
 
         SimulatorAddress workerAddress = new SimulatorAddress(AddressLevel.WORKER, 1, 1, 0);
         String agentAddress = workerAddress.getParent().toString();
@@ -109,7 +108,8 @@ public class FailureContainerTest {
     @Test
     public void testHasCriticalFailure_withNonCriticalFailures() {
         Set<FailureType> nonCriticalFailures = singleton(exceptionOperation.getType());
-        failureContainer = new FailureContainer(outputDirectory, componentRegistry, nonCriticalFailures);
+
+        failureContainer = new FailureContainer(outputDirectory, nonCriticalFailures);
 
         failureContainer.addFailureOperation(exceptionOperation);
         assertFalse(failureContainer.hasCriticalFailure());

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
@@ -333,7 +333,7 @@ public class RunTestSuiteTaskTest {
         componentRegistry.addWorkers(componentRegistry.getFirstAgent().getAddress(), singletonList(workerProcessSettings));
         componentRegistry.addTests(testSuite);
 
-        failureContainer = new FailureContainer(outputDirectory, componentRegistry, Collections.<FailureType>emptySet());
+        failureContainer = new FailureContainer(outputDirectory, Collections.<FailureType>emptySet());
         PerformanceStatsContainer performanceStatsContainer = new PerformanceStatsContainer();
         TestPhaseListeners testPhaseListeners = new TestPhaseListeners();
 

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/ProtocolUtil.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/ProtocolUtil.java
@@ -171,7 +171,7 @@ class ProtocolUtil {
         TestPhaseListeners testPhaseListeners = new TestPhaseListeners();
         PerformanceStatsContainer performanceStatsContainer = new PerformanceStatsContainer();
         File outputDirectory = TestUtils.createTmpDirectory();
-        FailureContainer failureContainer = new FailureContainer(outputDirectory, null, new HashSet<FailureType>());
+        FailureContainer failureContainer = new FailureContainer(outputDirectory, new HashSet<FailureType>());
         CoordinatorConnector coordinatorConnector = CoordinatorConnector.createInstance(componentRegistry, failureContainer,
                 testPhaseListeners, performanceStatsContainer, coordinatorPort);
         for (int i = 1; i <= numberOfAgents; i++) {

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/connector/CoordinatorConnectorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/connector/CoordinatorConnectorTest.java
@@ -56,7 +56,7 @@ public class CoordinatorConnectorTest {
         PerformanceStatsContainer performanceStatsContainer = new PerformanceStatsContainer();
 
         File outputDirectory = TestUtils.createTmpDirectory();
-        FailureContainer failureContainer = new FailureContainer(outputDirectory, null, new HashSet<FailureType>());
+        FailureContainer failureContainer = new FailureContainer(outputDirectory, new HashSet<FailureType>());
 
         coordinatorConnector = CoordinatorConnector.createInstance(componentRegistry, failureContainer, testPhaseListeners,
                 performanceStatsContainer, COORDINATOR_PORT);

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
@@ -96,7 +96,7 @@ public class CoordinatorOperationProcessorTest implements FailureListener {
         performanceStatsContainer = new PerformanceStatsContainer();
 
         outputDirectory = TestUtils.createTmpDirectory();
-        failureContainer = new FailureContainer(outputDirectory, componentRegistry, new HashSet<FailureType>());
+        failureContainer = new FailureContainer(outputDirectory, new HashSet<FailureType>());
 
         processor = new CoordinatorOperationProcessor(exceptionLogger, failureContainer, testPhaseListeners,
                 performanceStatsContainer, remoteControllerProcessor);
@@ -108,8 +108,8 @@ public class CoordinatorOperationProcessorTest implements FailureListener {
     }
 
     @Override
-    public void onFailure(FailureOperation operation, boolean isFinishedFailure, boolean isCritical) {
-        failureOperations.add(operation);
+    public void onFailure(FailureOperation failure, boolean isFinishedFailure, boolean isCritical) {
+        failureOperations.add(failure);
     }
 
     @Test


### PR DESCRIPTION
Removed component registry as argument. ComponentRegistry is now updated
through a regular listener registration. This reduces coupling.