### PR TITLE
Fix #1396 agent file missing simulator/java failed instances

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
@@ -239,6 +239,7 @@ class Provisioner {
 
                     echo(INDENTATION + publicIpAddress + " LAUNCHED");
                     componentRegistry.addAgent(publicIpAddress, privateIpAddress, tags);
+                    AgentsFile.save(agentsFile, componentRegistry);
                 }
 
                 for (NodeMetadata node : nodes) {
@@ -251,8 +252,6 @@ class Provisioner {
             for (Future future : futures) {
                 future.get();
             }
-
-            AgentsFile.save(agentsFile, componentRegistry);
         } catch (Exception e) {
             throw new CommandLineExitException("Failed to provision machines: " + e.getMessage());
         }


### PR DESCRIPTION
This is because the agents are written after everything completes. But it
should be written before the simulator/java installation begins.