### PR TITLE
Cleanup of RemoteClientTest and StartWorkersTaskTest

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/DeploymentPlan.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/DeploymentPlan.java
@@ -94,7 +94,8 @@ public class DeploymentPlan {
         this.agentWorkerLayouts = new ArrayList<AgentWorkerLayout>();
     }
 
-    public static DeploymentPlan createSingleInstanceClusterLayout(String agentIpAddress, WorkerParameters workerParameters) {
+    public static Map<SimulatorAddress, List<WorkerProcessSettings>> createSingleInstancePlan(String agentIpAddress,
+                                                                                              WorkerParameters workerParameters) {
         AgentData agentData = new AgentData(1, agentIpAddress, agentIpAddress);
         AgentWorkerLayout agentWorkerLayout = new AgentWorkerLayout(agentData, AgentWorkerMode.MEMBER);
         agentWorkerLayout.addWorker(WorkerType.MEMBER, workerParameters);
@@ -105,7 +106,7 @@ public class DeploymentPlan {
         deploymentPlan.memberWorkerCount += agentWorkerLayout.getCount(WorkerType.MEMBER);
         deploymentPlan.clientWorkerCount += agentWorkerLayout.getCount(WorkerType.CLIENT);
 
-        return deploymentPlan;
+        return deploymentPlan.asMap();
     }
 
     public Set<String> getVersionSpecs() {

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.simulator.agent;
 
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.simulator.agent.workerprocess.WorkerProcessSettings;
 import com.hazelcast.simulator.common.FailureType;
 import com.hazelcast.simulator.common.SimulatorProperties;
 import com.hazelcast.simulator.common.TestCase;
@@ -13,7 +14,6 @@ import com.hazelcast.simulator.coordinator.StartWorkersTask;
 import com.hazelcast.simulator.coordinator.TestPhaseListener;
 import com.hazelcast.simulator.coordinator.TestPhaseListeners;
 import com.hazelcast.simulator.coordinator.WorkerParameters;
-import com.hazelcast.simulator.coordinator.deployment.DeploymentPlan;
 import com.hazelcast.simulator.protocol.connector.CoordinatorConnector;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.operation.CreateTestOperation;
@@ -37,6 +37,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,7 +50,7 @@ import static com.hazelcast.simulator.TestEnvironmentUtils.deleteLogs;
 import static com.hazelcast.simulator.TestEnvironmentUtils.resetLogLevel;
 import static com.hazelcast.simulator.TestEnvironmentUtils.resetUserDir;
 import static com.hazelcast.simulator.TestEnvironmentUtils.setDistributionUserDir;
-import static com.hazelcast.simulator.coordinator.deployment.DeploymentPlan.createSingleInstanceClusterLayout;
+import static com.hazelcast.simulator.coordinator.deployment.DeploymentPlan.createSingleInstancePlan;
 import static com.hazelcast.simulator.utils.CommonUtils.await;
 import static com.hazelcast.simulator.utils.CommonUtils.joinThread;
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
@@ -226,8 +228,8 @@ public class AgentSmokeTest implements FailureListener {
                 fileAsText("dist/src/main/dist/conf/worker-hazelcast.sh"),
                 false
         );
-        DeploymentPlan deploymentPlan = createSingleInstanceClusterLayout(AGENT_IP_ADDRESS, workerParameters);
-        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
+        Map<SimulatorAddress, List<WorkerProcessSettings>> plan = createSingleInstancePlan(AGENT_IP_ADDRESS, workerParameters);
+        new StartWorkersTask(plan, remoteClient, componentRegistry, 0).run();
     }
 
     private void runPhase(TestPhaseListenerImpl listener, TestCase testCase, TestPhase testPhase) throws Exception {

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RemoteClientTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RemoteClientTest.java
@@ -3,14 +3,12 @@ package com.hazelcast.simulator.coordinator;
 import com.hazelcast.simulator.agent.workerprocess.WorkerProcessSettings;
 import com.hazelcast.simulator.common.TestCase;
 import com.hazelcast.simulator.common.TestSuite;
-import com.hazelcast.simulator.coordinator.deployment.DeploymentPlan;
 import com.hazelcast.simulator.protocol.connector.CoordinatorConnector;
 import com.hazelcast.simulator.protocol.core.AddressLevel;
 import com.hazelcast.simulator.protocol.core.Response;
 import com.hazelcast.simulator.protocol.core.ResponseType;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.core.SimulatorProtocolException;
-import com.hazelcast.simulator.protocol.operation.CreateWorkerOperation;
 import com.hazelcast.simulator.protocol.operation.IntegrationTestOperation;
 import com.hazelcast.simulator.protocol.operation.LogOperation;
 import com.hazelcast.simulator.protocol.operation.PingOperation;
@@ -48,8 +46,6 @@ public class RemoteClientTest {
     private final ComponentRegistry componentRegistry = new ComponentRegistry();
 
     private final CoordinatorConnector coordinatorConnector = mock(CoordinatorConnector.class);
-    private final ClusterLayoutParameters clusterLayoutParameters = mock(ClusterLayoutParameters.class);
-    private final WorkerParameters workerParameters = mock(WorkerParameters.class);
 
     @Before
     public void setUp() {
@@ -342,18 +338,6 @@ public class RemoteClientTest {
         verifyNoMoreInteractions(coordinatorConnector);
     }
 
-    private void initMockForCreateWorkerOperation(ResponseType responseType) {
-        if (responseType != null) {
-            Response response = mock(Response.class);
-            when(response.getFirstErrorResponseType()).thenReturn(responseType);
-
-            when(coordinatorConnector.write(any(SimulatorAddress.class), any(CreateWorkerOperation.class))).thenReturn(response);
-        } else {
-            Exception exception = new SimulatorProtocolException("expected exception");
-            when(coordinatorConnector.write(any(SimulatorAddress.class), any(CreateWorkerOperation.class))).thenThrow(exception);
-        }
-    }
-
     private void initMock(ResponseType responseType) {
         Map<SimulatorAddress, ResponseType> responseTypes = new HashMap<SimulatorAddress, ResponseType>();
         responseTypes.put(COORDINATOR, responseType);
@@ -362,13 +346,5 @@ public class RemoteClientTest {
         when(response.entrySet()).thenReturn(responseTypes.entrySet());
 
         when(coordinatorConnector.write(any(SimulatorAddress.class), any(SimulatorOperation.class))).thenReturn(response);
-    }
-
-    private DeploymentPlan getClusterLayout(int dedicatedMemberMachineCount, int memberWorkerCount, int clientWorkerCount) {
-        when(clusterLayoutParameters.getDedicatedMemberMachineCount()).thenReturn(dedicatedMemberMachineCount);
-        when(clusterLayoutParameters.getMemberWorkerCount()).thenReturn(memberWorkerCount);
-        when(clusterLayoutParameters.getClientWorkerCount()).thenReturn(clientWorkerCount);
-
-        return new DeploymentPlan(componentRegistry, workerParameters, clusterLayoutParameters);
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/StartWorkersTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/StartWorkersTaskTest.java
@@ -1,8 +1,6 @@
 package com.hazelcast.simulator.coordinator;
 
 import com.hazelcast.simulator.agent.workerprocess.WorkerProcessSettings;
-import com.hazelcast.simulator.common.TestCase;
-import com.hazelcast.simulator.common.TestSuite;
 import com.hazelcast.simulator.coordinator.deployment.DeploymentPlan;
 import com.hazelcast.simulator.protocol.connector.CoordinatorConnector;
 import com.hazelcast.simulator.protocol.core.Response;
@@ -11,114 +9,98 @@ import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.protocol.core.SimulatorProtocolException;
 import com.hazelcast.simulator.protocol.operation.CreateWorkerOperation;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
+import com.hazelcast.simulator.protocol.registry.WorkerData;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class StartWorkersTaskTest {
+
     private static final int WORKER_PING_INTERVAL_MILLIS = (int) TimeUnit.SECONDS.toMillis(10);
-    private final ComponentRegistry componentRegistry = new ComponentRegistry();
     private static final int MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS = 0;
 
+    private final ComponentRegistry componentRegistry = new ComponentRegistry();
     private final CoordinatorConnector coordinatorConnector = mock(CoordinatorConnector.class);
-    private final ClusterLayoutParameters clusterLayoutParameters = mock(ClusterLayoutParameters.class);
     private final WorkerParameters workerParameters = mock(WorkerParameters.class);
-    private static final String DEFAULT_TEST_ID = "RemoteClientTest";
 
     @Before
     public void setup() {
         componentRegistry.addAgent("192.168.0.1", "192.168.0.1");
         componentRegistry.addAgent("192.168.0.2", "192.168.0.2");
         componentRegistry.addAgent("192.168.0.3", "192.168.0.3");
-
-        WorkerProcessSettings workerProcessSettings = mock(WorkerProcessSettings.class);
-        when(workerProcessSettings.getWorkerIndex()).thenReturn(1);
-
-        SimulatorAddress agentAddress = componentRegistry.getFirstAgent().getAddress();
-        componentRegistry.addWorkers(agentAddress, Collections.singletonList(workerProcessSettings));
-
-        TestCase testCase = new TestCase(DEFAULT_TEST_ID);
-
-        TestSuite testSuite = new TestSuite("RemoteClientTest");
-        testSuite.addTest(testCase);
-
-        componentRegistry.addTests(testSuite);
     }
 
-    // this test has no value since it doesn't verify anything. It just triggers the code to run.
     @Test
     public void testCreateWorkers_withClients() {
         initMockForCreateWorkerOperation(ResponseType.SUCCESS);
-        DeploymentPlan deploymentPlan = getClusterLayout(0, 6, 3);
+        Map<SimulatorAddress, List<WorkerProcessSettings>> deploymentPlan = getClusterLayout(0, 6, 3);
 
-        RemoteClient remoteClient= new RemoteClient(
+        RemoteClient remoteClient = new RemoteClient(
                 coordinatorConnector, componentRegistry,
                 WORKER_PING_INTERVAL_MILLIS,
                 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
 
-        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+
+        assertComponentRegistry(componentRegistry, 6, 3);
     }
 
-//    @Test
-//    public void testCreateWorkers_noClients() {
-//        initMockForCreateWorkerOperation(ResponseType.SUCCESS);
-//        DeploymentPlan clusterLayout = getClusterLayout(0, 6, 0);
-//
-//        RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-//                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
-//        remoteClient.createWorkers(clusterLayout, false);
-//    }
-//
-    @Test(expected = CommandLineExitException.class)
-    public void testCreateWorkers_withErrorResponse() {
-        initMockForCreateWorkerOperation(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
-        DeploymentPlan deploymentPlan = getClusterLayout(0, 6, 0);
+    @Test
+    public void testCreateWorkers_noClients() {
+        initMockForCreateWorkerOperation(ResponseType.SUCCESS);
+        Map<SimulatorAddress, List<WorkerProcessSettings>> deploymentPlan = getClusterLayout(0, 6, 0);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
                 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
 
-        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+
+        assertComponentRegistry(componentRegistry, 6, 0);
+    }
+
+    @Test(expected = CommandLineExitException.class)
+    public void testCreateWorkers_withErrorResponse() {
+        initMockForCreateWorkerOperation(ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION);
+        Map<SimulatorAddress, List<WorkerProcessSettings>> deploymentPlan = getClusterLayout(0, 6, 0);
+
+        RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
+                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
+
+        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
     }
 
     @Test(expected = SimulatorProtocolException.class)
     public void testCreateWorkers_withExceptionOnWrite() {
         initMockForCreateWorkerOperation(null);
-        DeploymentPlan deploymentPlan = getClusterLayout(0, 6, 0);
+        Map<SimulatorAddress, List<WorkerProcessSettings>> deploymentPlan = getClusterLayout(0, 6, 0);
 
         RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
                 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS);
 
-        new StartWorkersTask(deploymentPlan.asMap(), remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
     }
 
-//    @Test
-//    public void testCreateWorkersAndTerminateWorkers_withPokeThread() {
-//        initMockForCreateWorkerOperation(ResponseType.SUCCESS);
-//        DeploymentPlan clusterLayout = getClusterLayout(0, 6, 0);
-//
-//        RemoteClient remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS,
-//                MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS, 0);
-//        remoteClient.createWorkers(clusterLayout, true);
-//
-//        sleepSeconds(1);
-//
-//        remoteClient.terminateWorkers(true);
-//    }
+    private Map<SimulatorAddress, List<WorkerProcessSettings>> getClusterLayout(int dedicatedMemberMachineCount,
+                                                                                int memberWorkerCount,
+                                                                                int clientWorkerCount) {
+        ClusterLayoutParameters clusterLayoutParameters = new ClusterLayoutParameters(
+                null,
+                null,
+                memberWorkerCount,
+                clientWorkerCount,
+                dedicatedMemberMachineCount,
+                componentRegistry.agentCount());
 
-
-    private DeploymentPlan getClusterLayout(int dedicatedMemberMachineCount, int memberWorkerCount, int clientWorkerCount) {
-        when(clusterLayoutParameters.getDedicatedMemberMachineCount()).thenReturn(dedicatedMemberMachineCount);
-        when(clusterLayoutParameters.getMemberWorkerCount()).thenReturn(memberWorkerCount);
-        when(clusterLayoutParameters.getClientWorkerCount()).thenReturn(clientWorkerCount);
-
-        return new DeploymentPlan(componentRegistry, workerParameters, clusterLayoutParameters);
+        return new DeploymentPlan(componentRegistry, workerParameters, clusterLayoutParameters).asMap();
     }
 
     private void initMockForCreateWorkerOperation(ResponseType responseType) {
@@ -131,5 +113,21 @@ public class StartWorkersTaskTest {
             Exception exception = new SimulatorProtocolException("expected exception");
             when(coordinatorConnector.write(any(SimulatorAddress.class), any(CreateWorkerOperation.class))).thenThrow(exception);
         }
+    }
+
+    private static void assertComponentRegistry(ComponentRegistry componentRegistry,
+                                                int expectedMemberCount,
+                                                int expectedClientCount) {
+        int actualMemberCount = 0;
+        int actualClientCount = 0;
+        for (WorkerData workerData : componentRegistry.getWorkers()) {
+            if (workerData.isMemberWorker()) {
+                actualMemberCount++;
+            } else {
+                actualClientCount++;
+            }
+        }
+        assertEquals(expectedMemberCount, actualMemberCount);
+        assertEquals(expectedClientCount, actualClientCount);
     }
 }


### PR DESCRIPTION
* Cleanup of unused tests methods.
* Added asserts to StartWorkersTaskTest.
* Changed DeploymentPlan.createSingleInstancePlan() to directly return the map of worker settings.