### PR TITLE
Removed Test Address level since not used

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -56,7 +56,7 @@ public class Agent implements Closeable {
                  int port,
                  int threadPoolSize,
                  int workerLastSeenTimeoutSeconds) {
-        SimulatorAddress agentAddress = new SimulatorAddress(AGENT, addressIndex, 0, 0);
+        SimulatorAddress agentAddress = new SimulatorAddress(AGENT, addressIndex, 0);
 
         this.publicAddress = publicAddress;
         Runtime.getRuntime().addShutdownHook(new AgentShutdownThread(true));

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManager.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManager.java
@@ -160,7 +160,7 @@ public class WorkerProcessManager {
 
                 SimulatorAddress workerAddress
                         = new SimulatorAddress(AddressLevel.WORKER, agentAddress.getAddressIndex(),
-                        parameters.intGet("WORKER_INDEX"), 0);
+                        parameters.intGet("WORKER_INDEX"));
 
                 server.sendCoordinator(new FailureOperation("Failed to start worker [" + workerAddress + "]",
                         WORKER_CREATE_ERROR, workerAddress, agentAddress.toString(), e));
@@ -179,7 +179,7 @@ public class WorkerProcessManager {
 
             String workerType = parameters.getWorkerType();
             SimulatorAddress workerAddress = new SimulatorAddress(
-                    AddressLevel.WORKER, agentAddress.getAgentIndex(), workerIndex, 0);
+                    AddressLevel.WORKER, agentAddress.getAgentIndex(), workerIndex);
 
             LogOperation logOperation = new LogOperation(
                     format("Created %s Worker %s", workerType, workerAddress), DEBUG);

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -290,7 +290,7 @@ public class Coordinator implements Closeable {
                 sleepSeconds(1);
                 for (TestData test : registry.getTests()) {
                     if (test.getTestSuite() == op.getTestSuite()) {
-                        return test.getAddress().toString();
+                        return test.getTestCase().getId();
                     }
                 }
             }
@@ -304,7 +304,7 @@ public class Coordinator implements Closeable {
     public String testStop(RcTestStopOperation op) throws Exception {
         LOGGER.info(format("Test [%s] stopping...", op.getTestId()));
 
-        TestData test = registry.getTestByAddress(SimulatorAddress.fromString(op.getTestId()));
+        TestData test = registry.getTest(op.getTestId());
         if (test == null) {
             throw new IllegalStateException(format("no test with id [%s] found", op.getTestId()));
         }
@@ -324,7 +324,7 @@ public class Coordinator implements Closeable {
     }
 
     public String testStatus(RcTestStatusOperation op) throws Exception {
-        TestData test = registry.getTestByAddress(SimulatorAddress.fromString(op.getTestId()));
+        TestData test = registry.getTest(op.getTestId());
         return test == null ? "null" : test.getStatusString();
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/DeploymentPlan.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/DeploymentPlan.java
@@ -209,7 +209,7 @@ public final class DeploymentPlan {
 
         void registerWorker(WorkerParameters parameters) {
             int workerIndex = agent.getNextWorkerIndex();
-            SimulatorAddress workerAddress = new SimulatorAddress(WORKER, agent.getAddressIndex(), workerIndex, 0);
+            SimulatorAddress workerAddress = new SimulatorAddress(WORKER, agent.getAddressIndex(), workerIndex);
 
             String workerDirName = workerAddress.toString() + '-' + agent.getPublicAddress() + '-' + parameters.getWorkerType();
             parameters.set("WORKER_ADDRESS", workerAddress)

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -110,9 +110,7 @@ public final class TestCaseRunner {
         this.failureCollector = failureCollector;
         this.performanceStatsCollector = performanceStatsCollector;
 
-        String testAddress = test.getAddress().toString();
-        this.prefix = padRight(testAddress + ":" + testCase.getId()
-                , testSuite.getMaxTestCaseIdLength() + 2 + testAddress.length());
+        this.prefix = padRight(testCase.getId(), testSuite.getMaxTestCaseIdLength() + 2);
 
         this.testPhaseSyncMap = testPhaseSyncMap;
 

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/registry/AgentData.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/registry/AgentData.java
@@ -67,7 +67,7 @@ public class AgentData {
             throw new IllegalArgumentException("addressIndex must be a positive number");
         }
         this.addressIndex = addressIndex;
-        this.address = new SimulatorAddress(AddressLevel.AGENT, addressIndex, 0, 0);
+        this.address = new SimulatorAddress(AddressLevel.AGENT, addressIndex, 0);
         this.publicAddress = checkNotNull(publicAddress, "publicAddress can't be null");
         this.privateAddress = checkNotNull(privateAddress, "privateAddress can't be null");
         this.tags = checkNotNull(tags, "tags can't be null");

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/registry/ComponentRegistry.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/registry/ComponentRegistry.java
@@ -20,7 +20,6 @@ import com.hazelcast.simulator.common.TestCase;
 import com.hazelcast.simulator.coordinator.TargetType;
 import com.hazelcast.simulator.coordinator.TestSuite;
 import com.hazelcast.simulator.coordinator.registry.AgentData.AgentWorkerMode;
-import com.hazelcast.simulator.protocol.core.AddressLevel;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 
@@ -300,8 +299,6 @@ public class ComponentRegistry {
         sb.append(format("    Tests %s", tests.size())).append('\n');
         for (TestData test : tests) {
             sb.append("        ")
-                    .append(test.getAddress())
-                    .append(" ")
                     .append(test.getTestCase().getId())
                     .append(" ")
                     .append(test.getStatusString())
@@ -322,10 +319,9 @@ public class ComponentRegistry {
                 id = id + "__" + count.getAndIncrement();
             }
             int testIndex = testIndexGenerator.incrementAndGet();
-            SimulatorAddress testAddress = new SimulatorAddress(AddressLevel.TEST, 0, 0, testIndex);
             testCase.setId(id);
 
-            TestData test = new TestData(testIndex, testAddress, testCase, testSuite);
+            TestData test = new TestData(testIndex, testCase, testSuite);
             result.add(test);
             tests.put(id, test);
         }
@@ -342,14 +338,5 @@ public class ComponentRegistry {
 
     public TestData getTest(String testId) {
         return tests.get(testId);
-    }
-
-    public TestData getTestByAddress(SimulatorAddress address) {
-        for (TestData test : getTests()) {
-            if (test.getAddress().equals(address)) {
-                return test;
-            }
-        }
-        return null;
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/registry/TestData.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/registry/TestData.java
@@ -18,7 +18,6 @@ package com.hazelcast.simulator.coordinator.registry;
 import com.hazelcast.simulator.common.TestCase;
 import com.hazelcast.simulator.common.TestPhase;
 import com.hazelcast.simulator.coordinator.TestSuite;
-import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 
 import static com.hazelcast.simulator.coordinator.registry.TestData.CompletedStatus.FAILED;
 import static com.hazelcast.simulator.coordinator.registry.TestData.CompletedStatus.IN_PROGRESS;
@@ -33,7 +32,6 @@ public class TestData {
     }
 
     private final int testIndex;
-    private final SimulatorAddress address;
     private final TestCase testCase;
     private final TestSuite testSuite;
     private volatile long startTimeMillis;
@@ -41,9 +39,8 @@ public class TestData {
     private volatile boolean stopRequested;
     private volatile CompletedStatus completedStatus = IN_PROGRESS;
 
-    TestData(int testIndex, SimulatorAddress address, TestCase testCase, TestSuite testSuite) {
+    TestData(int testIndex,  TestCase testCase, TestSuite testSuite) {
         this.testIndex = testIndex;
-        this.address = address;
         this.testCase = testCase;
         this.testSuite = testSuite;
     }
@@ -74,10 +71,6 @@ public class TestData {
 
     public int getTestIndex() {
         return testIndex;
-    }
-
-    public SimulatorAddress getAddress() {
-        return address;
     }
 
     public TestCase getTestCase() {

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/core/AddressLevel.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/core/AddressLevel.java
@@ -23,10 +23,9 @@ public enum AddressLevel {
 
     COORDINATOR(0),
     AGENT(1),
-    WORKER(2),
-    TEST(3);
+    WORKER(2);
 
-    private static final AddressLevel[] ADDRESS_LEVELS = new AddressLevel[]{COORDINATOR, AGENT, WORKER, TEST};
+    private static final AddressLevel[] ADDRESS_LEVELS = new AddressLevel[]{COORDINATOR, AGENT, WORKER};
 
     private final int intValue;
 
@@ -39,7 +38,7 @@ public enum AddressLevel {
     }
 
     public static int getMaxLevel() {
-        return TEST.intValue;
+        return WORKER.intValue;
     }
 
     public static AddressLevel fromInt(int intValue) {

--- a/simulator/src/main/java/com/hazelcast/simulator/protocol/core/SimulatorAddress.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/protocol/core/SimulatorAddress.java
@@ -36,32 +36,25 @@ import static java.lang.Integer.parseInt;
  *                    +--+---+                                           +---+--+
  * AGENT              | C_A1 |                              +------------+ C_A2 +------------+
  *                    +--+---+                              |            +------+            |
- *                       |                                 |                                 |
- *                       v                                 v                                 v
- *                  +----+----+                       +----+----+                       +----+----+
- * WORKER       +---+ C_A1_W1 +---+               +---+ C_A2_W1 +---+               +---+ C_A2_W2 +---+
- *              |   +---------+   |               |   +---------+   |               |   +---------+   |
- *              |                 |               |                 |               |                 |
- *              v                 v               v                 v               v                 v
- *        +-----+------+   +------+-----+   +-----+------+   +------+-----+   +-----+------+   +------+-----+
- * TEST   | C_A1_W1_T1 |   | C_A1_W1_T2 |   | C_A2_W1_T1 |   | C_A2_W1_T2 |   | C_A2_W2_T1 |   | C_A2_W2_T2 |
- *        +------------+   +------------+   +------------+   +------------+   +------------+   +------------+
+ *                       |                                  |                                |
+ *                       v                                  v                                v
+ *                  +----+----+                        +----+----+                      +----+----+
+ * WORKER           + C_A1_W1 +                        + C_A2_W1 +                      + C_A2_W2 +
+ *                  +---------+                        +---------+                      +---------+
  * </pre>
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class SimulatorAddress {
 
-    public static final SimulatorAddress COORDINATOR = new SimulatorAddress(AddressLevel.COORDINATOR, 0, 0, 0);
-    public static final SimulatorAddress ALL_AGENTS = new SimulatorAddress(AddressLevel.AGENT, 0, 0, 0);
-    public static final SimulatorAddress ALL_WORKERS = new SimulatorAddress(AddressLevel.WORKER, 0, 0, 0);
+    public static final SimulatorAddress COORDINATOR = new SimulatorAddress(AddressLevel.COORDINATOR, 0, 0);
+    public static final SimulatorAddress ALL_AGENTS = new SimulatorAddress(AddressLevel.AGENT, 0, 0);
+    public static final SimulatorAddress ALL_WORKERS = new SimulatorAddress(AddressLevel.WORKER, 0, 0);
 
-    private static final String REMOTE_STRING = "R";
     private static final String COORDINATOR_STRING = "C";
 
     private final AddressLevel addressLevel;
     private final int agentIndex;
     private final int workerIndex;
-    private final int testIndex;
 
     /**
      * Creates a new {@link SimulatorAddress} instance.
@@ -69,13 +62,11 @@ public class SimulatorAddress {
      * @param addressLevel the {@link AddressLevel} of the Simulator component
      * @param agentIndex   the index of the addressed Agent or <tt>0</tt> for all Agents
      * @param workerIndex  the index of the addressed Worker or <tt>0</tt> for all Workers
-     * @param testIndex    the index of the addressed Test or <tt>0</tt> for all Tests
      */
-    public SimulatorAddress(AddressLevel addressLevel, int agentIndex, int workerIndex, int testIndex) {
+    public SimulatorAddress(AddressLevel addressLevel, int agentIndex, int workerIndex) {
         this.addressLevel = addressLevel;
         this.agentIndex = agentIndex;
         this.workerIndex = workerIndex;
-        this.testIndex = testIndex;
     }
 
     /**
@@ -106,15 +97,6 @@ public class SimulatorAddress {
     }
 
     /**
-     * Returns the Test index of this {@link SimulatorAddress}.
-     *
-     * @return the index of the addressed Test or <tt>0</tt> if all Tests are addressed
-     */
-    public int getTestIndex() {
-        return testIndex;
-    }
-
-    /**
      * Returns the address index of the defined {@link AddressLevel} of this {@link SimulatorAddress}.
      *
      * @return the index of the {@link AddressLevel}
@@ -125,8 +107,6 @@ public class SimulatorAddress {
                 return agentIndex;
             case WORKER:
                 return workerIndex;
-            case TEST:
-                return testIndex;
             default:
                 throw new IllegalArgumentException("Coordinator has no addressIndex!");
         }
@@ -139,10 +119,8 @@ public class SimulatorAddress {
      */
     public SimulatorAddress getParent() {
         switch (addressLevel) {
-            case TEST:
-                return new SimulatorAddress(AddressLevel.WORKER, agentIndex, workerIndex, 0);
             case WORKER:
-                return new SimulatorAddress(AddressLevel.AGENT, agentIndex, 0, 0);
+                return new SimulatorAddress(AddressLevel.AGENT, agentIndex, 0);
             case AGENT:
                 return SimulatorAddress.COORDINATOR;
             default:
@@ -159,11 +137,9 @@ public class SimulatorAddress {
     public SimulatorAddress getChild(int childIndex) {
         switch (addressLevel) {
             case COORDINATOR:
-                return new SimulatorAddress(AddressLevel.AGENT, childIndex, 0, 0);
+                return new SimulatorAddress(AddressLevel.AGENT, childIndex, 0);
             case AGENT:
-                return new SimulatorAddress(AddressLevel.WORKER, agentIndex, childIndex, 0);
-            case WORKER:
-                return new SimulatorAddress(AddressLevel.TEST, agentIndex, workerIndex, childIndex);
+                return new SimulatorAddress(AddressLevel.WORKER, agentIndex, childIndex);
             default:
                 throw new IllegalArgumentException("Test has no child!");
         }
@@ -180,8 +156,6 @@ public class SimulatorAddress {
                 return agentIndex == 0;
             case WORKER:
                 return agentIndex == 0 || workerIndex == 0;
-            case TEST:
-                return agentIndex == 0 || workerIndex == 0 || testIndex == 0;
             default:
                 return false;
         }
@@ -203,9 +177,6 @@ public class SimulatorAddress {
         if (workerIndex != that.workerIndex) {
             return false;
         }
-        if (testIndex != that.testIndex) {
-            return false;
-        }
         return (addressLevel == that.addressLevel);
     }
 
@@ -214,7 +185,6 @@ public class SimulatorAddress {
         int result = addressLevel.hashCode();
         result = 31 * result + agentIndex;
         result = 31 * result + workerIndex;
-        result = 31 * result + testIndex;
         return result;
     }
 
@@ -224,7 +194,6 @@ public class SimulatorAddress {
         sb.append(COORDINATOR_STRING);
         appendAddressLevelString(sb, AddressLevel.COORDINATOR, "_A", agentIndex);
         appendAddressLevelString(sb, AddressLevel.AGENT, "_W", workerIndex);
-        appendAddressLevelString(sb, AddressLevel.WORKER, "_T", testIndex);
         return sb.toString();
     }
 
@@ -243,9 +212,8 @@ public class SimulatorAddress {
 
         int agentIndex = getAddressIndex(AddressLevel.COORDINATOR, addressLevel, "A*", sections);
         int workerIndex = getAddressIndex(AddressLevel.AGENT, addressLevel, "W*", sections);
-        int testIndex = getAddressIndex(AddressLevel.WORKER, addressLevel, "T*", sections);
 
-        return new SimulatorAddress(addressLevel, agentIndex, workerIndex, testIndex);
+        return new SimulatorAddress(addressLevel, agentIndex, workerIndex);
     }
 
     public static List<SimulatorAddress> fromString(List<String> list) {

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessFailureMonitorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessFailureMonitorTest.java
@@ -281,7 +281,7 @@ public class WorkerProcessFailureMonitorTest {
     }
 
     private SimulatorAddress createWorkerAddress() {
-        return new SimulatorAddress(WORKER, 1, ++addressIndex, 0);
+        return new SimulatorAddress(WORKER, 1, ++addressIndex);
     }
 
     private WorkerProcess addRunningWorkerProcess() {

--- a/simulator/src/test/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManagerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManagerTest.java
@@ -29,8 +29,8 @@ public class WorkerProcessManagerTest {
 
     @Before
     public void before() {
-        firstWorkerAddress = new SimulatorAddress(WORKER, 1, 1, 0);
-        secondWorkerAddress = new SimulatorAddress(WORKER, 1, 2, 0);
+        firstWorkerAddress = new SimulatorAddress(WORKER, 1, 1);
+        secondWorkerAddress = new SimulatorAddress(WORKER, 1, 2);
 
         firstWorkerProcess = new WorkerProcess(firstWorkerAddress, firstWorkerAddress.toString(), null);
         firstWorkerProcess.setProcess(mock(Process.class));
@@ -95,7 +95,7 @@ public class WorkerProcessManagerTest {
         long secondLastSeen = secondWorkerProcess.getLastSeen();
 
         sleepMillis(100);
-        workerProcessManager.updateLastSeenTimestamp(new SimulatorAddress(WORKER, 2, 1, 0));
+        workerProcessManager.updateLastSeenTimestamp(new SimulatorAddress(WORKER, 2, 1));
 
         assertEquals(firstLastSeen, firstWorkerProcess.getLastSeen());
         assertEquals(secondLastSeen, secondWorkerProcess.getLastSeen());

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorTest.java
@@ -168,7 +168,7 @@ public class CoordinatorTest {
                 .setDurationSeconds(10);
 
         String testId = coordinator.testRun(new RcTestRunOperation(suite).setAsync(true));
-        assertEquals("C_A*_W*_T" + (initialTestIndex + 1), testId);
+        assertEquals(suite.getTestCaseList().get(0).getId(), testId);
 
         assertTestCompletesEventually(testId);
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/FailureCollectorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/FailureCollectorTest.java
@@ -50,7 +50,7 @@ public class FailureCollectorTest {
         agentAddress = registry.addAgent("192.168.0.1", "192.168.0.1").getAddress();
 
 
-        workerAddress = new SimulatorAddress(WORKER, agentAddress.getAgentIndex(), 1, 0);
+        workerAddress = new SimulatorAddress(WORKER, agentAddress.getAgentIndex(), 1);
 
         WorkerParameters workerParameters = new WorkerParameters()
                 .set("WORKER_ADDRESS", workerAddress);
@@ -77,7 +77,7 @@ public class FailureCollectorTest {
 
     @Test
     public void notify_whenNonExistingWorker_thenIgnore() {
-        SimulatorAddress nonExistingWorkerAddress = new SimulatorAddress(WORKER, agentAddress.getAgentIndex(), 100, 0);
+        SimulatorAddress nonExistingWorkerAddress = new SimulatorAddress(WORKER, agentAddress.getAgentIndex(), 100);
         FailureOperation failure = new FailureOperation("exception", WORKER_EXCEPTION, nonExistingWorkerAddress, agentAddress.toString(),
                 "workerId", "testId", null);
 

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollectorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollectorTest.java
@@ -39,10 +39,10 @@ public class PerformanceStatsCollectorTest {
         emptyPerformanceStatsCollector = new PerformanceStatsCollector();
         performanceStatsCollector = new PerformanceStatsCollector();
 
-        a1w1 = new SimulatorAddress(WORKER, 1, 1, 0);
-        a1w2 = new SimulatorAddress(WORKER, 1, 2, 0);
-        a2w1 = new SimulatorAddress(WORKER, 2, 1, 0);
-        a2w2 = new SimulatorAddress(WORKER, 2, 2, 0);
+        a1w1 = new SimulatorAddress(WORKER, 1, 1);
+        a1w2 = new SimulatorAddress(WORKER, 1, 2);
+        a2w1 = new SimulatorAddress(WORKER, 2, 1);
+        a2w2 = new SimulatorAddress(WORKER, 2, 2);
 
         a1 = a1w1.getParent();
         a2 = a2w1.getParent();
@@ -70,7 +70,7 @@ public class PerformanceStatsCollectorTest {
 
     @Test
     public void testFormatPerformanceNumbers_avgLatencyOverMicrosThreshold() throws Exception {
-        SimulatorAddress worker = new SimulatorAddress(WORKER, 3, 1, 0);
+        SimulatorAddress worker = new SimulatorAddress(WORKER, 3, 1);
 
         Map<String, PerformanceStats> performanceStats = new HashMap<String, PerformanceStats>();
         performanceStats.put(TEST_CASE_ID_1, new PerformanceStats(

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/operations/FailureOperationTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/operations/FailureOperationTest.java
@@ -18,8 +18,8 @@ public class FailureOperationTest {
 
     private static final String TEST_ID = "ExceptionOperationTest";
 
-    private SimulatorAddress workerAddress = new SimulatorAddress(WORKER, 1, 1, 0);
-    private SimulatorAddress agentAddress = new SimulatorAddress(AGENT, 2, 0, 0);
+    private SimulatorAddress workerAddress = new SimulatorAddress(WORKER, 1, 1);
+    private SimulatorAddress agentAddress = new SimulatorAddress(AGENT, 2, 0);
 
     private TestException cause;
     private TestCase testCase;

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/registry/AgentDataTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/registry/AgentDataTest.java
@@ -17,7 +17,7 @@ public class AgentDataTest {
     public void testConstructor() {
         AgentData agentData = new AgentData(DEFAULT_ADDRESS_INDEX, DEFAULT_PUBLIC_ADDRESS, DEFAULT_PRIVATE_ADDRESS);
 
-        assertEquals(new SimulatorAddress(AddressLevel.AGENT, DEFAULT_ADDRESS_INDEX, 0, 0), agentData.getAddress());
+        assertEquals(new SimulatorAddress(AddressLevel.AGENT, DEFAULT_ADDRESS_INDEX, 0), agentData.getAddress());
         assertEquals(DEFAULT_ADDRESS_INDEX, agentData.getAddressIndex());
         assertEquals(DEFAULT_PUBLIC_ADDRESS, agentData.getPublicAddress());
         assertEquals(DEFAULT_PRIVATE_ADDRESS, agentData.getPrivateAddress());

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/registry/ComponentRegistryTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/registry/ComponentRegistryTest.java
@@ -5,7 +5,6 @@ import com.hazelcast.simulator.common.TestCase;
 import com.hazelcast.simulator.coordinator.TargetType;
 import com.hazelcast.simulator.coordinator.TestSuite;
 import com.hazelcast.simulator.coordinator.registry.AgentData.AgentWorkerMode;
-import com.hazelcast.simulator.protocol.core.AddressLevel;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.junit.Test;
@@ -117,7 +116,7 @@ public class ComponentRegistryTest {
         registry.addWorkers(parametersList);
         assertEquals(5, registry.workerCount());
 
-        registry.removeWorker(new SimulatorAddress(WORKER, 1, 3, 0));
+        registry.removeWorker(new SimulatorAddress(WORKER, 1, 3));
         assertEquals(4, registry.workerCount());
     }
 
@@ -311,7 +310,6 @@ public class ComponentRegistryTest {
         assertEquals(3, tests.size());
         for (TestData testData : tests) {
             assertTrue(testData.getTestCase().getId().startsWith("Test"));
-            assertEquals(AddressLevel.TEST, testData.getAddress().getAddressLevel());
         }
     }
 
@@ -326,7 +324,6 @@ public class ComponentRegistryTest {
         TestData testData = registry.getTest("Test2");
 
         assertEquals(2, testData.getTestIndex());
-        assertEquals(AddressLevel.TEST, testData.getAddress().getAddressLevel());
         assertEquals("Test2", testData.getTestCase().getId());
     }
 
@@ -345,7 +342,7 @@ public class ComponentRegistryTest {
             result.add(new WorkerParameters()
                     .set("WORKER_TYPE", workerType)
                     .set("WORKER_INDEX", k )
-                    .set("WORKER_ADDRESS", new SimulatorAddress(WORKER, agent.getAgentIndex(), k , 0)));
+                    .set("WORKER_ADDRESS", new SimulatorAddress(WORKER, agent.getAgentIndex(), k )));
         }
         return result;
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/registry/WorkerQueryTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/registry/WorkerQueryTest.java
@@ -25,8 +25,8 @@ public class WorkerQueryTest {
     @Before
     public void before() {
         list = new LinkedList<WorkerData>();
-        agent1 = new SimulatorAddress(AddressLevel.AGENT, 1, 0, 0);
-        agent2 = new SimulatorAddress(AddressLevel.AGENT, 2, 0, 0);
+        agent1 = new SimulatorAddress(AddressLevel.AGENT, 1, 0);
+        agent2 = new SimulatorAddress(AddressLevel.AGENT, 2, 0);
     }
 
     @Test
@@ -160,7 +160,7 @@ public class WorkerQueryTest {
 
     private WorkerParameters newParameters(SimulatorAddress agent, int workerIndex, String workerType, String versionSpec) {
         return new WorkerParameters()
-                .set("WORKER_ADDRESS", new SimulatorAddress(WORKER, agent.getAgentIndex(), workerIndex, 0))
+                .set("WORKER_ADDRESS", new SimulatorAddress(WORKER, agent.getAgentIndex(), workerIndex))
                 .set("WORKER_TYPE", workerType)
                 .set("VERSION_SPEC", versionSpec);
     }

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/core/AddressLevelTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/core/AddressLevelTest.java
@@ -22,11 +22,6 @@ public class AddressLevelTest {
         assertEquals(AddressLevel.WORKER, fromInt(AddressLevel.WORKER.toInt()));
     }
 
-    @Test
-    public void testFromInt_TEST() {
-        assertEquals(AddressLevel.TEST, fromInt(AddressLevel.TEST.toInt()));
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void testFromInt_tooLow() {
         fromInt(AddressLevel.getMinLevel() - 1);

--- a/simulator/src/test/java/com/hazelcast/simulator/protocol/core/SimulatorAddressTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/protocol/core/SimulatorAddressTest.java
@@ -10,34 +10,28 @@ import static org.junit.Assert.assertTrue;
 
 public class SimulatorAddressTest {
 
-    private final SimulatorAddress address = new SimulatorAddress(AddressLevel.TEST, 5, 6, 7);
-    private final SimulatorAddress addressSame = new SimulatorAddress(AddressLevel.TEST, 5, 6, 7);
+    private final SimulatorAddress workerAddress = new SimulatorAddress(AddressLevel.WORKER, 5, 6);
+    private final SimulatorAddress addressSame = new SimulatorAddress(AddressLevel.WORKER, 5, 6);
 
-    private final SimulatorAddress addressOtherAgent = new SimulatorAddress(AddressLevel.TEST, 9, 6, 7);
-    private final SimulatorAddress addressOtherWorker = new SimulatorAddress(AddressLevel.TEST, 5, 9, 7);
-    private final SimulatorAddress addressOtherTest = new SimulatorAddress(AddressLevel.TEST, 5, 6, 9);
+    private final SimulatorAddress addressOtherAgent = new SimulatorAddress(AddressLevel.WORKER, 9, 6);
+    private final SimulatorAddress addressOtherWorker = new SimulatorAddress(AddressLevel.WORKER, 5, 9);
 
-    private final SimulatorAddress addressAgentAddressLevel = new SimulatorAddress(AddressLevel.AGENT, 5, 6, 7);
-    private final SimulatorAddress addressWorkerAddressLevel = new SimulatorAddress(AddressLevel.WORKER, 5, 6, 7);
+    private final SimulatorAddress addressAgentAddressLevel = new SimulatorAddress(AddressLevel.AGENT, 5, 6);
+    private final SimulatorAddress addressWorkerAddressLevel = new SimulatorAddress(AddressLevel.WORKER, 5, 6);
 
     @Test
     public void testGetAddressLevel() {
-        assertEquals(AddressLevel.TEST, address.getAddressLevel());
+        assertEquals(AddressLevel.WORKER, workerAddress.getAddressLevel());
     }
 
     @Test
     public void testGetAgentIndex() {
-        assertEquals(5, address.getAgentIndex());
+        assertEquals(5, workerAddress.getAgentIndex());
     }
 
     @Test
     public void testGetWorkerIndex() {
-        assertEquals(6, address.getWorkerIndex());
-    }
-
-    @Test
-    public void testGetTestIndex() {
-        assertEquals(7, address.getTestIndex());
+        assertEquals(6, workerAddress.getWorkerIndex());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -57,7 +51,7 @@ public class SimulatorAddressTest {
 
     @Test
     public void testGetAddressIndex_fromTest() {
-        assertEquals(7, address.getAddressIndex());
+        assertEquals(6, workerAddress.getAddressIndex());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -77,27 +71,23 @@ public class SimulatorAddressTest {
 
     @Test
     public void getParent_fromTest() {
-        assertEquals(AddressLevel.WORKER, address.getParent().getAddressLevel());
+        assertEquals(AddressLevel.AGENT, workerAddress.getParent().getAddressLevel());
     }
 
     @Test
     public void getChild_fromCoordinator() {
-        assertEquals(new SimulatorAddress(AddressLevel.AGENT, 3, 0, 0), SimulatorAddress.COORDINATOR.getChild(3));
+        assertEquals(new SimulatorAddress(AddressLevel.AGENT, 3, 0), SimulatorAddress.COORDINATOR.getChild(3));
     }
 
     @Test
     public void getChild_fromAgent() {
-        assertEquals(new SimulatorAddress(AddressLevel.WORKER, 5, 9, 0), addressAgentAddressLevel.getChild(9));
+        assertEquals(new SimulatorAddress(AddressLevel.WORKER, 5, 9), addressAgentAddressLevel.getChild(9));
     }
 
-    @Test
-    public void getChild_fromWorker() {
-        assertEquals(new SimulatorAddress(AddressLevel.TEST, 5, 6, 2), addressWorkerAddressLevel.getChild(2));
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public void getChild_fromTest() {
-        address.getChild(1);
+        workerAddress.getChild(1);
     }
 
     @Test
@@ -107,7 +97,7 @@ public class SimulatorAddressTest {
 
     @Test
     public void containsWildcard_withAgent() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.AGENT, 1, 0, 0);
+        SimulatorAddress address = new SimulatorAddress(AddressLevel.AGENT, 1, 0);
         assertFalse(address.containsWildcard());
     }
 
@@ -118,19 +108,19 @@ public class SimulatorAddressTest {
 
     @Test
     public void containsWildcard_withWorker() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.WORKER, 1, 1, 0);
+        SimulatorAddress address = new SimulatorAddress(AddressLevel.WORKER, 1, 1);
         assertFalse(address.containsWildcard());
     }
 
     @Test
     public void containsWildcard_withWorker_withAgentWildcard() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.WORKER, 0, 1, 0);
+        SimulatorAddress address = new SimulatorAddress(AddressLevel.WORKER, 0, 1);
         assertTrue(address.containsWildcard());
     }
 
     @Test
     public void containsWildcard_withWorker_withWorkerWildcard() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.WORKER, 1, 0, 0);
+        SimulatorAddress address = new SimulatorAddress(AddressLevel.WORKER, 1, 0);
         assertTrue(address.containsWildcard());
     }
 
@@ -139,64 +129,33 @@ public class SimulatorAddressTest {
         assertTrue(SimulatorAddress.ALL_WORKERS.containsWildcard());
     }
 
-    @Test
-    public void containsWildcard_withTest() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.TEST, 1, 1, 1);
-        assertFalse(address.containsWildcard());
-    }
-
-    @Test
-    public void containsWildcard_withTest_withAgentWildcard() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.TEST, 0, 1, 1);
-        assertTrue(address.containsWildcard());
-    }
-
-    @Test
-    public void containsWildcard_withTest_withWorkerWildcard() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.TEST, 1, 0, 1);
-        assertTrue(address.containsWildcard());
-    }
-
-    @Test
-    public void containsWildcard_withTest_withTestWildcard() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.TEST, 1, 1, 0);
-        assertTrue(address.containsWildcard());
-    }
-
-    @Test
-    public void containsWildcard_withTest_withAllWildcards() {
-        SimulatorAddress address = new SimulatorAddress(AddressLevel.TEST, 0, 0, 0);
-        assertTrue(address.containsWildcard());
-    }
 
     @Test
     public void testEquals() {
-        assertEquals(address, address);
+        assertEquals(workerAddress, workerAddress);
 
-        assertNotEquals(address, null);
-        assertNotEquals(address, new Object());
+        assertNotEquals(workerAddress, null);
+        assertNotEquals(workerAddress, new Object());
 
-        assertNotEquals(address, addressOtherAgent);
-        assertNotEquals(address, addressOtherWorker);
-        assertNotEquals(address, addressOtherTest);
-        assertNotEquals(address, addressWorkerAddressLevel);
+        assertNotEquals(workerAddress, addressOtherAgent);
+        assertNotEquals(workerAddress, addressOtherWorker);
+        assertEquals(workerAddress, addressWorkerAddressLevel);
 
-        assertEquals(address, addressSame);
+        assertEquals(workerAddress, addressSame);
     }
 
     @Test
     public void testHashcode() {
-        assertNotEquals(address.hashCode(), addressOtherAgent.hashCode());
-        assertNotEquals(address.hashCode(), addressOtherWorker.hashCode());
-        assertNotEquals(address.hashCode(), addressOtherTest.hashCode());
-        assertNotEquals(address.hashCode(), addressWorkerAddressLevel.hashCode());
+        assertNotEquals(workerAddress.hashCode(), addressOtherAgent.hashCode());
+        assertNotEquals(workerAddress.hashCode(), addressOtherWorker.hashCode());
+        assertEquals(workerAddress.hashCode(), addressWorkerAddressLevel.hashCode());
 
-        assertEquals(address.hashCode(), addressSame.hashCode());
+        assertEquals(workerAddress.hashCode(), addressSame.hashCode());
     }
 
     @Test
     public void testToString() {
-        assertNotNull(address.toString());
+        assertNotNull(workerAddress.toString());
     }
 
     @Test
@@ -207,73 +166,37 @@ public class SimulatorAddressTest {
 
     @Test
     public void testFromString_singleAgent() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.AGENT, 5, 0, 0);
+        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.AGENT, 5, 0);
         assertToAndFromStringEquals(expectedAddress);
     }
 
     @Test
     public void testFromString_allAgents() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.AGENT, 0, 0, 0);
+        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.AGENT, 0, 0);
         assertToAndFromStringEquals(expectedAddress);
     }
 
     @Test
     public void testFromString_singleAgent_singleWorker() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 3, 7, 0);
+        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 3, 7);
         assertToAndFromStringEquals(expectedAddress);
     }
 
     @Test
     public void testFromString_singleAgent_allWorkers() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 3, 0, 0);
+        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 3, 0);
         assertToAndFromStringEquals(expectedAddress);
     }
 
     @Test
     public void testFromString_allAgents_singleWorker() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 0, 8, 0);
+        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 0, 8);
         assertToAndFromStringEquals(expectedAddress);
     }
 
     @Test
     public void testFromString_allAgents_allWorkers() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 0, 0, 0);
-        assertToAndFromStringEquals(expectedAddress);
-    }
-
-    @Test
-    public void testFromString_singleAgent_singleWorker_singleTest() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.TEST, 3, 2, 6);
-        assertToAndFromStringEquals(expectedAddress);
-    }
-
-    @Test
-    public void testFromString_singleAgent_singleWorker_allTests() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.TEST, 3, 2, 0);
-        assertToAndFromStringEquals(expectedAddress);
-    }
-
-    @Test
-    public void testFromString_singleAgent_allWorkers_singleTest() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.TEST, 9, 0, 3);
-        assertToAndFromStringEquals(expectedAddress);
-    }
-
-    @Test
-    public void testFromString_singleAgent_allWorkers_allTests() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.TEST, 9, 0, 0);
-        assertToAndFromStringEquals(expectedAddress);
-    }
-
-    @Test
-    public void testFromString_allAgents_allWorkers_singleTest() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.TEST, 0, 0, 17);
-        assertToAndFromStringEquals(expectedAddress);
-    }
-
-    @Test
-    public void testFromString_allAgents_allWorkers_allTests() {
-        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.TEST, 0, 0, 108);
+        SimulatorAddress expectedAddress = new SimulatorAddress(AddressLevel.WORKER, 0, 0);
         assertToAndFromStringEquals(expectedAddress);
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerTest.java
@@ -18,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.hazelcast.simulator.TestEnvironmentUtils.localResourceDirectory;
@@ -54,7 +53,7 @@ public class WorkerTest {
                 .setAgents(registry.getAgents())
                 .setAll(properties.asPublicMap())
                 .set("CONFIG", fileAsText(localResourceDirectory() + "/hazelcast.xml"));
-        workerAddress = new SimulatorAddress(AddressLevel.WORKER, AGENT_INDEX, WORKER_INDEX, 0);
+        workerAddress = new SimulatorAddress(AddressLevel.WORKER, AGENT_INDEX, WORKER_INDEX);
 
         parameters = driver.loadWorkerParameters("member")
                 .set("WORKER_ADDRESS", workerAddress)


### PR DESCRIPTION
Tests  addressing isn't needed. The coordinator decided which workers are going to get a requests and tests worker addressing is lowest level of addressing needed. Inside the worker it is just a test id.

fix #1418