### PR TITLE
Fixes memory leak in RunTestSuiteTask

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
@@ -72,6 +72,7 @@ public class RunTestSuiteTask {
         try {
             run0();
         } finally {
+            testPhaseListeners.removeAllListeners(runners);
             componentRegistry.removeTests();
             performanceStatsCollector.logDetailedPerformanceInfo(testSuite.getDurationSeconds());
         }
@@ -87,7 +88,7 @@ public class RunTestSuiteTask {
                 coordinatorParameters.getLastTestPhaseToSync());
 
         echoer.echo("Starting TestSuite");
-        logTestSuiteDuration(parallel);
+        echoTestSuiteDuration(parallel);
 
         for (TestData testData : componentRegistry.getTests()) {
             int testIndex = testData.getTestIndex();
@@ -118,7 +119,7 @@ public class RunTestSuiteTask {
         echoTestSuiteEnd(testCount, started);
     }
 
-    private void logTestSuiteDuration(boolean isParallel) {
+    private void echoTestSuiteDuration(boolean isParallel) {
         int testDuration = testSuite.getDurationSeconds();
         if (testDuration > 0) {
             echoer.echo("Running time per test: %s", secondsToHuman(testDuration));

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestPhaseListeners.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestPhaseListeners.java
@@ -20,6 +20,7 @@ import com.hazelcast.simulator.testcontainer.TestPhase;
 import org.apache.log4j.Logger;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -40,6 +41,14 @@ public class TestPhaseListeners {
 
     public void addListener(int testIndex, TestPhaseListener listener) {
         listenerMap.put(testIndex, listener);
+    }
+
+    public void removeAllListeners(Collection<? extends TestPhaseListener> listeners) {
+        for (Map.Entry<Integer, TestPhaseListener> entry : listenerMap.entrySet()) {
+            if (listeners.contains(entry.getValue())) {
+                listenerMap.remove(entry.getKey());
+            }
+        }
     }
 
     public void updatePhaseCompletion(int testIndex, TestPhase testPhase, SimulatorAddress workerAddress) {

--- a/simulator/src/test/java/com/hazelcast/simulator/TestSupport.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/TestSupport.java
@@ -1,5 +1,7 @@
 package com.hazelcast.simulator;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/TestPhaseListenersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/TestPhaseListenersTest.java
@@ -5,8 +5,13 @@ import com.hazelcast.simulator.testcontainer.TestPhase;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashSet;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class TestPhaseListenersTest {
 
@@ -20,6 +25,20 @@ public class TestPhaseListenersTest {
     @Test
     public void testGetListeners() {
         assertTrue(testPhaseListeners.getListeners().isEmpty());
+    }
+
+    @Test
+    public void removeAllListeners() {
+        TestPhaseListener listener1 = mock(TestPhaseListener.class);
+        TestPhaseListener listener2 = mock(TestPhaseListener.class);
+        TestPhaseListener listener3 = mock(TestPhaseListener.class);
+        testPhaseListeners.addListener(1, listener1);
+        testPhaseListeners.addListener(1, listener2);
+        testPhaseListeners.addListener(1, listener3);
+
+        testPhaseListeners.removeAllListeners(asList(listener1, listener2));
+
+        assertEquals(singleton(listener3), new HashSet<TestPhaseListener>(testPhaseListeners.getListeners()));
     }
 
     @Test


### PR DESCRIPTION
Currently it isn't a problem because will kill the coordinator after running
a testsuite; but the TestPhaseListeners are not unregistered. This causes
problems with the session based approach.