### PR TITLE
WorkerParameter cleanup performanceMonitorInterval

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -108,9 +108,12 @@ final class Coordinator {
         echoLocal("Last TestPhase to sync: %s", lastTestPhaseToSync);
         echoLocal("Output directory: " + outputDirectory.getAbsolutePath());
 
-        boolean performanceEnabled = workerParameters.isMonitorPerformance();
-        int performanceIntervalSeconds = workerParameters.getWorkerPerformanceMonitorIntervalSeconds();
-        echoLocal("Performance monitor enabled: %s (%d seconds)", performanceEnabled, performanceIntervalSeconds);
+        int performanceIntervalSeconds = workerParameters.getPerformanceMonitorIntervalSeconds();
+        if (performanceIntervalSeconds > 0) {
+            echoLocal("Performance monitor enabled (%d seconds)", performanceIntervalSeconds);
+        } else {
+            echoLocal("Performance monitor disabled");
+        }
     }
 
     void run(TestSuite testSuite) {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/WorkerParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/WorkerParameters.java
@@ -19,7 +19,6 @@ import com.hazelcast.simulator.common.SimulatorProperties;
 import com.hazelcast.simulator.protocol.registry.AgentData;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 
-import static java.lang.Math.min;
 import static java.lang.String.format;
 
 /**
@@ -27,26 +26,19 @@ import static java.lang.String.format;
  */
 public class WorkerParameters {
 
-    private static final int DEFAULT_WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS = 10;
-
     private final boolean autoCreateHzInstance;
     private final int workerStartupTimeout;
-
     private final String versionSpec;
-
     private final String memberJvmOptions;
     private final String clientJvmOptions;
-
     private final String memberHzConfig;
     private final String clientHzConfig;
     private final String log4jConfig;
-
-    private final boolean monitorPerformance;
-    private final int workerPerformanceMonitorIntervalSeconds;
-
+    // value of 1 or higher means enabled.
+    private final int performanceMonitorIntervalSeconds;
     private final String workerScript;
 
-    public WorkerParameters(SimulatorProperties properties,
+    public WorkerParameters(String versionSpec,
                             boolean autoCreateHzInstance,
                             int workerStartupTimeout,
                             String memberJvmOptions,
@@ -55,30 +47,17 @@ public class WorkerParameters {
                             String clientHzConfig,
                             String log4jConfig,
                             String workerScript,
-                            boolean monitorPerformance) {
+                            int performanceMonitorIntervalSeconds) {
         this.autoCreateHzInstance = autoCreateHzInstance;
         this.workerStartupTimeout = workerStartupTimeout;
-
-        this.versionSpec = properties.getVersionSpec();
-
+        this.versionSpec = versionSpec;
         this.memberJvmOptions = memberJvmOptions;
         this.clientJvmOptions = clientJvmOptions;
-
         this.memberHzConfig = memberHzConfig;
         this.clientHzConfig = clientHzConfig;
         this.log4jConfig = log4jConfig;
-
-        this.monitorPerformance = monitorPerformance;
-        this.workerPerformanceMonitorIntervalSeconds = initWorkerPerformanceMonitorIntervalSeconds(properties);
+        this.performanceMonitorIntervalSeconds = performanceMonitorIntervalSeconds;
         this.workerScript = workerScript;
-    }
-
-    private int initWorkerPerformanceMonitorIntervalSeconds(SimulatorProperties properties) {
-        String intervalSeconds = properties.get("WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS");
-        if (intervalSeconds == null || intervalSeconds.isEmpty()) {
-            return DEFAULT_WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS;
-        }
-        return Integer.parseInt(intervalSeconds);
     }
 
     public boolean isAutoCreateHzInstance() {
@@ -113,23 +92,8 @@ public class WorkerParameters {
         return log4jConfig;
     }
 
-    public boolean isMonitorPerformance() {
-        return monitorPerformance;
-    }
-
-    public int getWorkerPerformanceMonitorIntervalSeconds() {
-        if (monitorPerformance) {
-            return workerPerformanceMonitorIntervalSeconds;
-        } else {
-            return -1;
-        }
-    }
-
-    public int getRunPhaseLogIntervalSeconds(int runPhaseLogIntervalSeconds) {
-        if (!monitorPerformance) {
-            return runPhaseLogIntervalSeconds;
-        }
-        return min(workerPerformanceMonitorIntervalSeconds, runPhaseLogIntervalSeconds);
+    public int getPerformanceMonitorIntervalSeconds() {
+        return performanceMonitorIntervalSeconds;
     }
 
     public String getWorkerScript() {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/AgentWorkerLayout.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/deployment/AgentWorkerLayout.java
@@ -83,7 +83,7 @@ final class AgentWorkerLayout {
         environment.put("LOG4j_CONFIG", parameters.getLog4jConfig());
         environment.put("AUTOCREATE_HAZELCAST_INSTANCE", Boolean.toString(parameters.isAutoCreateHzInstance()));
         environment.put("WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS",
-                Integer.toString(parameters.getWorkerPerformanceMonitorIntervalSeconds()));
+                Integer.toString(parameters.getPerformanceMonitorIntervalSeconds()));
 
         WorkerProcessSettings settings = new WorkerProcessSettings(
                 agentData.getNextWorkerIndex(),

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -233,7 +233,7 @@ public class AgentSmokeTest implements FailureListener {
 
     private void createWorkers() {
         WorkerParameters workerParameters = new WorkerParameters(
-                new SimulatorProperties(),
+                "outofthebox",
                 true,
                 60000,
                 "",
@@ -242,8 +242,7 @@ public class AgentSmokeTest implements FailureListener {
                 "",
                 fileAsText(internalDistPath() + "/conf/worker-log4j.xml"),
                 fileAsText(internalDistPath() + "/conf/worker-hazelcast.sh"),
-                false
-        );
+                0);
         DeploymentPlan deploymentPlan = createSingleInstanceDeploymentPlan(AGENT_IP_ADDRESS, workerParameters);
         new StartWorkersTask(deploymentPlan.getWorkerDeployment(), remoteClient, componentRegistry, 0).run();
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
@@ -19,7 +19,6 @@ import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.protocol.registry.TargetType;
 import com.hazelcast.simulator.protocol.registry.TestData;
 import com.hazelcast.simulator.testcontainer.TestPhase;
-import com.hazelcast.simulator.utils.TestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -51,7 +50,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -76,7 +74,7 @@ public class RunTestSuiteTaskTest {
 
     private boolean parallel = false;
     private boolean verifyEnabled = true;
-    private boolean monitorPerformance = false;
+    private int monitorPerformanceMonitorIntervalSeconds = 0;
 
     @BeforeClass
     public static void prepareEnvironment() {
@@ -145,7 +143,7 @@ public class RunTestSuiteTaskTest {
     public void runParallel_performanceMonitorEnabled() {
         testSuite.setDurationSeconds(4);
         parallel = true;
-        monitorPerformance = true;
+        monitorPerformanceMonitorIntervalSeconds = 10;
 
         RunTestSuiteTask task = createRunTestSuiteTask();
         task.run();
@@ -323,9 +321,7 @@ public class RunTestSuiteTaskTest {
                 .setTargetCount(targetCount);
 
         WorkerParameters workerParameters = mock(WorkerParameters.class);
-        when(workerParameters.isMonitorPerformance()).thenReturn(monitorPerformance);
-        when(workerParameters.getWorkerPerformanceMonitorIntervalSeconds()).thenReturn(3);
-        when(workerParameters.getRunPhaseLogIntervalSeconds(anyInt())).thenReturn(3);
+        when(workerParameters.getPerformanceMonitorIntervalSeconds()).thenReturn(monitorPerformanceMonitorIntervalSeconds);
 
         RunTestSuiteTask task = new RunTestSuiteTask(testSuite, coordinatorParameters, componentRegistry, failureCollector,
                 testPhaseListeners, remoteClient, performanceStatsCollector,

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/WorkerParametersTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/WorkerParametersTest.java
@@ -45,12 +45,12 @@ public class WorkerParametersTest {
 
     @Test
     public void testConstructor() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, true, 2342, "memberJvmOptions", "clientJvmOptions",
-                memberConfig, clientConfig, "log4jConfig", "worker.sh", true);
+        WorkerParameters workerParameters = new WorkerParameters("outofthebox", true, 2342, "memberJvmOptions", "clientJvmOptions",
+                memberConfig, clientConfig, "log4jConfig", "worker.sh", 1234);
 
         assertTrue(workerParameters.isAutoCreateHzInstance());
         assertEquals(2342, workerParameters.getWorkerStartupTimeout());
-        assertEquals(1234, workerParameters.getWorkerPerformanceMonitorIntervalSeconds());
+        assertEquals(1234, workerParameters.getPerformanceMonitorIntervalSeconds());
         assertEquals("outofthebox", workerParameters.getVersionSpec());
 
         assertEquals("memberJvmOptions", workerParameters.getMemberJvmOptions());
@@ -59,33 +59,8 @@ public class WorkerParametersTest {
         assertEquals(memberConfig, workerParameters.getMemberHzConfig());
         assertEquals(clientConfig, workerParameters.getClientHzConfig());
         assertEquals("log4jConfig", workerParameters.getLog4jConfig());
-        assertTrue(workerParameters.isMonitorPerformance());
 
         assertEquals("worker.sh", workerParameters.getWorkerScript());
-    }
-
-    @Test
-    public void testGetRunPhaseLogIntervalSeconds_noPerformanceMonitor() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, "worker.sh", false);
-
-        int intervalSeconds = workerParameters.getRunPhaseLogIntervalSeconds(5);
-        assertEquals(5, intervalSeconds);
-    }
-
-    @Test
-    public void testGetRunPhaseLogIntervalSeconds_withPerformanceMonitor_overPerformanceMonitorInterval() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, "worker.sh", true);
-
-        int intervalSeconds = workerParameters.getRunPhaseLogIntervalSeconds(5000);
-        assertEquals(1234, intervalSeconds);
-    }
-
-    @Test
-    public void testGetRunPhaseLogIntervalSeconds_withPerformanceMonitor_belowPerformanceMonitorInterval() {
-        WorkerParameters workerParameters = new WorkerParameters(properties, false, 0, null, null, null, null, null, "worker.sh", true);
-
-        int intervalSeconds = workerParameters.getRunPhaseLogIntervalSeconds(30);
-        assertEquals(30, intervalSeconds);
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/deployment/DeploymentUtilsTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/deployment/DeploymentUtilsTest.java
@@ -170,7 +170,7 @@ public class DeploymentUtilsTest {
 
     @Test
     public void testGenerateFromArguments_singleMemberWorker() {
-        when(workerParameters.isMonitorPerformance()).thenReturn(true);
+        when(workerParameters.getPerformanceMonitorIntervalSeconds()).thenReturn(10);
 
         workerDeployment = generateFromArguments(componentRegistry, workerParameters, 1, 0, 0);
 


### PR DESCRIPTION
Simplified to a single field for tracking performance monitor interval
removed dependency on simulatorproperties (needed for coordinator sessions)