### PR TITLE
Tags for workers/agents

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/common/AgentsFile.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/AgentsFile.java
@@ -18,22 +18,25 @@ package com.hazelcast.simulator.common;
 import com.hazelcast.simulator.protocol.registry.AgentData;
 import com.hazelcast.simulator.protocol.registry.ComponentRegistry;
 import com.hazelcast.simulator.utils.CommandLineExitException;
+import com.hazelcast.simulator.utils.TagUtils;
 
 import java.io.File;
+import java.util.Map;
 
 import static com.hazelcast.simulator.utils.FileUtils.fileAsText;
 import static com.hazelcast.simulator.utils.FileUtils.writeText;
 import static com.hazelcast.simulator.utils.FormatUtils.NEW_LINE;
+import static com.hazelcast.simulator.utils.TagUtils.tagsToString;
 import static java.lang.String.format;
 
 /**
  * Utility class to deal with the {@value #NAME} file.
- *
+ * <p>
  * An agent entry can either be  a single address or two addresses separated with a comma.
- *
+ * <p>
  * If you specify both addresses the first one is the public address. It is used by the Simulator Coordinator for SSH access.
  * The second address is the private address, which is used by Hazelcast instances to form the cluster.
- *
+ * <p>
  * The address separation is needed to deal with cloud environments like EC2.
  */
 public final class AgentsFile {
@@ -47,48 +50,70 @@ public final class AgentsFile {
         ComponentRegistry componentRegistry = new ComponentRegistry();
 
         String content = fileAsText(agentFile);
-        String[] addresses = content.split(NEW_LINE);
+        String[] lines = content.split(NEW_LINE);
         int lineNumber = 1;
-        for (String line : addresses) {
-            int indexOfComment = line.indexOf('#');
-            if (indexOfComment != -1) {
-                line = line.substring(0, indexOfComment);
-            }
+        for (String line : lines) {
+            line = cleanLine(line);
 
-            line = line.trim();
             if (line.isEmpty()) {
                 continue;
             }
 
-            String[] chunks = line.split(",");
-            switch (chunks.length) {
+            int tagsIndex = line.indexOf('|');
+            String addressesString = tagsIndex == -1 ? line : line.substring(0, tagsIndex);
+            String tagsString = tagsIndex == -1 ? "" : line.substring(tagsIndex + 1);
+
+            String publicIpAddress;
+            String privateIpAddress;
+            String[] addresses = addressesString.split(",");
+            switch (addresses.length) {
                 case 1:
-                    componentRegistry.addAgent(chunks[0], chunks[0]);
+                    publicIpAddress = addresses[0];
+                    privateIpAddress = addresses[0];
                     break;
                 case 2:
-                    componentRegistry.addAgent(chunks[0], chunks[1]);
+                    publicIpAddress = addresses[0];
+                    privateIpAddress = addresses[1];
                     break;
                 default:
                     throw new CommandLineExitException(format("Line %s of file %s is invalid!"
                             + " It should contain one or two IP addresses separated by a comma,"
-                            + " but it contains %s", lineNumber, agentFile, chunks.length));
+                            + " but it contains %s", lineNumber, agentFile, addresses.length));
             }
+            Map<String, String> tags = TagUtils.parseTags(tagsString);
+            componentRegistry.addAgent(publicIpAddress, privateIpAddress, tags);
         }
 
         return componentRegistry;
     }
 
+    private static String cleanLine(String line) {
+        int indexOfComment = line.indexOf('#');
+        if (indexOfComment != -1) {
+            line = line.substring(0, indexOfComment);
+        }
+
+        line = line.trim();
+        return line;
+    }
+
     public static void save(File agentsFile, ComponentRegistry registry) {
         StringBuilder sb = new StringBuilder();
-        for (AgentData agentData : registry.getAgents()) {
-            String publicAddress = agentData.getPublicAddress();
-            String privateAddress = agentData.getPrivateAddress();
+        for (AgentData agent : registry.getAgents()) {
+            String publicAddress = agent.getPublicAddress();
+            String privateAddress = agent.getPrivateAddress();
 
             if (publicAddress.equals(privateAddress)) {
-                sb.append(publicAddress).append(NEW_LINE);
+                sb.append(publicAddress);
             } else {
-                sb.append(publicAddress).append(',').append(privateAddress).append(NEW_LINE);
+                sb.append(publicAddress).append(',').append(privateAddress);
             }
+
+            Map<String, String> tags = agent.getTags();
+            if (!tags.isEmpty()) {
+                sb.append('|').append(tagsToString(tags));
+            }
+            sb.append(NEW_LINE);
         }
         writeText(sb.toString(), agentsFile);
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -63,7 +63,7 @@ final class CoordinatorCli {
     private static final Logger LOGGER = Logger.getLogger(CoordinatorCli.class);
 
     CoordinatorDownloader downloader;
-    CoordinatorRunMonolith coordinatorRun;
+    CoordinatorRunMonolith runMonolith;
     Coordinator coordinator;
     TestSuite testSuite;
     CoordinatorParameters coordinatorParameters;
@@ -200,7 +200,7 @@ final class CoordinatorCli {
             } else {
                 this.workerParametersMap = loadWorkerParameters();
                 this.deploymentPlan = newDeploymentPlan();
-                this.coordinatorRun = new CoordinatorRunMonolith(coordinator);
+                this.runMonolith = new CoordinatorRunMonolith(coordinator);
             }
         }
     }
@@ -215,8 +215,8 @@ final class CoordinatorCli {
             if (testSuite == null) {
                 LOGGER.info("Coordinator started in interactive mode. Waiting for commands from the coordinator-remote");
             } else {
-                coordinatorRun.init(deploymentPlan);
-                boolean success = coordinatorRun.run(testSuite);
+                runMonolith.init(deploymentPlan);
+                boolean success = runMonolith.run(testSuite);
                 System.exit(success ? 0 : 1);
             }
         }
@@ -259,7 +259,7 @@ final class CoordinatorCli {
                 initClientHzConfig(
                         loadClientHzConfig(),
                         componentRegistry,
-                        simulatorProperties,
+                        simulatorProperties.asMap(),
                         coordinatorParameters.getLicenseKey()));
 
         return new WorkerParameters()
@@ -280,7 +280,7 @@ final class CoordinatorCli {
                 initMemberHzConfig(loadMemberHzConfig(),
                         componentRegistry,
                         coordinatorParameters.getLicenseKey(),
-                        simulatorProperties, true));
+                        simulatorProperties.asMap(), true));
 
         return new WorkerParameters()
                 .setVersionSpec(simulatorProperties.getVersionSpec())
