### PR TITLE
Testcaserunner phase cleanup

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/RunTestSuiteTask.java
@@ -84,7 +84,7 @@ public class RunTestSuiteTask {
         LOGGER.info("Starting TestSuite");
         echoTestSuiteDuration(parallel);
 
-        for (TestData testData: tests) {
+        for (TestData testData : tests) {
             int testIndex = testData.getTestIndex();
             TestCase testCase = testData.getTestCase();
             LOGGER.info(format("Configuration for %s (T%d):%n%s", testCase.getId(), testIndex, testCase));
@@ -116,13 +116,9 @@ public class RunTestSuiteTask {
         if (testDuration > 0) {
             LOGGER.info(format("Running time per test: %s", secondsToHuman(testDuration)));
             int totalDuration = isParallel ? testDuration : testDuration * testSuite.size();
-            if (testSuite.isWaitForTestCase()) {
-                LOGGER.info(format("Testsuite will run until tests are finished for a maximum time of: %s",
-                        secondsToHuman(totalDuration)));
-            } else {
-                LOGGER.info(format("Expected total TestSuite time: %s", secondsToHuman(totalDuration)));
-            }
-        } else if (testSuite.isWaitForTestCase()) {
+            LOGGER.info(format("Testsuite will run until tests are finished for a maximum time of: %s",
+                    secondsToHuman(totalDuration)));
+        } else {
             LOGGER.info("Testsuite will run until tests are finished");
         }
     }
@@ -183,7 +179,7 @@ public class RunTestSuiteTask {
     }
 
     static Map<TestPhase, CountDownLatch> getTestPhaseSyncMap(int testCount, boolean parallel,
-                                                                     TestPhase latestTestPhaseToSync) {
+                                                              TestPhase latestTestPhaseToSync) {
         if (!parallel) {
             return null;
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestSuite.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestSuite.java
@@ -41,8 +41,8 @@ public class TestSuite {
 
     private final List<TestCase> testCaseList = new LinkedList<TestCase>();
     private int durationSeconds;
-    private int warmupSeconds;
-    private boolean waitForTestCase;
+    // -1 means no warmup
+    private int warmupSeconds = -1;
     private boolean failFast;
     private boolean parallel;
     private TargetType targetType;
@@ -107,15 +107,6 @@ public class TestSuite {
         return durationSeconds;
     }
 
-    public TestSuite setWaitForTestCase(boolean waitForTestCase) {
-        this.waitForTestCase = waitForTestCase;
-        return this;
-    }
-
-    public boolean isWaitForTestCase() {
-        return waitForTestCase;
-    }
-
     public TestSuite setFailFast(boolean failFast) {
         this.failFast = failFast;
         return this;
@@ -163,7 +154,6 @@ public class TestSuite {
         return "TestSuite{"
                 + "durationSeconds=" + durationSeconds
                 + ", warmupSeconds=" + warmupSeconds
-                + ", waitForTestCase=" + waitForTestCase
                 + ", failFast=" + failFast
                 + ", parallel=" + parallel
                 + ", targetType=" + targetType

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/CommonUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/CommonUtils.java
@@ -33,6 +33,7 @@ import java.util.jar.JarFile;
 
 import static com.hazelcast.simulator.utils.EmptyStatement.ignore;
 import static com.hazelcast.simulator.utils.FormatUtils.NEW_LINE;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public final class CommonUtils {
@@ -175,9 +176,17 @@ public final class CommonUtils {
         }
     }
 
-    public static void sleepMillis(int millis) {
+    public static void sleepUntilMs(long deadlineMs) {
+        long now = System.currentTimeMillis();
+        long duration = deadlineMs - now;
+        if (duration > 0) {
+            sleepMillis(duration);
+        }
+    }
+
+    public static void sleepMillis(long millis) {
         try {
-            TimeUnit.MILLISECONDS.sleep(millis);
+            MILLISECONDS.sleep(millis);
         } catch (InterruptedException ignore) {
             ignore(ignore);
         }
@@ -208,7 +217,7 @@ public final class CommonUtils {
 
     public static void sleepMillisThrowException(int millis) {
         try {
-            TimeUnit.MILLISECONDS.sleep(millis);
+            MILLISECONDS.sleep(millis);
         } catch (InterruptedException e) {
             throw rethrow(e);
         }
@@ -216,7 +225,7 @@ public final class CommonUtils {
 
     /**
      * Sleeps a random amount of time.
-     *
+     * <p>
      * The call is ignored if maxDelayNanos equals or smaller than zero.
      *
      * @param random        the Random used to randomize

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -86,7 +86,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(CoordinatorCli.DEFAULT_DURATION_SECONDS, testSuite.getDurationSeconds());
     }
 
@@ -97,7 +96,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(CoordinatorCli.DEFAULT_DURATION_SECONDS, testSuite.getDurationSeconds());
     }
 
@@ -109,7 +107,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(423, testSuite.getDurationSeconds());
     }
 
@@ -121,7 +118,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(TimeUnit.SECONDS.toSeconds(3), testSuite.getDurationSeconds());
     }
 
@@ -133,7 +129,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(TimeUnit.MINUTES.toSeconds(5), testSuite.getDurationSeconds());
     }
 
@@ -145,7 +140,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(TimeUnit.HOURS.toSeconds(4), testSuite.getDurationSeconds());
     }
 
@@ -157,7 +151,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(TimeUnit.DAYS.toSeconds(23), testSuite.getDurationSeconds());
     }
 
@@ -170,7 +163,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(0, testSuite.getDurationSeconds());
     }
 
@@ -208,7 +200,6 @@ public class CoordinatorCliTest {
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertFalse(testSuite.isWaitForTestCase());
         assertEquals(10, testSuite.getDurationSeconds());
         assertEquals(5, testSuite.getWarmupSeconds());
     }
@@ -225,26 +216,13 @@ public class CoordinatorCliTest {
     }
 
     @Test
-    public void testInit_waitForTestCaseCompletion() {
-        args.add("--waitForTestCaseCompletion");
-
-        CoordinatorCli cli = createCoordinatorCli();
-
-        TestSuite testSuite = cli.testSuite;
-        assertTrue(testSuite.isWaitForTestCase());
-        assertEquals(0, testSuite.getDurationSeconds());
-    }
-
-    @Test
-    public void testInit_waitForTestCaseCompletion_and_duration() {
-        args.add("--waitForTestCaseCompletion");
+    public void testInit_waitForDuration() {
         args.add("--duration");
         args.add("42s");
 
         CoordinatorCli cli = createCoordinatorCli();
 
         TestSuite testSuite = cli.testSuite;
-        assertTrue(testSuite.isWaitForTestCase());
         assertEquals(42, testSuite.getDurationSeconds());
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/RunTestSuiteTaskTest.java
@@ -118,7 +118,6 @@ public class RunTestSuiteTaskTest {
 
     @Test
     public void runParallel_waitForTestCase_and_duration() {
-        testSuite.setWaitForTestCase(true);
         testSuite.setDurationSeconds(3);
         parallel = true;
 
@@ -130,7 +129,6 @@ public class RunTestSuiteTaskTest {
 
     @Test
     public void runParallel_waitForTestCase_noVerify() {
-        testSuite.setWaitForTestCase(true);
         testSuite.setDurationSeconds(0);
         parallel = true;
         verifyEnabled = false;
@@ -155,7 +153,6 @@ public class RunTestSuiteTaskTest {
 
     @Test
     public void runParallel_withTargetCount() {
-        testSuite.setWaitForTestCase(true);
         testSuite.setDurationSeconds(0);
         parallel = true;
         verifyEnabled = false;
@@ -181,7 +178,6 @@ public class RunTestSuiteTaskTest {
 
     @Test
     public void runParallel_withWarmup_waitForTestCase() {
-        testSuite.setWaitForTestCase(true);
         testSuite.setDurationSeconds(0);
         testSuite.setWarmupSeconds(1);
         parallel = true;
@@ -377,11 +373,11 @@ public class RunTestSuiteTaskTest {
             }
         }
 
-        if (testSuite.getDurationSeconds() > 0 && testSuite.getWarmupSeconds() > 0) {
-            assertEquals("actualStopTestCount incorrect", 2 * testCount, actualStopTestCount);
-        } else if (testSuite.getDurationSeconds() != 0 || testSuite.getWarmupSeconds() != 0) {
-            assertEquals("actualStopTestCount incorrect", testCount, actualStopTestCount);
+        int expectedStopCount = testCount;
+        if (testSuite.getWarmupSeconds() >= 0) {
+            expectedStopCount+=testCount;
         }
+        assertEquals("actualStopTestCount incorrect", expectedStopCount, actualStopTestCount);
 
         for (Map.Entry<TestPhase, AtomicInteger> entry : remainingPhaseCount.entrySet()) {
             TestPhase phase = entry.getKey();
@@ -399,7 +395,7 @@ public class RunTestSuiteTaskTest {
             expectedTestPhases.remove(TestPhase.LOCAL_VERIFY);
         }
 
-        if (testSuite.getWarmupSeconds() == 0) {
+        if (testSuite.getWarmupSeconds() < 0) {
             // exclude warmup test phases
             expectedTestPhases.remove(WARMUP);
             expectedTestPhases.remove(TestPhase.LOCAL_AFTER_WARMUP);

--- a/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/IterationTest.java
+++ b/tests/tests-common/src/main/java/com/hazelcast/simulator/tests/special/IterationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.tests.special;
+
+import com.hazelcast.simulator.test.AbstractTest;
+import com.hazelcast.simulator.test.BaseThreadState;
+import com.hazelcast.simulator.test.StopException;
+import com.hazelcast.simulator.test.annotations.BeforeRun;
+import com.hazelcast.simulator.test.annotations.TimeStep;
+
+/**
+ * Simple test that runs for a number of iterations.
+ *
+ * Each timestep thread will run for the number of iterations.
+ */
+public class IterationTest extends AbstractTest {
+
+    public int iterationCount = 1000000;
+    public boolean exceptionOnExit;
+
+    @BeforeRun
+    public void beforeRun(ThreadState state) {
+        state.count = iterationCount;
+    }
+
+    @TimeStep
+    public void timeStep(ThreadState state) {
+        if (state.count == 0) {
+            if (exceptionOnExit) {
+                throw new RuntimeException("Expected exception");
+            } else {
+                throw new StopException();
+            }
+        }
+
+        state.count--;
+    }
+
+    public class ThreadState extends BaseThreadState {
+        int count;
+    }
+}


### PR DESCRIPTION
Removed the stop thread. 
Removed waitForTestCaseSpec since you always want to do this. You never want to move on to the next phase, if run/warmup has not yet completed since this would immediately run into exceptions like the one from the ticket.

fix https://github.com/hazelcast/hazelcast-simulator/issues/1198