### PR TITLE
Removed the worker classpath option

### DIFF
--- a/archetype/src/main/resources/archetype-resources/workdir/run.sh
+++ b/archetype/src/main/resources/archetype-resources/workdir/run.sh
@@ -4,15 +4,16 @@ set -e
 
 provisioner --scale 4
 
-coordinator     --memberWorkerCount 2 \
-                --workerVmOptions "-ea -server -Xms2G -Xmx2G -verbosegc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError" \
-                --hzFile            hazelcast.xml \
-                --clientWorkerCount 2 \
-                --clientWorkerVmOptions "-ea -server -Xms2G -Xmx2G -verbosegc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:gc.log -XX:+HeapDumpOnOutOfMemoryError" \
-                --clientHzFile      client-hazelcast.xml \
-                --workerClassPath   '../target/*.jar' \
-                --duration          5m \
-                --monitorPerformance \
+# all the libs we need we copy to the upload directory. They will automatically be uploaded and put on the classpath
+# of the worker
+mkdr -p upload
+cp ../target/*.jar upload
+
+coordinator     --members 2 \
+                --memberArgs "-Xms2G -Xmx2G" \
+                --clients 2 \
+                --clientArgs "-Xms2G -Xmx2G" \
+                --duration 5m \
                 test.properties
 
 provisioner --terminate

--- a/archetype/src/main/resources/archetype-resources/workdir/simulator.properties
+++ b/archetype/src/main/resources/archetype-resources/workdir/simulator.properties
@@ -6,10 +6,8 @@
 #
 CLOUD_PROVIDER=aws-ec2
 # These files contain your AWS access key ID and secret access key
-CLOUD_IDENTITY=~/ec2.identity
-CLOUD_CREDENTIAL=~/ec2.credential
 
 MACHINE_SPEC=hardwareId=m3.medium,locationId=us-east-1,imageId=us-east-1/ami-fb8e9292
 JDK_FLAVOR=oracle
-JDK_VERSION=7
+JDK_VERSION=8
 VERSION_SPEC=outofthebox

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -124,11 +124,6 @@ final class CoordinatorCli {
             "Auto create Hazelcast instances.")
             .withRequiredArg().ofType(Boolean.class).defaultsTo(true);
 
-    private final OptionSpec<String> workerClassPathSpec = parser.accepts("workerClassPath",
-            "A file/directory containing the classes/jars/resources that are going to be uploaded to the agents."
-                    + " Use ';' as separator for multiple entries. The wildcard '*' can also be used.")
-            .withRequiredArg().ofType(String.class);
-
     private final OptionSpec<String> sessionIdSpec = parser.accepts("sessionId",
             "Defines the ID of the Session. If not set the actual date will be used."
                     + " The session ID is used for creating the working directory")
@@ -232,7 +227,6 @@ final class CoordinatorCli {
     private CoordinatorParameters loadCoordinatorParameters() {
         CoordinatorParameters coordinatorParameters = new CoordinatorParameters()
                 .setSimulatorProperties(simulatorProperties)
-                .setWorkerClassPath(options.valueOf(workerClassPathSpec))
                 .setLastTestPhaseToSync(options.valueOf(syncToTestPhaseSpec))
                 .setAfterCompletionFile(getConfigurationFile("after-completion.sh").getAbsolutePath())
                 .setPerformanceMonitorIntervalSeconds(getPerformanceMonitorInterval())

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorParameters.java
@@ -32,7 +32,6 @@ public class CoordinatorParameters {
     private TestPhase lastTestPhaseToSync = TestPhase.getLastTestPhase();
 
     private SimulatorProperties simulatorProperties;
-    private String workerClassPath;
     private boolean skipDownload;
     private boolean skipShutdownHook;
     private int workerVmStartupDelayMs;
@@ -64,15 +63,6 @@ public class CoordinatorParameters {
 
     public CoordinatorParameters setSimulatorProperties(SimulatorProperties simulatorProperties) {
         this.simulatorProperties = simulatorProperties;
-        return this;
-    }
-
-    public String getWorkerClassPath() {
-        return workerClassPath;
-    }
-
-    public CoordinatorParameters setWorkerClassPath(String workerClassPath) {
-        this.workerClassPath = workerClassPath;
         return this;
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -288,17 +288,6 @@ public class CoordinatorCliTest {
         assertEquals(42, testSuite.getDurationSeconds());
     }
 
-    @Test
-    public void testInit_workerClassPath() {
-        args.add("--workerClassPath");
-        args.add("*.jar");
-        args.add(testSuiteFile.getAbsolutePath());
-
-        CoordinatorCli cli = createCoordinatorCli();
-
-        assertEquals("*.jar", cli.coordinatorParameters.getWorkerClassPath());
-    }
-
     @Test(expected = CommandLineExitException.class)
     public void testInit_noWorkersDefined() {
         args.add("--members");


### PR DESCRIPTION
Using the upload directory, any artifact needed like jars, will automatically be put
on the classpath. So extra jars needed, we can just copy in the upload directory. No
need to have a special flag for it.

This flag was still in the system, but not used any longer.