### PR TITLE
Fixes a bug in the performance calculation premature ending

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollector.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollector.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.simulator.utils.FormatUtils.formatDouble;
 import static com.hazelcast.simulator.utils.FormatUtils.formatLong;
 import static com.hazelcast.simulator.utils.FormatUtils.formatPercentage;
+import static com.hazelcast.simulator.utils.FormatUtils.secondsToHuman;
 import static com.hazelcast.simulator.worker.performance.PerformanceStats.INTERVAL_LATENCY_PERCENTILE;
 import static java.lang.Math.round;
 import static java.lang.String.format;
@@ -121,10 +122,14 @@ public class PerformanceStatsCollector {
 
         StringBuilder sb = new StringBuilder();
 
+        double throughput = totalOperationCount / runningTimeSeconds;
+        sb.append("Total running time " + secondsToHuman(Math.round(runningTimeSeconds)) + "\n");
+
         sb.append(format("Total throughput        %s%% %s ops %s ops/s\n",
                 formatPercentage(1, 1),
                 formatLong(totalOperationCount, OPERATION_COUNT_FORMAT_LENGTH),
-                formatDouble(totalOperationCount / runningTimeSeconds, THROUGHPUT_FORMAT_LENGTH)));
+                formatDouble(throughput, THROUGHPUT_FORMAT_LENGTH)));
+
 
         for (SimulatorAddress address : sort(agentPerformanceStatsMap.keySet())) {
             PerformanceStats performanceStats = agentPerformanceStatsMap.get(address);

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -275,13 +275,18 @@ public final class TestCaseRunner implements TestPhaseListener {
 
         stop(RUN);
 
-        logPerformanceInfo();
+        logFinalPerformanceInfo(startMs);
 
         waitForGlobalTestPhaseCompletion(RUN);
     }
 
-    private void logPerformanceInfo() {
-        long durationMillis = SECONDS.toMillis(testSuite.getDurationSeconds()) - testCase.getWarmupMillis();
+    private void logFinalPerformanceInfo(long startMs) {
+        // the running time of the test is current time minus the start time. We can't rely on testsuite duration
+        // due to premature abortion of a test. Or if the test has no explicit duration configured
+        long durationWithWarmupMillis = currentTimeMillis() - startMs;
+
+        // then we need to subtract the warmup.
+        long durationMillis = durationWithWarmupMillis - testCase.getWarmupMillis();
 
         if (performanceMonitorIntervalSeconds > 0) {
             LOGGER.info(testCase.getId() + " Waiting for all performance info");


### PR DESCRIPTION
The problem was that the desired running time was used, not the actual running time.

So if you run for 10 seconds and then end the test, but your desired running time is 60 seconds, and the throughput is 1/6 of real throughput.