### PR TITLE
Timestep artifacts in subdir

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/utils/TestUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/TestUtils.java
@@ -180,6 +180,10 @@ public final class TestUtils {
         File userDir = getUserDir();
         if (userDir.exists()) {
             for (File file : userDir.listFiles()) {
+                if (file.isDirectory()) {
+                    continue;
+                }
+
                 assertFalse("exception found:" + file + " content:"
                         + FileUtils.fileAsText(file), file.getName().endsWith(".exception"));
             }


### PR DESCRIPTION
Instead of dumping in the main worker directory, the artifacts (classes/java-src) are now
dumped in a subdirectory timestep-worker-classes.

Fix #1271