### PR TITLE
Fixed resource file convertion to text

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
@@ -92,8 +92,8 @@ class Wizard {
         echo("Will create working directory '%s' for cloud provider '%s'", workDir, cloudProvider);
         ensureExistingDirectory(workDir);
 
-        copyResourceFile(workDir, "run", "runScript");
-        copyResourceFile(workDir, "test.properties", "testSuite");
+        copyResourceFile(workDir, "runScript", "run");
+        copyResourceFile(workDir, "testSuite", "test.properties");
 
         if (isLocal(cloudProvider)) {
             return;
@@ -115,9 +115,9 @@ class Wizard {
         }
 
         if (isStatic(cloudProvider)) {
-            copyResourceFile(workDir, "prepare", "prepareScriptStatic");
+            copyResourceFile(workDir, "prepareScriptStatic", "prepare");
         } else {
-            copyResourceFile(workDir, "prepare", "prepareScriptCloud");
+            copyResourceFile(workDir, "prepareScriptCloud", "prepare");
         }
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/WizardUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/WizardUtils.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
 import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingFile;
-import static com.hazelcast.simulator.utils.FileUtils.getResourceFile;
+import static com.hazelcast.simulator.utils.FileUtils.toTextFromResourceFile;
 import static com.hazelcast.simulator.utils.FileUtils.writeText;
 import static com.hazelcast.simulator.utils.NativeUtils.execute;
 import static java.lang.String.format;
@@ -43,9 +43,9 @@ final class WizardUtils {
     private WizardUtils() {
     }
 
-    static void copyResourceFile(File workDir, String targetName, String sourceName) {
-        File runScript = ensureExistingFile(workDir, targetName);
-        writeText(getResourceFile(sourceName), runScript);
+    static void copyResourceFile(File workDir, String sourceFileName, String destinationFileName) {
+        File runScript = ensureExistingFile(workDir, destinationFileName);
+        writeText(toTextFromResourceFile(sourceFileName), runScript);
         execute(format("chmod u+x %s", runScript.getAbsolutePath()));
     }
 


### PR DESCRIPTION
After running `simulator-wizard --createWorkDir tests`, content of `run` file is like this:
```
/home/ahmet/simulator/file:/home/ahmet/simulator/hazelcast-simulator-0.10-SNAPSHOT/lib/simulator-0.10-SNAPSHOT.jar!/runScript
```

Instead of file path, `run` file should be a copy of `runScript`.  This pr fixes that problem by copying actual content of `runScript` to `run` file.

Additionally order of parameters for`copyResourceFile` method is changed to make it easier to read.