### PR TITLE
Remove simulator properties requirement

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -27,14 +27,21 @@ CLOUD_PROVIDER=local
 # Cloud credentials
 # =====================================================================
 #
-# The cloud credentials cannot be directly configured as property value. This is to prevent them from accidentally being committed
-# or being zipped and sent to someone. We store a path to files instead, which you should keep out of your working directory.
+# The cloud identity (AWS access key ID).
 #
-# The path to a file containing your identity (AWS access key ID).
+# The cloud identity can be configured in two was:
+#    1: using a file reference. So you set the path to the file containing the cloud identity. This is
+#       the prefered way because it is more secure. Normally you put this file in your home dir
+#    2: using the value. This is the simplest way, but you need to be careful that this doesn't leave
+#       your system. E.g. because it got added to a git repo, zipped etc.
+#
 #
 CLOUD_IDENTITY=~/ec2.identity
+
 #
-# The path to the file containing your credential (AWS secret access key).
+# The cloud credential (AWS secret access key).
+#
+# It can be configured in the same way as CLOUD_IDENTITY using direct value or file reference.
 #
 CLOUD_CREDENTIAL=~/ec2.credential
 
@@ -84,15 +91,11 @@ HARAKIRI_MONITOR_WAIT_SECONDS=7200
 GROUP_NAME=simulator-agent-${username}
 
 #
-# The name of the user on your local machine.
-#
-# JClouds will automatically make a new user on the remote machine  with this name as loginname. It will also copy
-# the public key of your system to the remote machine and add it to the ~/.ssh/authorized_keys. So once the instance
-# is created, you can login with 'ssh USER@ip'.
+# The name of the SIMULATOR_USER on remote machines
 #
 # The default value 'simulator' is fine in most cases. So probably you don't want to change this.
 #
