### PR TITLE
Simplified the TerminateWorkerOperation

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
@@ -37,7 +37,6 @@ import static com.hazelcast.simulator.common.GitInfo.getCommitIdAbbrev;
 import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
 import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
-import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
 import static com.hazelcast.simulator.utils.FileUtils.getUserDir;
 import static com.hazelcast.simulator.utils.FileUtils.writeText;
@@ -116,12 +115,8 @@ public class Worker {
 
     public void shutdown(TerminateWorkerOperation op) {
         LOGGER.warn("Terminating worker");
-        if (type == WorkerType.MEMBER) {
-            sleepSeconds(op.getMemberWorkerShutdownDelaySeconds());
-        }
-
         closeQuietly(server);
-        shutdownThread = new WorkerShutdownThread(op.isEnsureProcessShutdown());
+        shutdownThread = new WorkerShutdownThread(op.isRealShutdown());
         shutdownThread.start();
     }
 
@@ -270,10 +265,7 @@ public class Worker {
                 hazelcastInstance.shutdown();
             }
 
-            if (performanceMonitor != null) {
-                echo("Shutting down WorkerPerformanceMonitor");
-                performanceMonitor.shutdown();
-            }
+            closeQuietly(performanceMonitor);
         }
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/operations/TerminateWorkerOperation.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/operations/TerminateWorkerOperation.java
@@ -17,7 +17,6 @@ package com.hazelcast.simulator.worker.operations;
 
 import com.google.gson.annotations.SerializedName;
 import com.hazelcast.simulator.protocol.operation.SimulatorOperation;
-import com.hazelcast.simulator.worker.Worker;
 
 /**
  * Initiates the shutdown process of the Worker.
@@ -25,36 +24,18 @@ import com.hazelcast.simulator.worker.Worker;
 public class TerminateWorkerOperation implements SimulatorOperation {
 
     /**
-     * Defines a delay for {@link Worker} for the shutdown, to give Hazelcast clients enough
-     * time to disconnect gracefully, before the Hazelcast members are gone.
+     * If the worker should do a real shutdown or just fake it. This is needed for integration testing the code.
      *
-     * Client Workers can ignore this parameter.
+     * If you are implementing a non java client? Just ignore this property and terminate your client.
      */
-    @SerializedName("memberWorkerShutdownDelaySeconds")
-    private final int memberWorkerShutdownDelaySeconds;
+    @SerializedName("realShutdown")
+    private final boolean realShutdown;
 
-    /**
-     * Defines if Java Workers should shutdown their process (e.g. via {@link System#exit(int)}).
-     *
-     * This is done to ensure that the Worker process is killed, even if some Threads are non-responsive.
-     * In Java Workers this is also used to shutdown log4j, to ensure flushing of the logs.
-     *
-     * This switch should not be set in integration tests, otherwise the logging will be gone in
-     * subsequent tests. This may also kill the JVM of the test itself.
-     */
-    @SerializedName("ensureProcessShutdown")
-    private final boolean ensureProcessShutdown;
-
-    public TerminateWorkerOperation(int memberWorkerShutdownDelaySeconds, boolean ensureProcessShutdown) {
-        this.memberWorkerShutdownDelaySeconds = memberWorkerShutdownDelaySeconds;
-        this.ensureProcessShutdown = ensureProcessShutdown;
+    public TerminateWorkerOperation(boolean realShutdown) {
+        this.realShutdown = realShutdown;
     }
 
-    public int getMemberWorkerShutdownDelaySeconds() {
-        return memberWorkerShutdownDelaySeconds;
-    }
-
-    public boolean isEnsureProcessShutdown() {
-        return ensureProcessShutdown;
+    public boolean isRealShutdown() {
+        return realShutdown;
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceMonitor.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/performance/PerformanceMonitor.java
@@ -21,6 +21,7 @@ import com.hazelcast.simulator.worker.testcontainer.TestContainer;
 import com.hazelcast.simulator.worker.testcontainer.TestManager;
 import org.apache.log4j.Logger;
 
+import java.io.Closeable;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Monitors the performance of all running Simulator Tests.
  */
-public class PerformanceMonitor {
+public class PerformanceMonitor implements Closeable {
 
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 10;
     private static final long WAIT_FOR_TEST_CONTAINERS_DELAY_NANOS = MILLISECONDS.toNanos(100);
@@ -70,11 +71,12 @@ public class PerformanceMonitor {
         thread.start();
     }
 
-    public void shutdown() {
+    @Override
+    public void close() {
         if (!shutdown.compareAndSet(false, true)) {
             return;
         }
-
+        LOGGER.info("Shutting down WorkerPerformanceMonitor");
         joinThread(thread, MINUTES.toMillis(SHUTDOWN_TIMEOUT_SECONDS));
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerOperationProcessorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerOperationProcessorTest.java
@@ -65,7 +65,7 @@ public class WorkerOperationProcessorTest {
 
     @Test
     public void test_TerminateWorkerOperation() throws Exception {
-        TerminateWorkerOperation op = new TerminateWorkerOperation(0, true);
+        TerminateWorkerOperation op = new TerminateWorkerOperation(true);
 
         processor.process(op, sourceAddress, promise);
 

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerTest.java
@@ -78,7 +78,7 @@ public class WorkerTest {
     @After
     public void after() throws Exception {
         if (worker != null) {
-            worker.shutdown(new TerminateWorkerOperation(0, false));
+            worker.shutdown(new TerminateWorkerOperation(false));
             worker.awaitShutdown();
         }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/performance/PerformanceMonitorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/performance/PerformanceMonitorTest.java
@@ -55,24 +55,24 @@ public class PerformanceMonitorTest {
 
     @After
     public void after() {
-        performanceMonitor.shutdown();
+        performanceMonitor.close();
 
         teardownFakeUserDir();
     }
 
     @Test
-    public void test_shutdownTwice() {
+    public void test_closeTwice() {
         performanceMonitor.start();
 
-        performanceMonitor.shutdown();
-        performanceMonitor.shutdown();
+        performanceMonitor.close();
+        performanceMonitor.close();
     }
 
     @Test(expected = IllegalThreadStateException.class)
     public void test_restartAfterStop() {
         performanceMonitor.start();
 
-        performanceMonitor.shutdown();
+        performanceMonitor.close();
 
         performanceMonitor.start();
     }
@@ -116,7 +116,7 @@ public class PerformanceMonitorTest {
         testContext.stop();
         joinThread(runTestThread);
 
-        performanceMonitor.shutdown();
+        performanceMonitor.close();
     }
 
     private TestContext addTest(Object test) {


### PR DESCRIPTION
Instead of it having a parameter with the delay for members; the coordinator
takes care of delaying any termination to member if there are clients. This
makes implementation less complex.

Also some renaming.