### PR TITLE
Set coordinator file encoding to UTF8

### DIFF
--- a/dist/src/main/dist/bin/coordinator
+++ b/dist/src/main/dist/bin/coordinator
@@ -9,5 +9,6 @@ export JAVA_OPTS="-server -Xmx1g -Xms256m ${JAVA_EXTRA_OPTS}"
 java -cp "${SIMULATOR_HOME}/lib/*:${SIMULATOR_HOME}/test-lib/ignite/*:${SIMULATOR_HOME}/test-lib/infinispan/*" ${JAVA_OPTS} \
     -DSIMULATOR_HOME=${SIMULATOR_HOME} \
     -Dhazelcast.logging.type=log4j \
+    -Dfile.encoding=UTF8 \
     -Dlog4j.configuration=file:${SIMULATOR_HOME}/conf/coordinator-log4j.xml \
     com.hazelcast.simulator.coordinator.CoordinatorCli "$@"


### PR DESCRIPTION
Otherwise, when printing performance numbers to stdout under a different encoding (like `ANSI_X3.4-1968` in my case)  __?__ can be seen instead of  __&#181;__
Example:
` 1,007,825 ops   100,651.65 ops/s         45 ? (avg)        155 ? (99.9th)     11,239 ? (max)`