### PR TITLE
Simplified StartWorkersTask

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -177,7 +177,7 @@ public final class Coordinator {
                 startCoordinatorConnector();
                 startRemoteClient();
                 new StartWorkersTask(
-                        deploymentPlan,
+                        deploymentPlan.asMap(),
                         remoteClient,
                         componentRegistry,
                         coordinatorParameters.getWorkerVmStartupDelayMs()).run();

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/AgentWorkerLayout.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/AgentWorkerLayout.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * The layout of workers for a given Simulator Agent.
  */
-public final class AgentWorkerLayout {
+final class AgentWorkerLayout {
 
     private final List<WorkerProcessSettings> workerProcessSettingsList = new ArrayList<WorkerProcessSettings>();
     private final AtomicInteger currentWorkerIndex = new AtomicInteger();
@@ -60,6 +60,10 @@ public final class AgentWorkerLayout {
 
     public String getPrivateAddress() {
         return agentData.getPrivateAddress();
+    }
+
+    public AgentData getAgentData() {
+        return agentData;
     }
 
     public Set<String> getVersionSpecs() {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/DeploymentPlan.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/DeploymentPlan.java
@@ -15,16 +15,20 @@
  */
 package com.hazelcast.simulator.coordinator.deployment;
 
+import com.hazelcast.simulator.agent.workerprocess.WorkerProcessSettings;
 import com.hazelcast.simulator.coordinator.ClusterLayoutParameters;
 import com.hazelcast.simulator.coordinator.WorkerParameters;
+import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.registry.AgentData;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.worker.WorkerType;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.simulator.coordinator.deployment.ClusterUtils.formatIpAddresses;
@@ -47,7 +51,8 @@ public class DeploymentPlan {
     private int memberWorkerCount;
     private int clientWorkerCount;
 
-    public DeploymentPlan(ComponentRegistry componentRegistry, WorkerParameters workerParameters,
+    public DeploymentPlan(ComponentRegistry componentRegistry,
+                          WorkerParameters workerParameters,
                           ClusterLayoutParameters clusterLayoutParameters) {
         agentWorkerLayouts = initMemberLayout(componentRegistry, workerParameters, clusterLayoutParameters);
 
@@ -107,7 +112,16 @@ public class DeploymentPlan {
         return versionSpecs;
     }
 
-    public List<AgentWorkerLayout> getAgentWorkerLayouts() {
+    public Map<SimulatorAddress, List<WorkerProcessSettings>> asMap() {
+        Map<SimulatorAddress, List<WorkerProcessSettings>> result = new HashMap<SimulatorAddress, List<WorkerProcessSettings>>();
+        for (AgentWorkerLayout layout : getAgentWorkerLayouts()) {
+            result.put(layout.getAgentData().getAddress(), layout.getWorkerProcessSettings());
+        }
+
+        return result;
+    }
+
+    private List<AgentWorkerLayout> getAgentWorkerLayouts() {
         return agentWorkerLayouts;
     }
 
@@ -117,9 +131,5 @@ public class DeploymentPlan {
 
     public int getClientWorkerCount() {
         return clientWorkerCount;
-    }
-
-    public int getTotalWorkerCount() {
-        return memberWorkerCount + clientWorkerCount;
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -227,7 +227,7 @@ public class AgentSmokeTest implements FailureListener {
                 false
         );
         DeploymentPlan deploymentPlan = createSingleInstanceClusterLayout(AGENT_IP_ADDRESS, workerParameters);
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
     }
 
     private void runPhase(TestPhaseListenerImpl listener, TestCase testCase, TestPhase testPhase) throws Exception {

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/StartWorkersTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/StartWorkersTaskTest.java
@@ -63,7 +63,7 @@ public class StartWorkersTaskTest {
                 WORKER_PING_INTERVAL_MILLIS,
                 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
 
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
     }
 
 //    @Test
@@ -84,7 +84,7 @@ public class StartWorkersTaskTest {
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
                 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
 
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
     }
 
     @Test(expected = SimulatorProtocolException.class)
@@ -95,7 +95,7 @@ public class StartWorkersTaskTest {
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
                 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
 
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
     }
 
 //    @Test


### PR DESCRIPTION
 so it just receives a list of workersettings per agent. This reduces coupling on the DeploymentPlan and extended internals.