### PR TITLE
Fixes problem that testcase not stopping

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -55,7 +55,7 @@ public class Agent {
     private final String cloudCredential;
 
     private final AgentConnector agentConnector;
-    private final FailureSenderImpl failureSender;
+    private final FailureHandlerImpl failureSender;
     private final WorkerProcessFailureMonitor workerProcessFailureMonitor;
 
     private volatile TestSuite testSuite;
@@ -74,7 +74,7 @@ public class Agent {
         this.cloudCredential = cloudCredential;
 
         this.agentConnector = AgentConnector.createInstance(this, workerProcessManager, port, threadPoolSize);
-        this.failureSender = new FailureSenderImpl(publicAddress, agentConnector);
+        this.failureSender = new FailureHandlerImpl(publicAddress, agentConnector);
         this.workerProcessFailureMonitor = new WorkerProcessFailureMonitor(failureSender, workerProcessManager,
                 workerLastSeenTimeoutSeconds);
 

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/FailureHandler.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/FailureHandler.java
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hazelcast.simulator.agent;
+package com.hazelcast.simulator.agent.workerprocess;
 
-import com.hazelcast.simulator.agent.workerprocess.WorkerProcess;
 import com.hazelcast.simulator.common.FailureType;
 
-public interface FailureSender {
+public interface FailureHandler {
 
-    boolean sendFailureOperation(String message, FailureType type, WorkerProcess workerProcess, String testId, String cause);
+    boolean handle(String message, FailureType type, WorkerProcess workerProcess, String testId, String cause);
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcess.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcess.java
@@ -33,6 +33,7 @@ public class WorkerProcess {
     private volatile boolean isFinished;
     private volatile Process process;
     private volatile String hzAddress;
+    private volatile boolean failureIgnored;
 
     public WorkerProcess(SimulatorAddress address, String id, File workerHome) {
         this.address = address;
@@ -94,5 +95,13 @@ public class WorkerProcess {
 
     public void setHzAddress(String memberAddress) {
         this.hzAddress = memberAddress;
+    }
+
+    public boolean isFailureIgnored() {
+        return failureIgnored;
+    }
+
+    public void setFailureIgnored(boolean failureIgnored) {
+        this.failureIgnored = failureIgnored;
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManager.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManager.java
@@ -44,8 +44,10 @@ public class WorkerProcessManager {
     }
 
     public void ignore(SimulatorAddress workerAddress) {
-        LOGGER.info("Dropping worker [" + workerAddress + "]");
-        workerProcesses.remove(workerAddress);
+        WorkerProcess workerProcess = workerProcesses.get(workerAddress);
+        if (workerProcess != null) {
+            workerProcess.setFailureIgnored(true);
+        }
     }
 
     public Collection<WorkerProcess> getWorkerProcesses() {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -428,9 +428,13 @@ public final class Coordinator {
         }
 
         SimulatorAddress memberAddress = randomMember.getAddress();
+
         componentRegistry.removeWorker(memberAddress);
+
         coordinatorConnector.write(memberAddress.getParent(), new IgnoreWorkerFailureOperation(memberAddress));
+
         coordinatorConnector.writeAsync(memberAddress, new KillWorkerOperation());
+
         LOGGER.info("Kill send to worker [" + memberAddress + "]");
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/FailureHandlerImplTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/FailureHandlerImplTest.java
@@ -31,10 +31,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FailureSenderImplTest {
+public class FailureHandlerImplTest {
 
     private static final String FAILURE_MESSAGE = "failure message";
-    private static final String SESSION_ID = "FailureSenderImplTest";
+    private static final String SESSION_ID = "FailureHandlerImplTest";
     private static final String CAUSE = "any stacktrace";
 
     private SimulatorAddress workerAddress;
@@ -42,7 +42,7 @@ public class FailureSenderImplTest {
 
     private AgentConnector agentConnector;
 
-    private FailureSenderImpl failureSender;
+    private FailureHandlerImpl failureSender;
 
     private ResponseFuture responseFuture;
 
@@ -64,13 +64,13 @@ public class FailureSenderImplTest {
 
         TestSuite testSuite = new TestSuite();
 
-        failureSender = new FailureSenderImpl("127.0.0.1", agentConnector);
+        failureSender = new FailureHandlerImpl("127.0.0.1", agentConnector);
         failureSender.setTestSuite(testSuite);
     }
 
     @Test
     public void testSendFailureOperation() {
-        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_EXCEPTION, workerProcess, SESSION_ID, CAUSE);
+        boolean success = failureSender.handle(FAILURE_MESSAGE, WORKER_EXCEPTION, workerProcess, SESSION_ID, CAUSE);
 
         assertTrue(success);
         assertFalse(responseFuture.isDone());
@@ -78,7 +78,7 @@ public class FailureSenderImplTest {
 
     @Test(timeout = 10000)
     public void testSendFailureOperation_whenWorkerIsFinished_thenUnblockResponseFutureByFailure() throws Exception {
-        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_FINISHED, workerProcess, SESSION_ID, CAUSE);
+        boolean success = failureSender.handle(FAILURE_MESSAGE, WORKER_FINISHED, workerProcess, SESSION_ID, CAUSE);
 
         assertTrue(success);
         assertTrue(responseFuture.isDone());
@@ -90,7 +90,7 @@ public class FailureSenderImplTest {
         Response failureResponse = new Response(1, COORDINATOR, workerAddress, FAILURE_COORDINATOR_NOT_FOUND);
         when(agentConnector.write(any(SimulatorAddress.class), any(SimulatorOperation.class))).thenReturn(failureResponse);
 
-        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, WORKER_EXCEPTION, workerProcess, SESSION_ID, CAUSE);
+        boolean success = failureSender.handle(FAILURE_MESSAGE, WORKER_EXCEPTION, workerProcess, SESSION_ID, CAUSE);
 
         assertFalse(success);
         assertFalse(responseFuture.isDone());
@@ -101,7 +101,7 @@ public class FailureSenderImplTest {
         when(agentConnector.write(any(SimulatorAddress.class), any(SimulatorOperation.class)))
                 .thenThrow(new SimulatorProtocolException("expected exception"));
 
-        boolean success = failureSender.sendFailureOperation(FAILURE_MESSAGE, NETTY_EXCEPTION, workerProcess, SESSION_ID, CAUSE);
+        boolean success = failureSender.handle(FAILURE_MESSAGE, NETTY_EXCEPTION, workerProcess, SESSION_ID, CAUSE);
 
         assertFalse(success);
         assertFalse(responseFuture.isDone());


### PR DESCRIPTION
fix #1123

It has been improved so that the worker isn't deleted and follows the regular process
of termination in case of failure. But if a worker has been marked as 'ignore failure'
on the agent, the failure isn't published to the coordinator.

This means that its connections and all that are closed when the worker is terminated
and no communication with a dead worker is scheduled.