### PR TITLE
Removed the need for test.properties file

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorRemoteCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorRemoteCli.java
@@ -701,7 +701,7 @@ public final class CoordinatorRemoteCli implements Closeable {
             if (durationSeconds != 0 && warmupSeconds > durationSeconds) {
                 throw new CommandLineExitException("warmup can't be larger than duration");
             }
-            TestSuite suite = TestSuite.loadTestSuite(testSuiteFile, "")
+            TestSuite suite = new TestSuite(testSuiteFile)
                     .setDurationSeconds(durationSeconds)
                     .setWarmupSeconds(warmupSeconds)
                     .setWorkerQuery(newQuery())

--- a/simulator/src/test/java/com/hazelcast/simulator/common/TestSuiteTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/common/TestSuiteTest.java
@@ -10,10 +10,8 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Map;
 
-import static com.hazelcast.simulator.coordinator.TestSuite.loadTestSuite;
 import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingFile;
-import static com.hazelcast.simulator.utils.FileUtils.writeText;
 import static com.hazelcast.simulator.utils.FormatUtils.NEW_LINE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -46,7 +44,7 @@ public class TestSuiteTest {
     public void loadTestSuite_whenInvalidTestId() throws Exception {
         String txt = "*@class=AtomicLong" + NEW_LINE;
 
-        createTestSuite(txt);
+        new TestSuite(txt);
     }
 
     @Test
@@ -54,7 +52,7 @@ public class TestSuiteTest {
         String txt = "atomicLongTest@class=AtomicLong" + NEW_LINE
                 + "atomicLongTest@threadCount=10";
 
-        TestSuite testSuite = createTestSuite(txt);
+        TestSuite testSuite = new TestSuite(txt);
         assertEquals(1, testSuite.size());
         TestCase testCase = testSuite.getTestCaseList().get(0);
         assertEquals("atomicLongTest", testCase.getId());
@@ -69,7 +67,7 @@ public class TestSuiteTest {
                 + "atomicBooleanTest@class=AtomicBoolean" + NEW_LINE
                 + "atomicBooleanTest@threadCount=20";
 
-        TestSuite testSuite = createTestSuite(txt);
+        TestSuite testSuite = new TestSuite(txt);
         assertEquals(2, testSuite.size());
 
         TestCase atomicLongTestCase = testSuite.getTestCase("atomicLongTest");
@@ -88,7 +86,7 @@ public class TestSuiteTest {
         String txt = "class=AtomicLong" + NEW_LINE
                 + "threadCount=10";
 
-        TestSuite testSuite = createTestSuite(txt);
+        TestSuite testSuite = new TestSuite(txt);
         assertEquals(1, testSuite.size());
 
         TestCase testCase = testSuite.getTestCaseList().get(0);
@@ -104,21 +102,21 @@ public class TestSuiteTest {
     public void loadTestSuite_missingClassName() throws Exception {
         String txt = "threadCount=10";
 
-        createTestSuite(txt);
+        new TestSuite(txt);
     }
 
     @Test(expected = BindException.class)
     public void loadTestSuite_missingClassName_withTestCaseId() throws Exception {
         String txt = "TestCase@threadCount=10";
 
-        createTestSuite(txt);
+        new TestSuite(txt);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void loadTestSuite_emptyClassName() throws Exception {
         String txt = "class=";
 
-        createTestSuite(txt);
+        new TestSuite(txt);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -126,55 +124,40 @@ public class TestSuiteTest {
         String txt = "class=AtomicLong" + NEW_LINE
                 + "threadCount=";
 
-        createTestSuite(txt);
+        new TestSuite(txt);
     }
 
     @Test
     public void getTestCase_null() throws Exception {
-        TestSuite testSuite = createTestSuite("");
+        TestSuite testSuite = new TestSuite("");
 
         assertNull(testSuite.getTestCase(null));
     }
 
     @Test
     public void getTestCase_notFound() throws Exception {
-        TestSuite testSuite = createTestSuite("");
+        TestSuite testSuite = new TestSuite("");
 
         assertNull(testSuite.getTestCase("notFound"));
     }
 
     @Test
     public void getTestCase_toString() throws Exception {
-        TestSuite testSuite = createTestSuite("");
+        TestSuite testSuite = new TestSuite("");
 
         assertNotNull(testSuite.toString());
     }
 
     @Test(expected = CommandLineExitException.class)
     public void propertiesNotFound() throws Exception {
-        loadTestSuite(new File("notFound"), null);
+        new TestSuite(new File("notFound"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void invalidTestCaseId() throws Exception {
         String txt = "In$valid@class=AtomicLong" + NEW_LINE;
 
-        createTestSuite(txt);
-    }
-
-    @Test
-    public void overrideProperties() throws Exception {
-        String txt = "class=AtomicLong" + NEW_LINE
-                + "threadCount=10";
-
-        String overrideProperties = "threadCount=20";
-
-        TestSuite testSuite = createTestSuite(txt, overrideProperties);
-        assertEquals(1, testSuite.size());
-
-        TestCase testCase = testSuite.getTestCaseList().get(0);
-        assertEquals("AtomicLong", testCase.getClassname());
-        assertEquals("20", testCase.getProperty("threadCount"));
+        new TestSuite(txt);
     }
 
     @Test
@@ -187,15 +170,5 @@ public class TestSuiteTest {
         testSuite.addTest(new TestCase("four"));
 
         assertEquals(8, testSuite.getMaxTestCaseIdLength());
-    }
-
-    private TestSuite createTestSuite(String txt) throws Exception {
-        return createTestSuite(txt, "");
-    }
-
-    private TestSuite createTestSuite(String txt, String overrideProperties) throws Exception {
-        writeText(txt, testSuiteFile);
-
-        return loadTestSuite(testSuiteFile, overrideProperties);
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -326,7 +326,7 @@ public class CoordinatorCliTest {
 
     @Test(expected = CommandLineExitException.class)
     public void testInit_testSuite_notFound() {
-        args.add("not.found");
+        args.add("not_found.properties");
 
         createCoordinatorCli();
     }


### PR DESCRIPTION
So coordinator can still be used with a test.properties file; but can also be used
with a string containing the tests.