-USER=simulator
+SIMULATOR_USER=simulator
 
 #
 # The options added to SSH. Probably you don't need to change this.

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -452,7 +452,6 @@ final class CoordinatorCli {
 
     private File getTestSuiteFile() {
         File testSuiteFile;
-
         List testsuiteFiles = options.nonOptionArguments();
         if (testsuiteFiles.size() > 1) {
             throw new CommandLineExitException(format("Too many TestSuite files specified: %s", testsuiteFiles));

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/ComputeServiceBuilder.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/ComputeServiceBuilder.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_PROVIDER;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.isStatic;
 import static com.hazelcast.simulator.utils.FileUtils.newFile;
 import static com.hazelcast.simulator.utils.FormatUtils.NEW_LINE;
@@ -63,7 +63,7 @@ class ComputeServiceBuilder {
 
         String cloudProvider = properties.getCloudProvider();
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(format("Using %s: %s", PROPERTY_CLOUD_PROVIDER, cloudProvider));
+            LOGGER.debug(format("Using %s: %s", CLOUD_PROVIDER, cloudProvider));
         }
 
         ContextBuilder contextBuilder = newContextBuilder(cloudProvider);

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/ProvisionerCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/ProvisionerCli.java
@@ -65,7 +65,6 @@ final class ProvisionerCli {
             "Tags for an agent.")
             .withRequiredArg().ofType(String.class);
 
-
     private final OptionSet options;
     private final Map<String, String> tags;
     private Provisioner provisioner;

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
@@ -29,9 +29,9 @@ import java.io.File;
 import java.util.Properties;
 import java.util.TreeSet;
 
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_CREDENTIAL;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_IDENTITY;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_PROVIDER;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_CREDENTIAL;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_IDENTITY;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_LOCAL;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_STATIC;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
@@ -107,12 +107,12 @@ class Wizard {
         ensureExistingFile(workDir, AgentsFile.NAME);
 
         File simulatorPropertiesFile = ensureExistingFile(workDir, SimulatorProperties.PROPERTIES_FILE_NAME);
-        writeText(format("%s=%s%n", PROPERTY_CLOUD_PROVIDER, cloudProvider), simulatorPropertiesFile);
+        writeText(format("%s=%s%n", CLOUD_PROVIDER, cloudProvider), simulatorPropertiesFile);
         if (isEC2(cloudProvider)) {
             appendText(format(
                     "%n# These files contain your AWS access key ID and secret access key (change if needed)%n#%s=%s%n#%s=%s%n",
-                    PROPERTY_CLOUD_IDENTITY, simulatorProperties.get(PROPERTY_CLOUD_IDENTITY),
-                    PROPERTY_CLOUD_CREDENTIAL, simulatorProperties.get(PROPERTY_CLOUD_CREDENTIAL)),
+                    CLOUD_IDENTITY, simulatorProperties.get(CLOUD_IDENTITY),
+                    CLOUD_CREDENTIAL, simulatorProperties.get(CLOUD_CREDENTIAL)),
                     simulatorPropertiesFile);
             appendText(format(
                     "%n# Machine specification used for AWS (change if needed)%n#MACHINE_SPEC=%s%n",
@@ -122,8 +122,8 @@ class Wizard {
 
             appendText(format(
                     "%n# These files contain your GCE credentials (change if needed)%n%s=%s%n%s=%s%n",
-                    PROPERTY_CLOUD_IDENTITY, "~/gce.id",
-                    PROPERTY_CLOUD_CREDENTIAL, "~/gce.pem"),
+                    CLOUD_IDENTITY, "~/gce.id",
+                    CLOUD_CREDENTIAL, "~/gce.pem"),
                     simulatorPropertiesFile);
             appendText(format(
                     "%nGROUP_NAME=simulator-agent%nUSER=%s%n",
@@ -186,7 +186,7 @@ class Wizard {
 
     void compareSimulatorProperties() {
         SimulatorProperties defaultProperties = new SimulatorProperties();
-        String defaultPropertiesString = defaultProperties.getAsString();
+        String defaultPropertiesString = defaultProperties.getDefaultsAsString();
         Properties userProperties = WizardUtils.getUserProperties();
 
         int size = userProperties.size();

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/WizardCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/WizardCli.java
@@ -23,6 +23,8 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.apache.log4j.Logger;
 
+import java.io.File;
+
 import static com.hazelcast.simulator.common.GitInfo.getBuildTime;
 import static com.hazelcast.simulator.common.GitInfo.getCommitIdAbbrev;
 import static com.hazelcast.simulator.utils.CliUtils.initOptionsWithHelp;
@@ -108,7 +110,7 @@ final class WizardCli {
     private static SimulatorProperties getSimulatorProperties(boolean initWithWorkingDirFile) {
         SimulatorProperties simulatorProperties = new SimulatorProperties();
         if (initWithWorkingDirFile) {
-            simulatorProperties.init(null);
+            simulatorProperties.init((File) null);
         }
         return simulatorProperties;
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/common/SimulatorPropertiesTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/common/SimulatorPropertiesTest.java
@@ -9,9 +9,9 @@ import java.io.File;
 
 import static com.hazelcast.simulator.TestEnvironmentUtils.setupFakeEnvironment;
 import static com.hazelcast.simulator.TestEnvironmentUtils.tearDownFakeEnvironment;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_CREDENTIAL;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_IDENTITY;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_PROVIDER;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_CREDENTIAL;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_IDENTITY;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -38,14 +38,14 @@ public class SimulatorPropertiesTest {
 
     @Test
     public void testInit_defaults() {
-        simulatorProperties.init(null);
+        simulatorProperties.init((File) null);
     }
 
     @Test
     public void testInit_workingDir() {
         File workingDirProperties = new File(simulatorHome, "simulator.properties");
 
-        appendText("USER=workingDirUserName", workingDirProperties);
+        appendText("SIMULATOR_USER=workingDirUserName", workingDirProperties);
 
         simulatorProperties.init(workingDirProperties);
 
@@ -61,7 +61,7 @@ public class SimulatorPropertiesTest {
     @Test
     public void testInit_customFile() {
         File file = new File(simulatorHome, "simulator.properties");
-        appendText("USER=testUserName", file);
+        appendText("SIMULATOR_USER=testUserName", file);
 
         simulatorProperties.init(file);
 
@@ -126,7 +126,7 @@ public class SimulatorPropertiesTest {
 
     @Test
     public void testContainsKey() {
-        assertTrue(simulatorProperties.containsKey(PROPERTY_CLOUD_PROVIDER));
+        assertTrue(simulatorProperties.containsKey(CLOUD_PROVIDER));
         assertFalse(simulatorProperties.containsKey("UNKNOWN_PROPERTY"));
     }
 
@@ -172,7 +172,7 @@ public class SimulatorPropertiesTest {
 
     @Test
     public void testGet_withDefaultValue_defaultIsIgnored() {
-        assertEquals("simulator", simulatorProperties.get("USER", "ignored"));
+        assertEquals("simulator", simulatorProperties.get("SIMULATOR_USER", "ignored"));
     }
 
     @Test
@@ -211,18 +211,9 @@ public class SimulatorPropertiesTest {
         appendText("testCloudIdentityString", identityFile);
 
         File customFile = new File(simulatorHome, "simulator.properties");
-        initProperty(customFile, PROPERTY_CLOUD_IDENTITY, identityFile.getAbsolutePath());
+        initProperty(customFile, CLOUD_IDENTITY, identityFile.getAbsolutePath());
 
         assertEquals("testCloudIdentityString", simulatorProperties.getCloudIdentity());
-    }
-
-    @Test(expected = CommandLineExitException.class)
-    public void testGet_CLOUD_IDENTITY_notFound() {
-        File customFile = new File(simulatorHome, "simulator.properties");
-
-        initProperty(customFile, PROPERTY_CLOUD_IDENTITY, "notFound");
-
-        simulatorProperties.getCloudIdentity();
     }
 
     @Test
@@ -231,15 +222,7 @@ public class SimulatorPropertiesTest {
         appendText("testIdentity", credentialsFile);
 
         File customFile = new File(simulatorHome, "simulator.properties");
-        initProperty(customFile, PROPERTY_CLOUD_CREDENTIAL, credentialsFile.getAbsolutePath());
-
-        assertEquals("testIdentity", simulatorProperties.getCloudCredential());
-    }
-
-    @Test(expected = CommandLineExitException.class)
-    public void testGet_CLOUD_CREDENTIAL_notFound() {
-        File customFile = new File(simulatorHome, "simulator.properties");
-        initProperty(customFile, PROPERTY_CLOUD_CREDENTIAL, "notexist");
+        initProperty(customFile, CLOUD_CREDENTIAL, credentialsFile.getAbsolutePath());
 
         assertEquals("testIdentity", simulatorProperties.getCloudCredential());
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.simulator.TestEnvironmentUtils.createAgentsFileWithLocalhost;
 import static com.hazelcast.simulator.TestEnvironmentUtils.setupFakeEnvironment;
 import static com.hazelcast.simulator.TestEnvironmentUtils.tearDownFakeEnvironment;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_PROVIDER;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_STATIC;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
 import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
@@ -94,7 +94,7 @@ public class CoordinatorCliTest {
 
     @Test
     public void testInit_withCloudProviderStatic() {
-        appendText(format("%s=%s%n", PROPERTY_CLOUD_PROVIDER, PROVIDER_STATIC), propertiesFile);
+        appendText(format("%s=%s%n", CLOUD_PROVIDER, PROVIDER_STATIC), propertiesFile);
 
         args.add(testSuiteFile.getAbsolutePath());
         CoordinatorCli cli = createCoordinatorCli();
@@ -402,7 +402,7 @@ public class CoordinatorCliTest {
     @Test
     public void testInit_withLocalSetup() {
         File simulatorProperties = new File(getUserDir(), "simulator.properties").getAbsoluteFile();
-        writeText(format("%s=%s", PROPERTY_CLOUD_PROVIDER, CloudProviderUtils.PROVIDER_LOCAL), simulatorProperties);
+        writeText(format("%s=%s", CLOUD_PROVIDER, CloudProviderUtils.PROVIDER_LOCAL), simulatorProperties);
 
         try {
             CoordinatorCli cli = createCoordinatorCli();

--- a/simulator/src/test/java/com/hazelcast/simulator/utils/HarakiriMonitorUtilsTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/utils/HarakiriMonitorUtilsTest.java
@@ -9,8 +9,8 @@ import java.io.File;
 
 import static com.hazelcast.simulator.TestEnvironmentUtils.setupFakeEnvironment;
 import static com.hazelcast.simulator.TestEnvironmentUtils.tearDownFakeEnvironment;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_CREDENTIAL;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_IDENTITY;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_CREDENTIAL;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_IDENTITY;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_EC2;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_STATIC;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
@@ -76,8 +76,8 @@ public class HarakiriMonitorUtilsTest {
     @Test
     public void testGetStartCommand() {
         properties.setCloudProvider(PROVIDER_EC2);
-        properties.set(PROPERTY_CLOUD_IDENTITY, "identity");
-        properties.set(PROPERTY_CLOUD_CREDENTIAL, "credential");
+        properties.set(CLOUD_IDENTITY, "identity");
+        properties.set(CLOUD_CREDENTIAL, "credential");
 
         File identity = ensureExistingFile("identity");
         File credentials = ensureExistingFile("credential");

--- a/simulator/src/test/java/com/hazelcast/simulator/wizard/WizardTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/wizard/WizardTest.java
@@ -16,9 +16,9 @@ import static com.hazelcast.simulator.TestEnvironmentUtils.resetSecurityManager;
 import static com.hazelcast.simulator.TestEnvironmentUtils.setExitExceptionSecurityManagerWithStatusZero;
 import static com.hazelcast.simulator.TestEnvironmentUtils.setupFakeEnvironment;
 import static com.hazelcast.simulator.TestEnvironmentUtils.tearDownFakeEnvironment;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_CREDENTIAL;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_IDENTITY;
-import static com.hazelcast.simulator.common.SimulatorProperties.PROPERTY_CLOUD_PROVIDER;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_CREDENTIAL;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_IDENTITY;
+import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_EC2;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_GCE;
 import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_LOCAL;
@@ -213,8 +213,8 @@ public class WizardTest {
         ensureExistingFile(localSimulatorPropertiesFile);
 
         appendText("invalid=unknown" + NEW_LINE, localSimulatorPropertiesFile);
-        appendText(format("%s=changed%n", PROPERTY_CLOUD_PROVIDER), localSimulatorPropertiesFile);
-        appendText(format("%s=%s%n", PROPERTY_CLOUD_IDENTITY, defaultProperties.get(PROPERTY_CLOUD_IDENTITY)),
+        appendText(format("%s=changed%n", CLOUD_PROVIDER), localSimulatorPropertiesFile);
+        appendText(format("%s=%s%n", CLOUD_IDENTITY, defaultProperties.get(CLOUD_IDENTITY)),
                 localSimulatorPropertiesFile);
 
         wizard.compareSimulatorProperties();
@@ -253,8 +253,8 @@ public class WizardTest {
         assertTrue(simulatorPropertiesContent.contains(cloudProvider));
 
         if (!isStatic(cloudProvider)) {
-            assertTrue(simulatorPropertiesContent.contains(PROPERTY_CLOUD_IDENTITY));
-            assertTrue(simulatorPropertiesContent.contains(PROPERTY_CLOUD_CREDENTIAL));
+            assertTrue(simulatorPropertiesContent.contains(CLOUD_IDENTITY));
+            assertTrue(simulatorPropertiesContent.contains(CLOUD_CREDENTIAL));
         }
 
         assertTrue(agentsFile.exists());


### PR DESCRIPTION
The variables can be defined and exported in the bash script and will automatically
be picked up without needing to create a file.

Also there is no more need to create an ec2.identity and ec2.credential file. If
the properties refer to a file; the file is loaded. Otherwise the properties will
be interpreted as a direct value.

fix https://github.com/hazelcast/hazelcast-simulator/issues/1305