### PR TITLE
Performance collector cleanup

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -306,7 +306,7 @@ HAZELCAST_PORT_RANGE_SIZE = 50
 #
 # Interval for WorkerPerformanceMonitor
 #
-# Defines the interval for throughput and latency snapshots on the workers.
+# Defines the interval for throughput and latency snapshots on the workers. 0 disabled tracking performance.
 #
 WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS = 10
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -137,9 +137,6 @@ final class CoordinatorCli {
                     + " The session ID is used for creating the working directory")
             .withRequiredArg().ofType(String.class);
 
-    private final OptionSpec monitorPerformanceSpec = parser.accepts("monitorPerformance",
-            "If defined performance of tests is tracked.");
-
     private final OptionSpec<Boolean> verifyEnabledSpec = parser.accepts("verifyEnabled",
             "Defines if tests are verified.")
             .withRequiredArg().ofType(Boolean.class).defaultsTo(true);
@@ -317,10 +314,6 @@ final class CoordinatorCli {
     }
 
     private int getPerformanceMonitorInterval() {
-        if (!options.has(monitorPerformanceSpec)) {
-            return 0;
-        }
-
         String intervalSeconds = simulatorProperties.get("WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS");
         if (intervalSeconds == null || intervalSeconds.isEmpty()) {
             return DEFAULT_WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS;
@@ -355,7 +348,7 @@ final class CoordinatorCli {
         }
 
         // if the coordinator is not monitoring performance, we don't care for measuring latencies
-        if (!options.has(monitorPerformanceSpec)) {
+        if (coordinatorParameters.getPerformanceMonitorIntervalSeconds() == 0) {
             for (TestCase testCase : testSuite.getTestCaseList()) {
                 testCase.setProperty("measureLatency", "false");
             }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/RunTestSuiteTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/RunTestSuiteTask.java
@@ -208,13 +208,6 @@ public class RunTestSuiteTask {
             LOGGER.info(format("Running %s tests (%s)", testCount, isParallel ? "parallel" : "sequentially"));
         }
         LOGGER.info(HORIZONTAL_RULER);
-
-//        Integer targetCount = testSuite.getWorkerQuery().getMaxCount();
-//        if (targetCount > 0) {
-//            TargetType targetType = testSuite.getTargetType().resolvePreferClient(componentRegistry.hasClientWorkers());
-//            List<String> targetWorkers = componentRegistry.getWorkerAddresses(targetType, targetCount);
-//            LOGGER.info(format("RUN phase will be executed on %s: %s", targetType.toString(targetCount), targetWorkers));
-//        }
     }
 
     private void echoTestSuiteEnd(int testCount, long started) {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceStats.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceStats.java
@@ -21,7 +21,7 @@ import static java.lang.Math.max;
 
 /**
  * Container to transfer performance statistics for some time window.
- *
+ * <p>
  * Has methods to combine {@link PerformanceStats} instances by adding or setting maximum values.
  */
 public class PerformanceStats {
@@ -45,6 +45,7 @@ public class PerformanceStats {
         this.operationCount = EMPTY_OPERATION_COUNT;
         this.intervalThroughput = EMPTY_THROUGHPUT;
     }
+
 
     /**
      * Creates a {@link PerformanceStats} instance with values.
@@ -71,6 +72,15 @@ public class PerformanceStats {
         this.intervalLatencyMaxNanos = intervalLatencyMaxNanos;
     }
 
+    public PerformanceStats(PerformanceStats original) {
+        this.operationCount = original.operationCount;
+        this.intervalThroughput = original.intervalThroughput;
+        this.totalThroughput = original.totalThroughput;
+        this.intervalLatencyAvgNanos = original.intervalLatencyAvgNanos;
+        this.intervalLatency999PercentileNanos = original.intervalLatency999PercentileNanos;
+        this.intervalLatencyMaxNanos = original.intervalLatencyMaxNanos;
+    }
+
     /**
      * Combines two {@link PerformanceStats} instances, e.g. from different Simulator Workers.
      *
@@ -82,14 +92,14 @@ public class PerformanceStats {
 
     /**
      * Combines {@link PerformanceStats} instances, e.g. from different Simulator Workers.
-     *
+     * <p>
      * For the real-time performance monitor during the {@link TestPhase#RUN} the
      * maximum value should be set, so we get the maximum operation count and throughput values of all {@link PerformanceStats}
      * instances of the last interval.
-     *
+     * <p>
      * For the total performance number and the performance per Simulator Agent, the added values should be set, so we get the
      * summed up operation count and throughput values.
-     *
+     * <p>
      * The method always sets the maximum values for latency.
      *
      * @param other                          {@link PerformanceStats} which should be added to this instance
@@ -169,5 +179,14 @@ public class PerformanceStats {
                 + ", intervalLatency999PercentileNanos=" + intervalLatency999PercentileNanos
                 + ", intervalMaxLatencyNanos=" + intervalLatencyMaxNanos
                 + '}';
+    }
+
+
+    public static PerformanceStats aggregateAll(PerformanceStats... stats) {
+        PerformanceStats result = new PerformanceStats();
+        for (PerformanceStats s : stats) {
+            result.add(s);
+        }
+        return result;
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -36,7 +36,6 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static javafx.scene.input.KeyCode.F;
 import static org.junit.Assert.assertEquals;
 
 public class CoordinatorCliTest {

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/processors/CoordinatorOperationProcessorTest.java
@@ -165,7 +165,7 @@ public class CoordinatorOperationProcessorTest implements FailureListener {
         ResponseType responseType = process(processor, operation, workerAddress);
         assertEquals(SUCCESS, responseType);
 
-        String performanceNumbers = performanceStatsCollector.formatPerformanceNumbers("testId");
+        String performanceNumbers = performanceStatsCollector.formatIntervalPerformanceNumbers("testId");
         assertTrue(performanceNumbers.contains(formatLong(1000, OPERATION_COUNT_FORMAT_LENGTH)));
         assertTrue(performanceNumbers.contains(formatDouble(50, THROUGHPUT_FORMAT_LENGTH)));
         assertTrue(performanceNumbers.contains(formatLong(23, LATENCY_FORMAT_LENGTH)));


### PR DESCRIPTION
1: simplification by getting rid of the queue.
2: sometimes no interval performance info is shown; this is because there is nothing in the queue. Now there always is a latest
3: monitor performance is enabled by default fix #1158
4: each test shows its own performance information fix #1231