### PR TITLE
Added hook later in constructor otherwise NPE can be seen in hook exe…

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -58,7 +58,6 @@ public class Agent implements Closeable {
         SimulatorAddress agentAddress = agentAddress(addressIndex);
 
         this.publicAddress = publicAddress;
-        Runtime.getRuntime().addShutdownHook(new AgentShutdownThread(true));
 
         this.broker = new Broker()
                 .setBrokerAddress(localIp(), port);
@@ -77,6 +76,8 @@ public class Agent implements Closeable {
                 processManager, workerLastSeenTimeoutSeconds);
 
         server.setProcessor(new AgentOperationProcessor(processManager, workerProcessFailureMonitor));
+
+        Runtime.getRuntime().addShutdownHook(new AgentShutdownThread(true));
     }
 
     private void createPidFile() {


### PR DESCRIPTION
…cution

For example: 
`processManager` can be null in `AgentShutdownThread` if `localIp` throws an exception in `Agent` construtor.