### PR TITLE
Added support for JDK 9

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -274,11 +274,13 @@ JDK_64_BITS=true
 #
 # The version of java to install.
 #
-# Oracle supports 6/7/8
+# Oracle supports 6/7/8/9 (Oracle 9 is the early access version)
+#       when using Oracle 9, add the following to the jvm parameters '--add-modules java.xml.bind'
+#       for more information see https://bugs.openjdk.java.net/browse/JDK-8157670
 # OpenJDK supports 6/7
 # IBM supports 6/7/8 (8 is an early access version)
 #
-# Fine grained control on the version will be added in the future. Currently it is the most recent released version.
+# Fine grained control on the version will be added in the future.
 #
 JDK_VERSION=8
 

--- a/dist/src/main/dist/jdk-install/jdk-oracle-9-64.sh
+++ b/dist/src/main/dist/jdk-install/jdk-oracle-9-64.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+source jdk-support.sh
+
+install wget
+install tar
+
+cd ~
+wget --no-verbose http://ec2-54-87-52-100.compute-1.amazonaws.com/jdk-9-ea+157_linux-x64_bin.tar.gz
+tar xfz jdk-9-ea+157_linux-x64_bin.tar.gz
+
+prepend 'export PATH=$JAVA_HOME/bin:$PATH'  ~/.bashrc
+prepend "export JAVA_HOME=~/jdk-9"  ~/.bashrc

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.1.3</logback.version>
 
-        <netty.version>4.1.6.Final</netty.version>
+        <netty.version>4.1.8.Final</netty.version>
         <javassist.version>3.12.1.GA</javassist.version>
 
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>


### PR DESCRIPTION
Fix #1281

Netty needed to be upgraded since it didn't deal well with Java 9.

An actual run with Hazelcast was not successful currently; needs more
analysis. But simulator did run successfully. So not completely sure
which part is failing.