@@ -301,7 +301,7 @@ final class CoordinatorCli {
                         loadMemberHzConfig(),
                         componentRegistry,
                         coordinatorParameters.getLicenseKey(),
-                        simulatorProperties, false));
+                        simulatorProperties.asMap(), false));
 
         return new WorkerParameters()
                 .setVersionSpec(simulatorProperties.getVersionSpec())

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorRunMonolith.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorRunMonolith.java
@@ -22,6 +22,8 @@ import com.hazelcast.simulator.coordinator.tasks.StartWorkersTask;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.apache.log4j.Logger;
 
+import java.util.HashMap;
+
 import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static java.lang.String.format;
 
@@ -49,6 +51,7 @@ public class CoordinatorRunMonolith {
 
         new StartWorkersTask(
                 deploymentPlan.getWorkerDeployment(),
+                new HashMap<String, String>(),
                 coordinator.client,
                 coordinator.componentRegistry,
                 coordinator.parameters.getWorkerVmStartupDelayMs()).run();

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/RcWorkerStartOperation.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/operation/RcWorkerStartOperation.java
@@ -17,7 +17,9 @@ package com.hazelcast.simulator.protocol.operation;
 
 import com.hazelcast.simulator.common.WorkerType;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RcWorkerStartOperation implements SimulatorOperation {
     private int count = 1;
@@ -26,38 +28,29 @@ public class RcWorkerStartOperation implements SimulatorOperation {
     private String workerType = WorkerType.MEMBER.name();
     private String hzConfig;
     private List<String> agentAddresses;
+    private Map<String, String> tags = new HashMap<String, String>();
+    private Map<String, String> agentTags;
 
-    public RcWorkerStartOperation() {
-
+    public Map<String, String> getAgentTags() {
+        return agentTags;
     }
 
-    public RcWorkerStartOperation(int count,
-                                  String versionSpec,
-                                  String vmOptions,
-                                  String workerType,
-                                  String hzConfig,
-                                  List<String> agentAddresses) {
-        this.count = count;
-        this.versionSpec = versionSpec;
-        this.vmOptions = vmOptions;
-        this.workerType = workerType;
-        this.hzConfig = hzConfig;
-        this.agentAddresses = agentAddresses;
-    }
-
-    public RcWorkerStartOperation setCount(int count) {
-        this.count = count;
+    public RcWorkerStartOperation setAgentTags(Map<String, String> agentTags) {
+        this.agentTags = agentTags;
         return this;
     }
 
-    public RcWorkerStartOperation setVersionSpec(String versionSpec) {
-        this.versionSpec = versionSpec;
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public RcWorkerStartOperation setTags(Map<String, String> environment) {
+        this.tags = environment;
         return this;
     }
 
-    public RcWorkerStartOperation setVmOptions(String vmOptions) {
-        this.vmOptions = vmOptions;
-        return this;
+    public String getWorkerType() {
+        return workerType;
     }
 
     public RcWorkerStartOperation setWorkerType(String workerType) {
@@ -65,13 +58,26 @@ public class RcWorkerStartOperation implements SimulatorOperation {
         return this;
     }
 
+    public String getHzConfig() {
+        return hzConfig;
+    }
+
     public RcWorkerStartOperation setHzConfig(String hzConfig) {
         this.hzConfig = hzConfig;
         return this;
     }
 
+    public List<String> getAgentAddresses() {
+        return agentAddresses;
+    }
+
     public RcWorkerStartOperation setAgentAddresses(List<String> agentAddresses) {
         this.agentAddresses = agentAddresses;
+        return this;
+    }
+
+    public RcWorkerStartOperation setCount(int count) {
+        this.count = count;
         return this;
     }
 
@@ -83,19 +89,17 @@ public class RcWorkerStartOperation implements SimulatorOperation {
         return versionSpec;
     }
 
+    public RcWorkerStartOperation setVersionSpec(String versionSpec) {
+        this.versionSpec = versionSpec;
+        return this;
+    }
+
     public String getVmOptions() {
         return vmOptions;
     }
 
-    public String getWorkerType() {
-        return workerType;
-    }
-
-    public String getHzConfig() {
-        return hzConfig;
-    }
-
-    public List<String> getAgentAddress() {
-        return agentAddresses;
+    public RcWorkerStartOperation setVmOptions(String vmOptions) {
+        this.vmOptions = vmOptions;
+        return this;
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/registry/AgentData.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/registry/AgentData.java
@@ -21,7 +21,9 @@ import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,8 +57,13 @@ public class AgentData {
     private final SimulatorAddress address;
     private final String publicAddress;
     private final String privateAddress;
+    private final Map<String, String> tags;
 
     public AgentData(int addressIndex, String publicAddress, String privateAddress) {
+        this(addressIndex, publicAddress, privateAddress, new HashMap<String, String>());
+    }
+
+    public AgentData(int addressIndex, String publicAddress, String privateAddress, Map<String, String> tags) {
         if (addressIndex <= 0) {
             throw new IllegalArgumentException("addressIndex must be a positive number");
         }
@@ -64,6 +71,11 @@ public class AgentData {
         this.address = new SimulatorAddress(AddressLevel.AGENT, addressIndex, 0, 0);
         this.publicAddress = checkNotNull(publicAddress, "publicAddress can't be null");
         this.privateAddress = checkNotNull(privateAddress, "privateAddress can't be null");
+        this.tags = checkNotNull(tags, "tags can't be null");
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
     }
 
     public void setAgentWorkerMode(AgentWorkerMode agentWorkerMode) {

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/registry/ComponentRegistry.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/registry/ComponentRegistry.java
@@ -47,6 +47,7 @@ import static java.util.Collections.unmodifiableList;
 /**
  * Keeps track of all Simulator components which are running.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class ComponentRegistry {
     private final AtomicInteger agentIndex = new AtomicInteger();
     private final AtomicInteger testIndexGenerator = new AtomicInteger();
@@ -57,9 +58,12 @@ public class ComponentRegistry {
     private final ConcurrentMap<String, TestData> tests = new ConcurrentHashMap<String, TestData>();
 
     public AgentData addAgent(String publicAddress, String privateAddress) {
-        AgentData agentData = new AgentData(agentIndex.incrementAndGet(), publicAddress, privateAddress);
-        agents.add(agentData);
+        return addAgent(publicAddress, privateAddress, new HashMap<String, String>());
+    }
 
+    public AgentData addAgent(String publicAddress, String privateAddress, Map<String, String> tags) {
+        AgentData agentData = new AgentData(agentIndex.incrementAndGet(), publicAddress, privateAddress, tags);
+        agents.add(agentData);
         return agentData;
     }
 
@@ -111,6 +115,16 @@ public class ComponentRegistry {
         return unmodifiableList(agents);
     }
 
+    public AgentData getAgent(SimulatorAddress simulatorAddress) {
+        for (AgentData agent : agents) {
+            if (agent.getAddress().equals(simulatorAddress)) {
+                return agent;
+            }
+        }
+
+        return null;
+    }
+
     public Set<String> getAgentIps() {
         Set<String> set = new HashSet<String>();
         for (AgentData agent : agents) {
@@ -140,10 +154,17 @@ public class ComponentRegistry {
         return null;
     }
 
-    public synchronized List<WorkerData> addWorkers(SimulatorAddress parentAddress, List<WorkerProcessSettings> settingsList) {
+    public List<WorkerData> addWorkers(SimulatorAddress parentAddress, List<WorkerProcessSettings> settingsList) {
+        return addWorkers(parentAddress, settingsList, new HashMap<String, String>());
+    }
+
+    public synchronized List<WorkerData> addWorkers(
+            SimulatorAddress parentAddress,
+            List<WorkerProcessSettings> settingsList,
+            Map<String, String> tags) {
         List<WorkerData> result = new ArrayList<WorkerData>(settingsList.size());
         for (WorkerProcessSettings settings : settingsList) {
-            WorkerData workerData = new WorkerData(parentAddress, settings);
+            WorkerData workerData = new WorkerData(parentAddress, settings, tags);
 
             AgentData agentData = agents.get(workerData.getAddress().getAgentIndex() - 1);
             agentData.addWorker(workerData);

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/registry/WorkerData.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/registry/WorkerData.java
@@ -16,10 +16,12 @@
 package com.hazelcast.simulator.protocol.registry;
 
 import com.hazelcast.simulator.agent.workerprocess.WorkerProcessSettings;
-import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.common.WorkerType;
+import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Contains the metadata of a Simulator Worker.
@@ -30,11 +32,21 @@ public class WorkerData {
 
     private final SimulatorAddress address;
     private final WorkerProcessSettings settings;
+    private final Map<String, String> tags;
     private volatile boolean ignoreFailures;
 
     WorkerData(SimulatorAddress parentAddress, WorkerProcessSettings settings) {
+        this(parentAddress, settings, new HashMap<String, String>());
+    }
+
+    WorkerData(SimulatorAddress parentAddress, WorkerProcessSettings settings, Map<String, String> tags) {
         this.address = parentAddress.getChild(settings.getWorkerIndex());
         this.settings = settings;
+        this.tags = tags;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
     }
 
     public SimulatorAddress getAddress() {

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/TagUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/TagUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class TagUtils {
+
+    private TagUtils() {
+    }
+
+    public static boolean matches(Map<String, String> expectedTags, Map<String, String> actualTags) {
+        for (Map.Entry<String, String> entry : expectedTags.entrySet()) {
+            String key = entry.getKey();
+            String expected = expectedTags.get(key);
+            String actual = actualTags.get(key);
+            if (!expected.equals(actual)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static Map<String, String> parseTags(String s) {
+        Map<String, String> result = new HashMap<String, String>();
+        if ("".equals(s)) {
+            return result;
+        }
+        for (String keyValue : s.split(",")) {
+            if (keyValue.contains("=")) {
+                String[] array = keyValue.split("=");
+                result.put(array[0], array[1]);
+            } else {
+                result.put(keyValue, "");
+            }
+        }
+
+        return result;
+    }
+
+    public static String tagsToString(Map<String, String> map) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(',');
+            }
+
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (value.equals("")) {
+                sb.append(key);
+            } else {
+                sb.append(key).append('=').append(value);
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/TestSupport.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/TestSupport.java
@@ -1,5 +1,7 @@
 package com.hazelcast.simulator;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
@@ -22,4 +24,18 @@ public class TestSupport {
         assertTrue(object + " is not an instanceof " + clazz.getName(), clazz.isAssignableFrom(object.getClass()));
         return (E) object;
     }
+
+    public static Map<String, String> toMap(String... array) {
+        if (array.length % 2 == 1) {
+            throw new IllegalArgumentException("even number of arguments expected");
+        }
+
+        Map<String, String> result = new HashMap<String, String>();
+        for (int k = 0; k < array.length; k += 2) {
+            result.put(array[k], array[k + 1]);
+        }
+        return result;
+    }
+
+
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/AgentSmokeTest.java
@@ -37,6 +37,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
@@ -241,7 +244,11 @@ public class AgentSmokeTest implements FailureListener {
                 .setWorkerScript(fileAsText(internalDistPath() + "/conf/worker-hazelcast-member.sh"))
                 .setEnvironment(environment);
         DeploymentPlan deploymentPlan = createSingleInstanceDeploymentPlan(AGENT_IP_ADDRESS, workerParameters);
-        new StartWorkersTask(deploymentPlan.getWorkerDeployment(), remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(
+                deploymentPlan.getWorkerDeployment(),
+                new HashMap<String, String>(),
+                remoteClient,
+                componentRegistry, 0).run();
     }
 
     private void runPhase(TestPhaseListenerImpl listener, TestData testData, TestPhase testPhase) throws Exception {

--- a/simulator/src/test/java/com/hazelcast/simulator/common/AgentsFileTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/common/AgentsFileTest.java
@@ -9,8 +9,11 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static com.hazelcast.simulator.TestSupport.toMap;
 import static com.hazelcast.simulator.common.AgentsFile.load;
 import static com.hazelcast.simulator.common.AgentsFile.save;
 import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
@@ -19,6 +22,7 @@ import static com.hazelcast.simulator.utils.FileUtils.writeText;
 import static com.hazelcast.simulator.utils.FormatUtils.NEW_LINE;
 import static com.hazelcast.simulator.utils.ReflectionUtils.invokePrivateConstructor;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class AgentsFileTest {
 
@@ -50,6 +54,19 @@ public class AgentsFileTest {
         AgentData agentData = componentRegistry.getFirstAgent();
         assertEquals("192.168.1.1", agentData.getPublicAddress());
         assertEquals("10.10.10.10", agentData.getPrivateAddress());
+    }
+
+    @Test
+    public void testLoad_publicAndPrivateAddressAndTags() {
+        writeText("192.168.1.1,10.10.10.10|a=10,b=20", agentsFile);
+
+        componentRegistry = load(agentsFile);
+        assertEquals(1, componentRegistry.agentCount());
+
+        AgentData agentData = componentRegistry.getFirstAgent();
+        assertEquals("192.168.1.1", agentData.getPublicAddress());
+        assertEquals("10.10.10.10", agentData.getPrivateAddress());
+        assertEquals(toMap("a","10","b","20"),agentData.getTags());
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunMonolithTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunMonolithTest.java
@@ -59,7 +59,7 @@ public class CoordinatorRunMonolithTest {
         this.agentData = componentRegistry.addAgent("127.0.0.1", "127.0.0.1");
 
         this.hzConfig = fileAsText(new File(localResourceDirectory(), "hazelcast.xml"));
-        initMemberHzConfig(hzConfig, componentRegistry, null, simulatorProperties, false);
+        initMemberHzConfig(hzConfig, componentRegistry, null, simulatorProperties.asMap(), false);
 
         File scriptFile = new File(internalDistPath() + "/conf/worker-hazelcast-member.sh");
         File logFile = new File(internalDistPath() + "/conf/agent-log4j.xml");

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/tasks/StartWorkersTaskTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/tasks/StartWorkersTaskTest.java
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class StartWorkersTaskTest {
                 coordinatorConnector, componentRegistry,
                 WORKER_PING_INTERVAL_MILLIS);
 
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan, Collections.<String, String>emptyMap(), remoteClient, componentRegistry, 0).run();
 
         assertComponentRegistry(componentRegistry, 6, 3);
     }
@@ -76,7 +77,7 @@ public class StartWorkersTaskTest {
 
         remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS);
 
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan, Collections.<String, String>emptyMap(),remoteClient, componentRegistry, 0).run();
 
         assertComponentRegistry(componentRegistry, 6, 0);
     }
@@ -88,7 +89,7 @@ public class StartWorkersTaskTest {
 
         remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS);
 
-        new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+        new StartWorkersTask(deploymentPlan, Collections.<String, String>emptyMap(), remoteClient, componentRegistry, 0).run();
     }
 
     @Test(expected = SimulatorProtocolException.class)
@@ -99,7 +100,7 @@ public class StartWorkersTaskTest {
 
             remoteClient = new RemoteClient(coordinatorConnector, componentRegistry, WORKER_PING_INTERVAL_MILLIS);
 
-            new StartWorkersTask(deploymentPlan, remoteClient, componentRegistry, 0).run();
+            new StartWorkersTask(deploymentPlan, Collections.<String, String>emptyMap(), remoteClient, componentRegistry, 0).run();
         }catch (RuntimeException e){
             e.printStackTrace();
             throw e;

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/registry/WorkerQueryTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/registry/WorkerQueryTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.simulator.TestSupport.toMap;
 import static com.hazelcast.simulator.common.WorkerType.JAVA_CLIENT;
 import static com.hazelcast.simulator.common.WorkerType.LITE_MEMBER;
 import static com.hazelcast.simulator.common.WorkerType.MEMBER;
@@ -33,9 +34,9 @@ public class WorkerQueryTest {
 
     @Test
     public void noFilters() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery().execute(list);
         assertEquals(list, result);
@@ -43,10 +44,10 @@ public class WorkerQueryTest {
 
     @Test
     public void versionSpec() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, MEMBER, "maven=3.6")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, MEMBER, "maven=3.6")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setVersionSpec("maven=3.7")
@@ -56,10 +57,10 @@ public class WorkerQueryTest {
 
     @Test
     public void workerType() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setWorkerType(MEMBER.name())
@@ -69,10 +70,10 @@ public class WorkerQueryTest {
 
     @Test
     public void maxCount() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
 
         WorkerQuery query = new WorkerQuery()
                 .setMaxCount(2);
@@ -82,11 +83,24 @@ public class WorkerQueryTest {
     }
 
     @Test
+    public void workerTags() {
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6"), toMap("a", "10")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7"), toMap("a", "20")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8"), toMap("a", "10","b","20")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
+
+        WorkerQuery query = new WorkerQuery().setWorkerTags(toMap("a","10"));
+        List<WorkerData> result = query
+                .execute(list);
+        assertEquals(asList(list.get(0), list.get(2)), result);
+    }
+
+    @Test
     public void targetType_whenAll() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setTargetType(TargetType.ALL)
@@ -96,10 +110,10 @@ public class WorkerQueryTest {
 
     @Test
     public void targetType_whenPreferClients() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setTargetType(TargetType.CLIENT)
@@ -109,10 +123,10 @@ public class WorkerQueryTest {
 
     @Test
     public void targetType_whenMember() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent1, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent1, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setTargetType(TargetType.MEMBER)
@@ -122,10 +136,10 @@ public class WorkerQueryTest {
 
     @Test
     public void agentAddresses() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent2, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent2, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent2, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent2, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setAgentAddresses(singletonList(agent1.toString()))
@@ -136,10 +150,10 @@ public class WorkerQueryTest {
 
     @Test
     public void workerAddresses() {
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(1, JAVA_CLIENT, "maven=3.6")));
-        list.add(new WorkerData(agent2, newWorkerProcessSettings(2, MEMBER, "maven=3.7")));
-        list.add(new WorkerData(agent1, newWorkerProcessSettings(3, LITE_MEMBER, "maven=3.8")));
-        list.add(new WorkerData(agent2, newWorkerProcessSettings(4, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(1, JAVA_CLIENT, "maven=3.6")));
+        list.add(new WorkerData(agent2, newSettings(2, MEMBER, "maven=3.7")));
+        list.add(new WorkerData(agent1, newSettings(3, LITE_MEMBER, "maven=3.8")));
+        list.add(new WorkerData(agent2, newSettings(4, MEMBER, "maven=3.7")));
 
         List<WorkerData> result = new WorkerQuery()
                 .setWorkerAddresses(asList(list.get(0).getAddress().toString(), list.get(2).getAddress().toString()))
@@ -147,7 +161,7 @@ public class WorkerQueryTest {
         assertEquals(asList(list.get(0), list.get(2)), result);
     }
 
-    private WorkerProcessSettings newWorkerProcessSettings(int workerIndex, WorkerType workerType, String versionSpec) {
+    private WorkerProcessSettings newSettings(int workerIndex, WorkerType workerType, String versionSpec) {
         return new WorkerProcessSettings(workerIndex, workerType, versionSpec, "", 0, new HashMap<String, String>());
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/provisioner/ProvisionerCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/provisioner/ProvisionerCliTest.java
@@ -7,6 +7,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static com.hazelcast.simulator.TestEnvironmentUtils.createAgentsFileWithLocalhost;
@@ -76,7 +77,7 @@ public class ProvisionerCliTest {
         cli.setProvisioner(provisioner);
         cli.run();
 
-        verify(provisioner).scale(0);
+        verify(provisioner).scale(0, new HashMap<String, String>());
         verify(provisioner).shutdown();
         verifyNoMoreInteractions(provisioner);
     }
@@ -90,7 +91,7 @@ public class ProvisionerCliTest {
         cli.setProvisioner(provisioner);
         cli.run();
 
-        verify(provisioner).scale(10);
+        verify(provisioner).scale(10, new HashMap<String, String>());
         verify(provisioner).shutdown();
         verifyNoMoreInteractions(provisioner);
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/provisioner/ProvisionerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/provisioner/ProvisionerTest.java
@@ -10,6 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Set;
 
 import static com.hazelcast.simulator.TestEnvironmentUtils.createAgentsFileWithLocalhost;
@@ -58,39 +59,45 @@ public class ProvisionerTest extends AbstractComputeServiceTest {
         deleteCloudCredentialFiles();
     }
 
+
+    // test is useless since it doesn't test anything
     @Test
     public void testScale_toNegative() {
         mockComputeServiceForScaleDown();
-        provisioner.scale(-1);
+        provisioner.scale(-1, new HashMap<String, String>());
     }
 
+    // test is useless since it doesn't test anything
     @Test
     public void testScale_toZero() {
         mockComputeServiceForScaleDown();
-        provisioner.scale(0);
+        provisioner.scale(0, new HashMap<String, String>());
     }
 
+    // test is useless since it doesn't test anything
     @Test
     public void testScale_toOne() {
-        provisioner.scale(1);
+        provisioner.scale(1, new HashMap<String, String>());
     }
 
+
+    // test is useless since it doesn't test anything
     @Test
     public void testScale_toTwo() throws Exception {
         mockComputeServiceForScaleUp();
-        provisioner.scale(2);
+        provisioner.scale(2, new HashMap<String, String>());
     }
 
     @Test(expected = IllegalStateException.class)
     public void testScale_toZero_withException() {
-        provisioner.scale(0);
+        provisioner.scale(0, new HashMap<String, String>());
     }
 
     @Test(expected = CommandLineExitException.class)
     public void testScale_toTwo_withException() throws Exception {
         IllegalStateException exception = new IllegalStateException("expected exception");
         when(computeService.createNodesInGroup(anyString(), anyInt(), any(Template.class))).thenThrow(exception);
-        provisioner.scale(2);
+        provisioner.scale(2, new HashMap<String, String>());
     }
 
     @Test

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/TagUtilsTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/TagUtilsTest.java
@@ -1,0 +1,60 @@
+package com.hazelcast.simulator.utils;
+
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.hazelcast.simulator.TestSupport.toMap;
+import static org.junit.Assert.assertEquals;
+
+public class TagUtilsTest {
+
+    @Test
+    public void parseTags() {
+        Map<String, String> result = TagUtils.parseTags("a,b=10,c=20");
+
+        assertEquals(toMap("a", "", "b", "10", "c", "20"), result);
+    }
+
+    @Test
+    public void parseTags_whenEmpty() {
+        Map<String, String> result = TagUtils.parseTags("");
+
+        assertEquals(toMap(), result);
+    }
+
+    @Test
+    public void tagsToString() {
+        Map<String, String> hashMap = new LinkedHashMap<String, String>();
+        hashMap.put("a", "");
+        hashMap.put("b", "10");
+        hashMap.put("c", "20");
+
+        String result = TagUtils.tagsToString(hashMap);
+
+        assertEquals("a,b=10,c=20", result);
+    }
+
+    @Test
+    public void match() {
+        assertMatches(true, "", "");
+        assertMatches(true, "", "a");
+        assertMatches(true, "", "a=10");
+        assertMatches(true, "a=10", "a=10");
+        assertMatches(true, "a=10", "a=10,b=20");
+        assertMatches(true, "a", "a");
+
+        assertMatches(false, "a", "");
+        assertMatches(false, "a", "b");
+        assertMatches(false, "a=10", "a=20");
+        assertMatches(false, "a=10,b=10", "a=10,b=20");
+    }
+
+    private void assertMatches(boolean match, String required, String actual) {
+        Map<String, String> e = TagUtils.parseTags(required);
+        Map<String, String> a = TagUtils.parseTags(actual);
+        assertEquals(match, TagUtils.matches(e, a));
+    }
+
+}

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/MemberWorkerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/MemberWorkerTest.java
@@ -51,12 +51,12 @@ public class MemberWorkerTest {
         properties.set("MANAGEMENT_CENTER_URL","none");
 
         String memberHzConfig = fileAsText(localResourceDirectory() + "/hazelcast.xml");
-        memberHzConfig = initMemberHzConfig(memberHzConfig, componentRegistry, null, properties, false);
+        memberHzConfig = initMemberHzConfig(memberHzConfig, componentRegistry, null, properties.asMap(), false);
         memberConfigFile = new File(getUserDir(), "hazelcast.xml");
         appendText(memberHzConfig, memberConfigFile);
 
         String clientHzConfig = fileAsText(localResourceDirectory() + "/client-hazelcast.xml");
-        clientHzConfig = initClientHzConfig(clientHzConfig, componentRegistry, properties, null);
+        clientHzConfig = initClientHzConfig(clientHzConfig, componentRegistry, properties.asMap(), null);
         clientConfigFile = new File(getUserDir(), "client-hazelcast.xml");
         appendText(clientHzConfig, clientConfigFile);
     }


### PR DESCRIPTION
For more advanced configuration, tags are added as an ability to:
- query for specific members e.g. run test on cluster1.
- pass key/value pairs for customization in e.g. config files

fix #1228 
fix #1229 
fix #1247 