### PR TITLE
Execution Group for timestep

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -71,7 +71,7 @@ HARAKIRI_MONITOR_WAIT_SECONDS=7200
 
 #
 # Just a prefix for the agent name. Different test clusters could be given different names. In GCE you need
-# to be very careful using multiple group-names, because for every port and every group-name a firewall rule is
+# to be very careful using multiple executionGroup-names, because for every port and every executionGroup-name a firewall rule is
 # made and you can only have 100 firewall rules.
 #
 # If the name contains ${username}, this section will be replaced by the actual user that runs the

--- a/simulator/src/main/java/com/hazelcast/simulator/test/annotations/AfterRun.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/annotations/AfterRun.java
@@ -29,4 +29,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface AfterRun {
+    /**
+     * The execution executionGroup. For more information see {@link TimeStep}.
+     *
+     * @return the execution executionGroup.
+     */
+    String executionGroup() default "";
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/test/annotations/BeforeRun.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/annotations/BeforeRun.java
@@ -31,4 +31,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface BeforeRun {
+    /**
+     * The execution executionGroup. For more information see {@link TimeStep}.
+     *
+     * @return the execution executionGroup.
+     */
+    String executionGroup() default "";
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/test/annotations/TimeStep.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/annotations/TimeStep.java
@@ -51,4 +51,20 @@ public @interface TimeStep {
      * @return the probability.
      */
     double prob() default 1;
+
+    /**
+     * Normally all timeStep methods will be executed by a single executionGroup of threads. But in some case you need to have
+     * some methods executed by one executionGroup of threads, and other methods by other groups threads. A good example would
+     * be a produce/consume example where the produce timeStep methods are called by different methods than consume timestep
+     * methods.
+     *
+     * Normally threadCount is configured using 'threadCount=5'. In case of 'foobar' executionGroup, the threadCount is
+     * configured using 'foobarThreadCount=5'.
+     *
+     * This setting is copied from JMH, see:
+     * http://javadox.com/org.openjdk.jmh/jmh-core/0.9/org/openjdk/jmh/annotations/Group.html
+     *
+     * @return the executionGroup.
+     */
+    String executionGroup() default "";
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepModel.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepModel.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,90 +42,129 @@ import static java.lang.reflect.Modifier.isStatic;
 public class TimeStepModel {
 
     private final Class testClass;
-    private final Class threadStateClass;
-    private final List<Method> beforeRunMethods;
-    private final List<Method> afterRunMethods;
-    private final List<Method> timeStepMethods;
-    private final Map<Method, Probability> probabilities;
-    private final byte[] timeStepProbabilityArray;
+
+    private final Map<String, ExecutionGroup> executionGroups = new HashMap<String, ExecutionGroup>();
     private final PropertyBinding propertyBinding;
-    private final Constructor threadStateConstructor;
 
     public TimeStepModel(Class testClass, PropertyBinding propertyBinding) {
         this.propertyBinding = propertyBinding;
         this.testClass = testClass;
-        this.beforeRunMethods = loadBeforeRunMethods();
-        this.afterRunMethods = loadAfterRunMethods();
-        this.timeStepMethods = loadTimeStepMethods();
-        this.threadStateClass = loadThreadStateClass();
-        this.threadStateConstructor = loadThreadStateConstructor();
-        this.probabilities = loadProbabilities();
-        this.timeStepProbabilityArray = loadTimeStepProbabilityArray(probabilities, getActiveTimeStepMethods());
+
+        loadTimeStepMethods();
+        loadBeforeRunMethods();
+        loadAfterRunMethods();
+
+        for (ExecutionGroup executionGroup : executionGroups.values()) {
+            executionGroup.init();
+        }
     }
+
 
     public final Class getTestClass() {
         return testClass;
     }
 
-    public final Class getThreadStateClass() {
-        return threadStateClass;
+    public final Class getThreadStateClass(String executionGroup) {
+        return executionGroups.get(executionGroup).threadStateClass;
     }
 
-    public final List<Method> getBeforeRunMethods() {
-        return beforeRunMethods;
+    public final Set<String> getExecutionGroups() {
+        return executionGroups.keySet();
     }
 
-    public final List<Method> getAfterRunMethods() {
-        return afterRunMethods;
+    public final List<Method> getBeforeRunMethods(String executionGroup) {
+        return executionGroups.get(executionGroup).beforeRunMethods;
     }
 
-    public final List<Method> getTimeStepMethods() {
-        return timeStepMethods;
+    public final List<Method> getAfterRunMethods(String executionGroup) {
+        return executionGroups.get(executionGroup).afterRunMethods;
     }
 
-    public final List<Method> getActiveTimeStepMethods() {
+    public final List<Method> getTimeStepMethods(String executionGroup) {
+        return executionGroups.get(executionGroup).timeStepMethods;
+    }
+
+    public final List<Method> getActiveTimeStepMethods(String group) {
         List<Method> result = new ArrayList<Method>();
-        for (Method method : timeStepMethods) {
-            if (probabilities.get(method).isLargerThanZero()) {
+        ExecutionGroup executionGroup = executionGroups.get(group);
+        for (Method method : executionGroup.timeStepMethods) {
+            if (executionGroup.probabilities.get(method).isLargerThanZero()) {
                 result.add(method);
             }
         }
         return result;
     }
 
-    public final Constructor getThreadStateConstructor() {
-        return threadStateConstructor;
+    public final Constructor getThreadStateConstructor(String executionGroup) {
+        return executionGroups.get(executionGroup).threadStateConstructor;
     }
 
     // just for testing
-    Probability getProbability(String methodName) {
-        for (Method method : getTimeStepMethods()) {
+    Probability getProbability(String group, String methodName) {
+        ExecutionGroup executionGroup = executionGroups.get(group);
+        for (Method method : executionGroup.timeStepMethods) {
             if (method.getName().equals(methodName)) {
-                return probabilities.get(method);
+                return executionGroup.probabilities.get(method);
             }
         }
         return null;
     }
 
-    private List<Method> loadBeforeRunMethods() {
+    private void loadBeforeRunMethods() {
         List<Method> methods = new AnnotatedMethodRetriever(testClass, BeforeRun.class)
                 .findAll();
 
         validateModifiers(methods);
         validateBeforeAndAfterRunArguments(BeforeRun.class.getSimpleName(), methods);
-        return methods;
+
+        for (Method method : methods) {
+            BeforeRun beforeRun = method.getAnnotation(BeforeRun.class);
+            String executionGroupName = beforeRun.executionGroup();
+            ensureExecutionGroupIsIdentifier(method, executionGroupName);
+            ExecutionGroup executionGroup = executionGroups.get(executionGroupName);
+            if (executionGroup == null) {
+                if (executionGroupName.equals("")) {
+                    throw new IllegalTestException(
+                            "@BeforeRun " + method + " is part of default executionGroup,"
+                                    + " but no timeStep methods for that executionGroup exist ");
+                } else {
+                    throw new IllegalTestException(
+                            "@BeforeRun " + method + " is part of executionGroup [" + executionGroupName
+                                    + "], but no timeStep methods for that executionGroup exist ");
+                }
+            }
+            executionGroup.beforeRunMethods.add(method);
+        }
     }
 
-    private List<Method> loadAfterRunMethods() {
+
+    private void loadAfterRunMethods() {
         List<Method> methods = new AnnotatedMethodRetriever(testClass, AfterRun.class)
                 .findAll();
 
         validateModifiers(methods);
         validateBeforeAndAfterRunArguments(AfterRun.class.getSimpleName(), methods);
-        return methods;
+        for (Method method : methods) {
+            AfterRun afterRun = method.getAnnotation(AfterRun.class);
+            String executionGroupName = afterRun.executionGroup();
+            ensureExecutionGroupIsIdentifier(method, executionGroupName);
+            ExecutionGroup executionGroup = executionGroups.get(executionGroupName);
+            if (executionGroup == null) {
+                if (executionGroupName.equals("")) {
+                    throw new IllegalTestException(
+                            "@AfterRun " + method + " is part of default executionGroup,"
+                                    + " but no timeStep methods for that executionGroup exist ");
+                } else {
+                    throw new IllegalTestException(
+                            "@AfterRun " + method + " is part of executionGroup [" + executionGroupName
+                                    + "], but no timeStep methods for that executionGroup exist ");
+                }
+            }
+            executionGroup.beforeRunMethods.add(method);
+        }
     }
 
-    private List<Method> loadTimeStepMethods() {
+    private void loadTimeStepMethods() {
         List<Method> methods = new AnnotatedMethodRetriever(testClass, TimeStep.class)
                 .findAll();
 
@@ -138,7 +178,46 @@ public class TimeStepModel {
         validateUniqueMethodNames(methods);
         validateModifiers(methods);
         validateTimeStepArguments(methods);
-        return methods;
+
+        for (Method method : methods) {
+            TimeStep timeStep = method.getAnnotation(TimeStep.class);
+            String group = timeStep.executionGroup();
+            ensureExecutionGroupIsIdentifier(method, group);
+            ExecutionGroup executionGroup = executionGroups.get(group);
+            if (executionGroup == null) {
+                executionGroup = new ExecutionGroup(group);
+                executionGroups.put(group, executionGroup);
+            }
+
+            executionGroup.timeStepMethods.add(method);
+        }
+    }
+
+    private static void ensureExecutionGroupIsIdentifier(Method method, String executionGroup) {
+        if (executionGroup.equals("")) {
+            return;
+        }
+
+        if (!isValidJavaIdentifier(executionGroup)) {
+            throw new IllegalTestException(
+                    method + " is using an invalid identifier for executionGroup [" + executionGroup + "]");
+
+        }
+    }
+
+    private static boolean isValidJavaIdentifier(String s) {
+        if (s.isEmpty()) {
+            return false;
+        }
+        if (!Character.isJavaIdentifierStart(s.charAt(0))) {
+            return false;
+        }
+        for (int i = 1; i < s.length(); i++) {
+            if (!Character.isJavaIdentifierPart(s.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void validateTimeStepArguments(List<Method> methods) {
@@ -189,159 +268,185 @@ public class TimeStepModel {
         }
     }
 
-    private Map<Method, Probability> loadProbabilities() {
-        Map<Method, Probability> probMap = new HashMap<Method, Probability>();
-
-        Method defaultMethod = null;
-        Probability totalProbability = new Probability(0);
-        for (Method method : timeStepMethods) {
-            Probability timeStepProbability = loadProbability(method);
-            if (timeStepProbability.isMinusOne()) {
-                if (defaultMethod != null) {
-                    throw new IllegalTestException("TimeStep method '" + method + "' can't have probability -1."
-                            + " Method '" + defaultMethod + "' already has probability -1 and only one such method is allowed");
-                }
-                defaultMethod = method;
-            } else if (timeStepProbability.isLargerThanOne()) {
-                throw new IllegalTestException("TimeStep method '" + method + "'"
-                        + " can't have a probability larger than 1, found: " + timeStepProbability);
-            } else if (timeStepProbability.isSmallerThanZero()) {
-                throw new IllegalTestException("TimeStep method '" + method + "'"
-                        + " can't have a probability smaller than 0, found: " + timeStepProbability);
-            } else {
-                totalProbability = totalProbability.add(timeStepProbability);
-                if (totalProbability.isLargerThanOne()) {
-                    throw new IllegalTestException("TimeStep method '" + method + "' with probability " + timeStepProbability
-                            + " exceeds the total probability of 1");
-                }
-                probMap.put(method, timeStepProbability);
-            }
-        }
-
-        if (defaultMethod != null) {
-            Probability probability = new Probability(1).sub(totalProbability);
-            probMap.put(defaultMethod, probability);
-        } else if (totalProbability.isSmallerThanOne()) {
-            throw new IllegalTestException("The total probability of TimeStep methods in test " + testClass.getName()
-                    + " is smaller than 1, found: " + totalProbability);
-        }
-
-        return probMap;
-    }
-
-    private Probability loadProbability(Method method) {
-        String propertyName = method.getName() + "Prob";
-        String valueString = propertyBinding.loadProperty(propertyName);
-
-        double value;
-        if (valueString == null) {
-            // nothing was specified. So lets use what is on the annotation
-            value = method.getAnnotation(TimeStep.class).prob();
-        } else {
-            // the user has explicitly configured a probability
-            try {
-                value = Double.parseDouble(valueString);
-            } catch (NumberFormatException e) {
-                throw new IllegalTestException(testClass.getName() + "." + propertyName
-                        + " value '" + valueString + "' is not a valid double value", e);
-            }
-        }
-
-        return new Probability(value);
-    }
 
     /**
      * Returns the probabilities of the {@link TimeStep} methods.
      *
      * @return the array of probabilities for each {@link TimeStep} method
      * or {@code null} if there is only a single {@link TimeStep} method.
-     *
-     * The value in the byte refers to the index of the method in the {@link #getActiveTimeStepMethods()}. If a method has 0.5
-     * probability and index 15, then 50% of the values in the array will point to 15.
+     * <p>
+     * The value in the byte refers to the index of the method in the {@link #getActiveTimeStepMethods(String)}.
+     * If a method has 0.5 probability and index 15, then 50% of the values in the array will point to 15.
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public byte[] getTimeStepProbabilityArray() {
-        return timeStepProbabilityArray;
+    public byte[] getTimeStepProbabilityArray(String group) {
+        return executionGroups.get(group).timeStepProbabilityArray;
     }
 
+    private final class ExecutionGroup {
+        private final List<Method> beforeRunMethods = new LinkedList<Method>();
+        private final List<Method> afterRunMethods = new LinkedList<Method>();
+        private final List<Method> timeStepMethods = new LinkedList<Method>();
+        private final String name;
+        private Class threadStateClass;
+        private Constructor threadStateConstructor;
+        private Map<Method, Probability> probabilities;
+        private byte[] timeStepProbabilityArray;
 
-    @SuppressWarnings("unchecked")
-    private Constructor loadThreadStateConstructor() {
-        if (threadStateClass == null) {
-            return null;
+        private ExecutionGroup(String name) {
+            this.name = name;
         }
 
-        Constructor constructor = null;
-        try {
-            constructor = threadStateClass.getDeclaredConstructor();
-        } catch (NoSuchMethodException ignore) {
-            ignore(ignore);
+        private void init() {
+            threadStateClass = loadThreadStateClass();
+            threadStateConstructor = loadThreadStateConstructor();
+            probabilities = loadProbabilities();
+            timeStepProbabilityArray = loadTimeStepProbabilityArray(probabilities, getActiveTimeStepMethods(name));
         }
 
-        try {
-            constructor = threadStateClass.getDeclaredConstructor(testClass);
-        } catch (NoSuchMethodException ignore) {
-            ignore(ignore);
+        private Class loadThreadStateClass() {
+            Set<Class> classes = new HashSet<Class>();
+            collectThreadStateClass(classes, beforeRunMethods);
+            collectThreadStateClass(classes, afterRunMethods);
+            collectThreadStateClass(classes, timeStepMethods);
+
+            if (classes.size() == 0) {
+                // no first argument is found
+                return null;
+            }
+
+            if (classes.size() > 1) {
+                throw new IllegalTestException("More than one type of thread state class found: " + classes);
+            }
+
+            return classes.iterator().next();
         }
 
-        if (constructor == null) {
-            throw new IllegalTestException("Found no valid constructor for '" + threadStateClass.getName() + "'."
-                    + " The constructor should have no arguments or one argument of type '" + threadStateClass.getName() + "'");
-        }
+        private void collectThreadStateClass(Set<Class> classes, List<Method> methods) {
+            for (Method method : methods) {
+                for (Class<?> paramType : method.getParameterTypes()) {
+                    if (paramType.isAssignableFrom(Probe.class)) {
+                        continue;
+                    }
 
-        try {
-            constructor.setAccessible(true);
-        } catch (Exception e) {
-            throw new IllegalTestException(e.getMessage(), e);
-        }
+                    if (paramType.isPrimitive()) {
+                        throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
+                                + " Thread state can't be a primitive.", method, paramType));
+                    }
+                    if (paramType.isInterface()) {
+                        throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
+                                + " Thread state can't be an interface.", method, paramType));
+                    }
+                    if (isAbstract(paramType.getModifiers())) {
+                        throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
+                                + " Thread state can't be an abstract.", method, paramType));
+                    }
+                    if (!isPublic(paramType.getModifiers())) {
+                        throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
+                                + " Thread state should be public.", method, paramType));
+                    }
 
-        return constructor;
-    }
-
-    private Class loadThreadStateClass() {
-        Set<Class> classes = new HashSet<Class>();
-        collectThreadStateClass(classes, beforeRunMethods);
-        collectThreadStateClass(classes, afterRunMethods);
-        collectThreadStateClass(classes, timeStepMethods);
-
-        if (classes.size() == 0) {
-            // no first argument is found
-            return null;
-        }
-
-        if (classes.size() > 1) {
-            throw new IllegalTestException("More than one type of thread state class found: " + classes);
-        }
-
-        return classes.iterator().next();
-    }
-
-    private static void collectThreadStateClass(Set<Class> classes, List<Method> methods) {
-        for (Method method : methods) {
-            for (Class<?> paramType : method.getParameterTypes()) {
-                if (paramType.isAssignableFrom(Probe.class)) {
-                    continue;
+                    classes.add(paramType);
                 }
-
-                if (paramType.isPrimitive()) {
-                    throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
-                            + " Thread state can't be a primitive.", method, paramType));
-                }
-                if (paramType.isInterface()) {
-                    throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
-                            + " Thread state can't be an interface.", method, paramType));
-                }
-                if (isAbstract(paramType.getModifiers())) {
-                    throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
-                            + " Thread state can't be an abstract.", method, paramType));
-                }
-                if (!isPublic(paramType.getModifiers())) {
-                    throw new IllegalTestException(format("Method '%s' contains an illegal thread state of type '%s'."
-                            + " Thread state should be public.", method, paramType));
-                }
-
-                classes.add(paramType);
             }
         }
+
+        @SuppressWarnings("unchecked")
+        private Constructor loadThreadStateConstructor() {
+            if (threadStateClass == null) {
+                return null;
+            }
+
+            Constructor constructor = null;
+            try {
+                constructor = threadStateClass.getDeclaredConstructor();
+            } catch (NoSuchMethodException ignore) {
+                ignore(ignore);
+            }
+
+            try {
+                constructor = threadStateClass.getDeclaredConstructor(testClass);
+            } catch (NoSuchMethodException ignore) {
+                ignore(ignore);
+            }
+
+            if (constructor == null) {
+                throw new IllegalTestException("Found no valid constructor for '" + threadStateClass.getName() + "'."
+                        + " The constructor should have no arguments or one argument "
+                        + "of type '" + threadStateClass.getName() + "'");
+            }
+
+            try {
+                constructor.setAccessible(true);
+            } catch (Exception e) {
+                throw new IllegalTestException(e.getMessage(), e);
+            }
+
+            return constructor;
+        }
+
+        private Map<Method, Probability> loadProbabilities() {
+            Map<Method, Probability> probMap = new HashMap<Method, Probability>();
+
+            Method defaultMethod = null;
+            Probability totalProbability = new Probability(0);
+            for (Method method : timeStepMethods) {
+                Probability timeStepProbability = loadProbability(method);
+                if (timeStepProbability.isMinusOne()) {
+                    if (defaultMethod != null) {
+                        throw new IllegalTestException("TimeStep method '" + method + "' can't have probability -1."
+                                + " Method '" + defaultMethod + "' already has probability -1 and "
+                                + "only one such method is allowed");
+                    }
+                    defaultMethod = method;
+                } else if (timeStepProbability.isLargerThanOne()) {
+                    throw new IllegalTestException("TimeStep method '" + method + "'"
+                            + " can't have a probability larger than 1, found: " + timeStepProbability);
+                } else if (timeStepProbability.isSmallerThanZero()) {
+                    throw new IllegalTestException("TimeStep method '" + method + "'"
+                            + " can't have a probability smaller than 0, found: " + timeStepProbability);
+                } else {
+                    totalProbability = totalProbability.add(timeStepProbability);
+                    if (totalProbability.isLargerThanOne()) {
+                        throw new IllegalTestException("TimeStep method '" + method + "' with probability " + timeStepProbability
+                                + " exceeds the total probability of 1");
+                    }
+                    probMap.put(method, timeStepProbability);
+                }
+            }
+
+            if (defaultMethod != null) {
+                Probability probability = new Probability(1).sub(totalProbability);
+                probMap.put(defaultMethod, probability);
+            } else if (totalProbability.isSmallerThanOne()) {
+                throw new IllegalTestException("The total probability of TimeStep methods in test " + testClass.getName()
+                        + " is smaller than 1, found: " + totalProbability);
+            }
+
+            return probMap;
+        }
+
+
+        private Probability loadProbability(Method method) {
+            String propertyName = method.getName() + "Prob";
+            String valueString = propertyBinding.loadProperty(propertyName);
+
+            double value;
+            if (valueString == null) {
+                // nothing was specified. So lets use what is on the annotation
+                value = method.getAnnotation(TimeStep.class).prob();
+            } else {
+                // the user has explicitly configured a probability
+                try {
+                    value = Double.parseDouble(valueString);
+                } catch (NumberFormatException e) {
+                    throw new IllegalTestException(testClass.getName() + "." + propertyName
+                            + " value '" + valueString + "' is not a valid double value", e);
+                }
+            }
+
+            return new Probability(value);
+        }
     }
+
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepRunnerCodeGenerator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepRunnerCodeGenerator.java
@@ -57,14 +57,21 @@ class TimeStepRunnerCodeGenerator {
 
     Class compile(
             String testCaseId,
+            String executionGroup,
             TimeStepModel timeStepModel,
             Class<? extends Metronome> metronomeClass,
             Class<? extends Probe> probeClass) {
-        String className = timeStepModel.getTestClass().getSimpleName() + "Runner";
+        String className = timeStepModel.getTestClass().getSimpleName();
+        if (!"".equals(executionGroup)) {
+            className += "_" + executionGroup + "_";
+
+        }
+        className += "Runner";
+
         if (!"".equals(testCaseId)) {
             className += testCaseId;
         }
-        JavaFileObject file = createJavaFileObject(className, metronomeClass, timeStepModel, probeClass);
+        JavaFileObject file = createJavaFileObject(className, executionGroup, metronomeClass, timeStepModel, probeClass);
         return compile(javaCompiler, file, className);
     }
 
@@ -113,6 +120,7 @@ class TimeStepRunnerCodeGenerator {
 
     private JavaFileObject createJavaFileObject(
             String className,
+            String executionGroup,
             Class<? extends Metronome> metronomeClass,
             TimeStepModel timeStepModel,
             Class<? extends Probe> probeClass) {
@@ -126,11 +134,11 @@ class TimeStepRunnerCodeGenerator {
             Map<String, Object> root = new HashMap<String, Object>();
             root.put("testInstanceClass", getClassName(timeStepModel.getTestClass()));
             root.put("metronomeClass", getMetronomeClass(metronomeClass));
-            root.put("timeStepMethods", timeStepModel.getActiveTimeStepMethods());
+            root.put("timeStepMethods", timeStepModel.getActiveTimeStepMethods(executionGroup));
             root.put("probeClass", getClassName(probeClass));
             root.put("isAssignableFrom", new IsAssignableFromMethod());
             root.put("Probe", Probe.class);
-            root.put("threadStateClass", getClassName(timeStepModel.getThreadStateClass()));
+            root.put("threadStateClass", getClassName(timeStepModel.getThreadStateClass(executionGroup)));
             root.put("hasProbe", new HasProbeMethod());
             root.put("className", className);
 

--- a/simulator/src/main/resources/TimeStepRunner.ftl
+++ b/simulator/src/main/resources/TimeStepRunner.ftl
@@ -12,8 +12,8 @@ public class ${className} extends TimeStepRunner {
 
 <#if metronomeClass??>
 </#if>
-    public ${className}(${testInstanceClass} testInstance, TimeStepModel model) {
-        super(testInstance, model);
+    public ${className}(${testInstanceClass} testInstance, TimeStepModel model, String executionGroup) {
+        super(testInstance, model, executionGroup);
     }
 
     @Override

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/TimeStepModel_IllegalTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/TimeStepModel_IllegalTest.java
@@ -214,6 +214,29 @@ public class TimeStepModel_IllegalTest {
                 + "}\n");
     }
 
+    // ===========================================
+
+    @Test
+    public void test_singleAfterRun() {
+        assertBroken("class CLAZZ{\n"
+                + "@AfterRun public void afterRun(){}\n"
+                + "}\n");
+    }
+
+    @Test
+    public void test_singleBeforeRun() {
+        assertBroken("class CLAZZ{\n"
+                + "@BeforeRun public void beforeRun(){}\n"
+                + "}\n");
+    }
+
+    @Test
+    public void test_invalidGroupName() {
+        assertBroken("class CLAZZ{\n"
+                + "@TimeStep(executionGroup=\".\") public void timeStep(){}\n"
+                + "}\n");
+    }
+
     private static void assertBroken(String source) {
         String header = "import java.util.*;\n"
                 + " import com.hazelcast.simulator.test.*;\n"

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/TimeStepModel_probabilityTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/TimeStepModel_probabilityTest.java
@@ -22,11 +22,15 @@ public class TimeStepModel_probabilityTest {
                 + "}\n", probs);
 
         assertProbability(model, "timeStep1", 1.0);
-        assertNull(model.getTimeStepProbabilityArray());
+        assertNull(model.getTimeStepProbabilityArray(""));
     }
 
     private void assertProbability(TimeStepModel model, String method, double value) {
-        assertEquals(value, model.getProbability(method).getValue(), 0.001);
+        assertEquals(value, model.getProbability("", method).getValue(), 0.001);
+    }
+
+    private void assertProbability(TimeStepModel model, String group, String method, double value) {
+        assertEquals(value, model.getProbability(group, method).getValue(), 0.001);
     }
 
     @Test(expected = IllegalTestException.class)
@@ -86,7 +90,52 @@ public class TimeStepModel_probabilityTest {
 
         assertProbability(model, "timeStep1", 1.0);
         assertProbability(model, "timeStep2", 0.0);
-        assertNull(model.getTimeStepProbabilityArray());
+        assertNull(model.getTimeStepProbabilityArray(""));
+    }
+
+    @Test
+    public void test_singleActiveMethodProperties_multipleProbabilities() {
+        HashMap<String, Double> probs = new HashMap<String, Double>();
+
+        TimeStepModel model = loadModel("public class CLAZZ{\n"
+                + "@TimeStep(prob=0.10, executionGroup=\"a\") public void a1(){}\n"
+                + "@TimeStep(prob=0.90, executionGroup=\"a\") public void a2(){}\n"
+                + "@TimeStep(prob=0.20, executionGroup=\"b\") public void b1(){}\n"
+                + "@TimeStep(prob=0.80, executionGroup=\"b\") public void b2(){}\n"
+
+                + "}\n", probs);
+
+        assertProbability(model, "a", "a1", 0.10);
+        assertProbability(model, "a", "a2", 0.90);
+        assertProbability(model, "b", "b1", 0.20);
+        assertProbability(model, "b", "b2", 0.80);
+
+        assertNotNull(model.getTimeStepProbabilityArray("a"));
+        assertNotNull(model.getTimeStepProbabilityArray("b"));
+    }
+
+    @Test
+    public void test_singleActiveMethodExternalProperties_multipleProbabilities() {
+        HashMap<String, Double> probs = new HashMap<String, Double>();
+        probs.put("a1Prob", 0.05);
+        probs.put("a2Prob", 0.95);
+        probs.put("b1Prob", 0.03);
+        probs.put("b2Prob", 0.97);
+
+        TimeStepModel model = loadModel("public class CLAZZ{\n"
+                + "@TimeStep(prob=0.10, executionGroup=\"a\") public void a1(){}\n"
+                + "@TimeStep(prob=0.90, executionGroup=\"a\") public void a2(){}\n"
+                + "@TimeStep(prob=0.20, executionGroup=\"b\") public void b1(){}\n"
+                + "@TimeStep(prob=0.80, executionGroup=\"b\") public void b2(){}\n"
+                + "}\n", probs);
+
+        assertProbability(model, "a", "a1", 0.05);
+        assertProbability(model, "a", "a2", 0.95);
+        assertProbability(model, "b", "b1", 0.03);
+        assertProbability(model, "b", "b2", 0.97);
+
+        assertNotNull(model.getTimeStepProbabilityArray("a"));
+        assertNotNull(model.getTimeStepProbabilityArray("b"));
     }
 
     @Test
@@ -100,7 +149,7 @@ public class TimeStepModel_probabilityTest {
 
         assertProbability(model, "timeStep1", 1.0);
         assertProbability(model, "timeStep2", 0.0);
-        assertNull(model.getTimeStepProbabilityArray());
+        assertNull(model.getTimeStepProbabilityArray(""));
     }
 
     @Test
@@ -114,7 +163,7 @@ public class TimeStepModel_probabilityTest {
 
         assertProbability(model, "timeStep1", 0.5);
         assertProbability(model, "timeStep2", 0.5);
-        assertNotNull(model.getTimeStepProbabilityArray());
+        assertNotNull(model.getTimeStepProbabilityArray(""));
     }
 
     @Test
@@ -128,7 +177,7 @@ public class TimeStepModel_probabilityTest {
 
         assertProbability(model, "timeStep1", 0.2);
         assertProbability(model, "timeStep2", 0.8);
-        assertNotNull(model.getTimeStepProbabilityArray());
+        assertNotNull(model.getTimeStepProbabilityArray(""));
     }
 
     @Test
@@ -144,7 +193,7 @@ public class TimeStepModel_probabilityTest {
 
         assertProbability(model, "timeStep1", 0.3);
         assertProbability(model, "timeStep2", 0.7);
-        assertNotNull(model.getTimeStepProbabilityArray());
+        assertNotNull(model.getTimeStepProbabilityArray(""));
     }
 
     private TimeStepModel loadModel(String code, Map<String, Double> probs) {


### PR DESCRIPTION
Allows for more complex timestep models with different groups of threads execute different timestep methods. 

Example:

```
@Timestep(group="producer")
void produce(){
    queue.offer("");
}

@Timestep(group="consumer")
void consume(){
    queue.take();
}

configure with:
producerThreadCount=2
consumerThreadCount=4
```