### PR TITLE
Nonblocking futures in netty

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/AgentConnector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/connector/AgentConnector.java
@@ -93,8 +93,7 @@ public class AgentConnector extends AbstractServerConnector implements ClientPip
         pipeline.addLast("messageEncoder", new MessageEncoder(localAddress, COORDINATOR));
         pipeline.addLast("frameDecoder", new SimulatorFrameDecoder());
         pipeline.addLast("protocolDecoder", new SimulatorProtocolDecoder(localAddress));
-        pipeline.addLast("forwardToWorkerHandler", new ForwardToWorkerHandler(localAddress, getClientConnectorManager(),
-                getScheduledExecutor()));
+        pipeline.addLast("forwardToWorkerHandler", new ForwardToWorkerHandler(localAddress, getClientConnectorManager()));
         pipeline.addLast("messageConsumeHandler", new MessageConsumeHandler(localAddress, processor, getScheduledExecutor()));
         pipeline.addLast("responseHandler", new ResponseHandler(localAddress, COORDINATOR, futureMap, addressIndex));
         pipeline.addLast("exceptionHandler", new ExceptionHandler(this));

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/core/ResponseFutureListener.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/core/ResponseFutureListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.protocol.core;
+
+public interface ResponseFutureListener {
+
+    void onCompletion(Response response);
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/processors/AgentOperationProcessor.java
@@ -37,13 +37,13 @@ import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.simulator.protocol.core.ResponseType.EXCEPTION_DURING_OPERATION_EXECUTION;
 import static com.hazelcast.simulator.protocol.core.ResponseType.SUCCESS;
 import static com.hazelcast.simulator.protocol.core.ResponseType.UNSUPPORTED_OPERATION_ON_THIS_PROCESSOR;
 import static com.hazelcast.simulator.protocol.core.SimulatorAddress.COORDINATOR;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.log4j.Level.DEBUG;
 import static org.apache.log4j.Level.FATAL;
 
@@ -135,7 +135,7 @@ public class AgentOperationProcessor extends AbstractOperationProcessor {
         for (WorkerProcessSettings workerProcessSettings : operation.getWorkerProcessSettings()) {
             WorkerProcessLauncher launcher = new WorkerProcessLauncher(agent, workerProcessManager, workerProcessSettings);
             LaunchWorkerCallable task = new LaunchWorkerCallable(launcher, workerProcessSettings);
-            Future<Boolean> future = executorService.schedule(task, operation.getDelayMs(), TimeUnit.MILLISECONDS);
+            Future<Boolean> future = executorService.schedule(task, operation.getDelayMs(), MILLISECONDS);
             futures.add(future);
         }
         for (Future<Boolean> future : futures) {

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/handler/ForwardToWorkerHandlerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/handler/ForwardToWorkerHandlerTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 public class ForwardToWorkerHandlerTest {
 
     private final AttributeKey<Integer> forwardAddressIndex = AttributeKey.valueOf("forwardAddressIndex");
-    private final ExecutorService executorService = ExecutorFactory.createFixedThreadPool(2, "ForwardToWorkerHandlerTest");
 
     @Mock
     private Attribute<Integer> forwardAddressIndexAttribute;
@@ -50,8 +49,7 @@ public class ForwardToWorkerHandlerTest {
 
         ClientConnectorManager clientConnectorManager = new ClientConnectorManager();
 
-        forwardToWorkerHandler = new ForwardToWorkerHandler(SimulatorAddress.COORDINATOR, clientConnectorManager,
-                executorService);
+        forwardToWorkerHandler = new ForwardToWorkerHandler(SimulatorAddress.COORDINATOR, clientConnectorManager);
     }
 
     @After
@@ -59,9 +57,6 @@ public class ForwardToWorkerHandlerTest {
         if (buffer != null) {
             buffer.release();
         }
-
-        executorService.shutdown();
-        executorService.awaitTermination(1, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
Blocking in the ForwardToWorkerHandler leads to hogging threads waiting for a response. It is now solved asynchronously using a listenable future. 

It doesn't address the actual reduction of the number of threads. But it will make sure we need less of them.

Probably this could be done directly in netty itself, but I don't have the time to figure that part out.