### PR TITLE
Moved properties into TestSuite

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/common/TestSuite.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/TestSuite.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.simulator.common;
 
+import com.hazelcast.simulator.protocol.registry.TargetType;
 import com.hazelcast.simulator.utils.BindException;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -35,27 +36,69 @@ import static com.hazelcast.simulator.utils.FileUtils.isValidFileName;
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
 
+@SuppressWarnings(value = "checkstyle:methodcount")
 public class TestSuite {
 
     private final List<TestCase> testCaseList = new LinkedList<TestCase>();
-
     private int durationSeconds;
     private int warmupDurationSeconds;
     private boolean waitForTestCase;
     private boolean failFast;
-
+    private boolean parallel;
+    private TargetType targetType;
+    private int targetCount;
+    private boolean verifyEnabled;
     private Set<FailureType> tolerableFailures = Collections.emptySet();
+
+    public TestSuite setVerifyEnabled(boolean verifyEnabled) {
+        this.verifyEnabled = verifyEnabled;
+        return this;
+    }
+
+    public boolean isVerifyEnabled() {
+        return verifyEnabled;
+    }
+
+
+    public TestSuite setParallel(boolean parallel) {
+        this.parallel = parallel;
+        return this;
+    }
+
+    public boolean isParallel() {
+        return parallel;
+    }
+
+    public TestSuite setTargetType(TargetType targetType) {
+        this.targetType = targetType;
+        return this;
+    }
+
+    public TargetType getTargetType(boolean hasClientWorkers) {
+        return targetType.resolvePreferClient(hasClientWorkers);
+    }
+
+    public TestSuite setTargetCount(int targetCount) {
+        this.targetCount = targetCount;
+        return this;
+    }
+
+    public int getTargetCount() {
+        return targetCount;
+    }
 
     public List<TestCase> getTestCaseList() {
         return testCaseList;
     }
 
-    public void setDurationSeconds(int durationSeconds) {
+    public TestSuite setDurationSeconds(int durationSeconds) {
         this.durationSeconds = durationSeconds;
+        return this;
     }
 
-    public void setWarmupDurationSeconds(int warmupDurationSeconds) {
+    public TestSuite setWarmupDurationSeconds(int warmupDurationSeconds) {
         this.warmupDurationSeconds = warmupDurationSeconds;
+        return this;
     }
 
     public int getWarmupDurationSeconds() {
@@ -66,32 +109,36 @@ public class TestSuite {
         return durationSeconds;
     }
 
-    public void setWaitForTestCase(boolean waitForTestCase) {
+    public TestSuite setWaitForTestCase(boolean waitForTestCase) {
         this.waitForTestCase = waitForTestCase;
+        return this;
     }
 
     public boolean isWaitForTestCase() {
         return waitForTestCase;
     }
 
-    public void setFailFast(boolean failFast) {
+    public TestSuite setFailFast(boolean failFast) {
         this.failFast = failFast;
+        return this;
     }
 
     public boolean isFailFast() {
         return failFast;
     }
 
-    public void setTolerableFailures(Set<FailureType> tolerableFailures) {
+    public TestSuite setTolerableFailures(Set<FailureType> tolerableFailures) {
         this.tolerableFailures = tolerableFailures;
+        return this;
     }
 
     public Set<FailureType> getTolerableFailures() {
         return tolerableFailures;
     }
 
-    public void addTest(TestCase testCase) {
+    public TestSuite addTest(TestCase testCase) {
         testCaseList.add(testCase);
+        return this;
     }
 
     public TestCase getTestCase(String testCaseId) {
@@ -126,9 +173,15 @@ public class TestSuite {
     public String toString() {
         return "TestSuite{"
                 + "durationSeconds=" + durationSeconds
+                + ", warmupDurationSeconds=" + warmupDurationSeconds
                 + ", waitForTestCase=" + waitForTestCase
-                + ", testCaseList=" + testCaseList
                 + ", failFast=" + failFast
+                + ", parallel=" + parallel
+                + ", targetType=" + targetType
+                + ", targetCount=" + targetCount
+                + ", verifyEnabled=" + verifyEnabled
+                + ", tolerableFailures=" + tolerableFailures
+                + ", testCaseList=" + testCaseList
                 + '}';
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -198,10 +198,6 @@ final class CoordinatorCli {
                 options.valueOf(sessionIdSpec),
                 simulatorProperties,
                 options.valueOf(workerClassPathSpec),
-                options.valueOf(verifyEnabledSpec),
-                options.has(parallelSpec),
-                options.valueOf(targetTypeSpec),
-                options.valueOf(targetCountSpec),
                 options.valueOf(syncToTestPhaseSpec),
                 options.valueOf(workerVmStartupDelayMsSpec),
                 options.has(skipDownloadSpec),
@@ -241,14 +237,18 @@ final class CoordinatorCli {
             durationSeconds = 0;
         }
 
-        TestSuite testSuite = TestSuite.loadTestSuite(getTestSuiteFile(), options.valueOf(overridesSpec));
-        testSuite.setDurationSeconds(durationSeconds);
-        testSuite.setWarmupDurationSeconds(getDurationSeconds(warmupDurationSpec));
-        testSuite.setWaitForTestCase(hasWaitForTestCase);
-        testSuite.setFailFast(options.valueOf(failFastSpec));
-        testSuite.setTolerableFailures(fromPropertyValue(options.valueOf(tolerableFailureSpec)));
+        TestSuite testSuite = TestSuite.loadTestSuite(getTestSuiteFile(), options.valueOf(overridesSpec))
+                .setDurationSeconds(durationSeconds)
+                .setWarmupDurationSeconds(getDurationSeconds(warmupDurationSpec))
+                .setWaitForTestCase(hasWaitForTestCase)
+                .setFailFast(options.valueOf(failFastSpec))
+                .setTolerableFailures(fromPropertyValue(options.valueOf(tolerableFailureSpec)))
+                .setVerifyEnabled(options.valueOf(verifyEnabledSpec))
+                .setParallel(options.has(parallelSpec))
+                .setTargetType(options.valueOf(targetTypeSpec))
+                .setTargetCount(options.valueOf(targetCountSpec));
 
-        // if the coordinator is not monitoring performance, we don't care for measuring latencies
+         // if the coordinator is not monitoring performance, we don't care for measuring latencies
         if (!options.has(monitorPerformanceSpec)) {
             for (TestCase testCase : testSuite.getTestCaseList()) {
                 testCase.setProperty("measureLatency", "false");

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
@@ -16,7 +16,6 @@
 package com.hazelcast.simulator.coordinator;
 
 import com.hazelcast.simulator.common.SimulatorProperties;
-import com.hazelcast.simulator.protocol.registry.TargetType;
 import com.hazelcast.simulator.testcontainer.TestPhase;
 
 import java.text.SimpleDateFormat;
@@ -31,11 +30,6 @@ class CoordinatorParameters {
     private final String workerClassPath;
 
     private final boolean skipDownload;
-    private final boolean verifyEnabled;
-    private final boolean parallel;
-
-    private final TargetType targetType;
-    private final int targetCount;
 
     private final TestPhase lastTestPhaseToSync;
     private final int workerVmStartupDelayMs;
@@ -47,10 +41,6 @@ class CoordinatorParameters {
     CoordinatorParameters(String sessionId,
                           SimulatorProperties properties,
                           String workerClassPath,
-                          boolean verifyEnabled,
-                          boolean parallel,
-                          TargetType targetType,
-                          int targetCount,
                           TestPhase lastTestPhaseToSync,
                           int workerVmStartupDelayMs,
                           boolean skipDownload,
@@ -58,10 +48,6 @@ class CoordinatorParameters {
         this.sessionId = sessionId == null ? createSessionId() : sessionId;
         this.simulatorProperties = properties;
         this.workerClassPath = workerClassPath;
-        this.verifyEnabled = verifyEnabled;
-        this.parallel = parallel;
-        this.targetType = targetType;
-        this.targetCount = targetCount;
         this.lastTestPhaseToSync = lastTestPhaseToSync;
         this.workerVmStartupDelayMs = workerVmStartupDelayMs;
         this.skipDownload = skipDownload;
@@ -82,22 +68,6 @@ class CoordinatorParameters {
 
     String getWorkerClassPath() {
         return workerClassPath;
-    }
-
-    boolean isVerifyEnabled() {
-        return verifyEnabled;
-    }
-
-    boolean isParallel() {
-        return parallel;
-    }
-
-    TargetType getTargetType(boolean hasClientWorkers) {
-        return targetType.resolvePreferClient(hasClientWorkers);
-    }
-
-    int getTargetCount() {
-        return targetCount;
     }
 
     TestPhase getLastTestPhaseToSync() {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
@@ -80,7 +80,7 @@ public class RunTestSuiteTask {
 
         componentRegistry.addTests(testSuite);
         int testCount = testSuite.size();
-        boolean parallel = coordinatorParameters.isParallel() && testCount > 1;
+        boolean parallel = testSuite.isParallel() && testCount > 1;
         Map<TestPhase, CountDownLatch> testPhaseSyncMap = getTestPhaseSyncMap(testCount, parallel,
                 coordinatorParameters.getLastTestPhaseToSync());
 
@@ -100,7 +100,6 @@ public class RunTestSuiteTask {
                     testPhaseSyncMap,
                     failureCollector,
                     componentRegistry,
-                    coordinatorParameters,
                     workerParameters,
                     performanceStatsCollector);
             testPhaseListeners.addListener(testIndex, runner);
@@ -169,9 +168,9 @@ public class RunTestSuiteTask {
         }
         echoer.echo(HORIZONTAL_RULER);
 
-        int targetCount = coordinatorParameters.getTargetCount();
+        int targetCount = testSuite.getTargetCount();
         if (targetCount > 0) {
-            TargetType targetType = coordinatorParameters.getTargetType(componentRegistry.hasClientWorkers());
+            TargetType targetType = testSuite.getTargetType(componentRegistry.hasClientWorkers());
             List<String> targetWorkers = componentRegistry.getWorkerAddresses(targetType, targetCount);
             echoer.echo("RUN phase will be executed on %s: %s", targetType.toString(targetCount), targetWorkers);
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -103,7 +103,6 @@ final class TestCaseRunner implements TestPhaseListener {
                    Map<TestPhase, CountDownLatch> testPhaseSyncMap,
                    FailureCollector failureCollector,
                    ComponentRegistry componentRegistry,
-                   CoordinatorParameters coordinatorParameters,
                    WorkerParameters workerParameters,
                    PerformanceStatsCollector performanceStatsCollector) {
         this.testIndex = testIndex;
@@ -119,9 +118,9 @@ final class TestCaseRunner implements TestPhaseListener {
         this.prefix = padRight(testCaseId, testSuite.getMaxTestCaseIdLength() + 1);
         this.testPhaseSyncMap = testPhaseSyncMap;
 
-        this.isVerifyEnabled = coordinatorParameters.isVerifyEnabled();
-        this.targetType = coordinatorParameters.getTargetType(componentRegistry.hasClientWorkers());
-        this.targetCount = coordinatorParameters.getTargetCount();
+        this.isVerifyEnabled = testSuite.isVerifyEnabled();
+        this.targetType = testSuite.getTargetType(componentRegistry.hasClientWorkers());
+        this.targetCount = testSuite.getTargetCount();
 
         this.monitorPerformance = workerParameters.isMonitorPerformance();
         this.logPerformanceIntervalSeconds = workerParameters.getWorkerPerformanceMonitorIntervalSeconds();

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorParametersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorParametersTest.java
@@ -1,13 +1,10 @@
 package com.hazelcast.simulator.coordinator;
 
 import com.hazelcast.simulator.common.SimulatorProperties;
-import com.hazelcast.simulator.protocol.registry.TargetType;
 import org.junit.Test;
 
 import static com.hazelcast.simulator.testcontainer.TestPhase.LOCAL_TEARDOWN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class CoordinatorParametersTest {
@@ -20,10 +17,6 @@ public class CoordinatorParametersTest {
                 "CoordinatorParametersTest",
                 properties,
                 "workerClassPath",
-                false,
-                true,
-                TargetType.PREFER_CLIENT,
-                5,
                 LOCAL_TEARDOWN,
                 0,
                 true,
@@ -32,11 +25,6 @@ public class CoordinatorParametersTest {
         assertEquals("CoordinatorParametersTest", coordinatorParameters.getSessionId());
         assertEquals(properties, coordinatorParameters.getSimulatorProperties());
         assertEquals("workerClassPath", coordinatorParameters.getWorkerClassPath());
-        assertFalse(coordinatorParameters.isVerifyEnabled());
-        assertTrue(coordinatorParameters.isParallel());
-        assertEquals(TargetType.CLIENT, coordinatorParameters.getTargetType(true));
-        assertEquals(TargetType.MEMBER, coordinatorParameters.getTargetType(false));
-        assertEquals(5, coordinatorParameters.getTargetCount());
         assertEquals(LOCAL_TEARDOWN, coordinatorParameters.getLastTestPhaseToSync());
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
@@ -320,10 +320,11 @@ public class RunTestSuiteTaskTest {
 
         CoordinatorParameters coordinatorParameters = mock(CoordinatorParameters.class);
         when(coordinatorParameters.getSimulatorProperties()).thenReturn(simulatorProperties);
-        when(coordinatorParameters.isVerifyEnabled()).thenReturn(verifyEnabled);
-        when(coordinatorParameters.isParallel()).thenReturn(parallel);
-        when(coordinatorParameters.getTargetType(anyBoolean())).thenReturn(TargetType.ALL);
-        when(coordinatorParameters.getTargetCount()).thenReturn(targetCount);
+
+        testSuite.setVerifyEnabled(verifyEnabled)
+                .setParallel(parallel)
+                .setTargetType(TargetType.ALL)
+                .setTargetCount(targetCount);
 
         WorkerParameters workerParameters = mock(WorkerParameters.class);
         when(workerParameters.isMonitorPerformance()).thenReturn(monitorPerformance);


### PR DESCRIPTION
run specific properties are moved into the TestSuite. This is needed for
the session functionality so that multiple test suites can be run with
different settings.