### PR TITLE
Map Streamer fallback to reflection when putAsync() throws NoSuchMethodError

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/ReflectionAsyncMapStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/ReflectionAsyncMapStreamer.java
@@ -1,0 +1,45 @@
+package com.hazelcast.simulator.worker.loadsupport;
+
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * This is needed when Simulator is compiled against Hazelcast 3.7+, but uses 3.6- in runtime.
+ *
+ * Reflection is not ideal, but it's still way better than using {@link SyncMapStreamer}
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class ReflectionAsyncMapStreamer<K, V> extends AbstractAsyncStreamer<K, V> {
+
+    private static final Method PUT_ASYNC_METHOD;
+    private final IMap<K, V> map;
+
+    static {
+        try {
+            PUT_ASYNC_METHOD = IMap.class.getMethod("putAsync", Object.class, Object.class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    ReflectionAsyncMapStreamer(int concurrencyLevel, IMap<K, V> map) {
+        super(concurrencyLevel);
+        this.map = map;
+    }
+
+    @Override
+    ICompletableFuture storeAsync(K key, V value) {
+        try {
+            return (ICompletableFuture) PUT_ASYNC_METHOD.invoke(map, key, value);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        } catch (InvocationTargetException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/ReflectionAsyncMapStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/ReflectionAsyncMapStreamer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.simulator.worker.loadsupport;
 
 import com.hazelcast.core.ICompletableFuture;

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
@@ -19,6 +19,9 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.core.IMap;
 
 import javax.cache.Cache;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.simulator.utils.BuildInfoUtils.isMinVersion;
@@ -32,6 +35,7 @@ import static com.hazelcast.simulator.worker.loadsupport.Streamer.DEFAULT_CONCUR
 public final class StreamerFactory {
 
     private static final AtomicBoolean CREATE_ASYNC = new AtomicBoolean(isMinVersion("3.5"));
+    private static volatile Boolean USE_REFLECTION_STREAMER = useReflectionAsyncStreamer();
 
     private StreamerFactory() {
     }
@@ -42,7 +46,11 @@ public final class StreamerFactory {
 
     public static <K, V> Streamer<K, V> getInstance(IMap<K, V> map, int concurrencyLevel) {
         if (CREATE_ASYNC.get()) {
-            return new AsyncMapStreamer<K, V>(concurrencyLevel, map);
+            if (USE_REFLECTION_STREAMER) {
+                return new ReflectionAsyncMapStreamer<K, V>(concurrencyLevel, map);
+            } else {
+                return new AsyncMapStreamer<K, V>(concurrencyLevel, map);
+            }
         }
         return new SyncMapStreamer<K, V>(map);
     }
@@ -60,5 +68,21 @@ public final class StreamerFactory {
 
     static void enforceAsync(boolean enforceAsync) {
         CREATE_ASYNC.set(enforceAsync);
+    }
+
+    private static boolean useReflectionAsyncStreamer() {
+        InvocationHandler handler = new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                return null;
+            }
+        };
+        IMap imapProxy = (IMap) Proxy.newProxyInstance(IMap.class.getClassLoader(), new Class[]{IMap.class}, handler);
+        try {
+            imapProxy.getAsync(null);
+            return false;
+        } catch (NoSuchMethodError e) {
+            return true;
+        }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
@@ -19,9 +19,6 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.core.IMap;
 
 import javax.cache.Cache;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.simulator.utils.BuildInfoUtils.isMinVersion;
@@ -71,18 +68,14 @@ public final class StreamerFactory {
     }
 
     private static boolean useReflectionAsyncStreamer() {
-        InvocationHandler handler = new InvocationHandler() {
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                return null;
-            }
-        };
-        IMap imapProxy = (IMap) Proxy.newProxyInstance(IMap.class.getClassLoader(), new Class[]{IMap.class}, handler);
+        IMap imapProxy = null;
         try {
             imapProxy.getAsync(null);
-            return false;
+            throw new AssertionError("expected NPE");
         } catch (NoSuchMethodError e) {
             return true;
+        } catch (NullPointerException e) {
+            return false;
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/StreamerFactory.java
@@ -32,7 +32,7 @@ import static com.hazelcast.simulator.worker.loadsupport.Streamer.DEFAULT_CONCUR
 public final class StreamerFactory {
 
     private static final AtomicBoolean CREATE_ASYNC = new AtomicBoolean(isMinVersion("3.5"));
-    private static volatile Boolean USE_REFLECTION_STREAMER = useReflectionAsyncStreamer();
+    private static final boolean USE_REFLECTION_STREAMER = useReflectionAsyncStreamer();
 
     private StreamerFactory() {
     }


### PR DESCRIPTION
This can happen when Simulator was compiled against Hazelacast 3.7+,
but Hazelcast 3.6- is used in runtime

The `IMap::fooAsync` returns `ICompletableFuture` in Hazelcast 3.7, but it returns just a regular `Future` in Hazelcast 3.6 and older. 

There are bridge methods so code compiled against Hazelcast 3.6 will work when Hazelcast 3.7 is used in runtime. However code compiled against Hazelcast 3.7+ will not work when Hazelcast 3.6- is used in runtime and it affects Simulator Streamers. 

This changeset detects this situation and fallbacks to reflection-based streamers - method return type does not matter in reflective invocations. 