### PR TITLE
Fix problem with multiple runs and same sesion id

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java
@@ -29,7 +29,7 @@ import com.hazelcast.simulator.coordinator.registry.TestData;
 import com.hazelcast.simulator.coordinator.registry.WorkerData;
 import com.hazelcast.simulator.coordinator.registry.WorkerQuery;
 import com.hazelcast.simulator.coordinator.tasks.DownloadTask;
-import com.hazelcast.simulator.coordinator.tasks.InstallUploadDirTask;
+import com.hazelcast.simulator.coordinator.tasks.PrepareSessionTask;
 import com.hazelcast.simulator.coordinator.tasks.KillWorkersTask;
 import com.hazelcast.simulator.coordinator.tasks.RunTestSuiteTask;
 import com.hazelcast.simulator.coordinator.tasks.StartWorkersTask;
@@ -113,7 +113,7 @@ public class Coordinator implements Closeable {
 
         startClient();
 
-        new InstallUploadDirTask(
+        new PrepareSessionTask(
                 publicAddresses(registry.getAgents()),
                 simulatorProperties.asMap(),
                 new File(System.getProperty("user.dir"), "upload").getAbsoluteFile(),

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/PrepareSessionTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/PrepareSessionTask.java
@@ -25,20 +25,22 @@ import static com.hazelcast.simulator.utils.FileUtils.getConfigurationFile;
 import static com.hazelcast.simulator.utils.FormatUtils.join;
 
 /**
- * Uploads the 'upload' directory
+ * Prepares the session on the remote machines.
  *
- * The real work is done by the 'upload.sh' script.
+ * This includes creating the session directory, uploading the 'uploads' directory.
+ *
+ * The real work is done by the 'prepare_session.sh' script.
  */
-public class InstallUploadDirTask {
+public class PrepareSessionTask {
     private final List<String> agents;
     private final Map<String, String> simulatorProperties;
     private final File uploadDir;
     private final String sessionId;
 
-    public InstallUploadDirTask(List<String> agents,
-                                Map<String, String> simulatorProperties,
-                                File uploadDir,
-                                String sessionId) {
+    public PrepareSessionTask(List<String> agents,
+                              Map<String, String> simulatorProperties,
+                              File uploadDir,
+                              String sessionId) {
         this.agents = agents;
         this.simulatorProperties = simulatorProperties;
         this.uploadDir = uploadDir;
@@ -46,7 +48,7 @@ public class InstallUploadDirTask {
     }
 
     public void run() {
-        String installFile = getConfigurationFile("upload.sh").getAbsolutePath();
+        String installFile = getConfigurationFile("prepare_session.sh").getAbsolutePath();
         String agentIps = join(agents, ",");
         new BashCommand(installFile)
                 .addEnvironment(simulatorProperties)


### PR DESCRIPTION
The problem was that the old session directory on the remote machines wasn't deleted and
therefor the old files were causing problems.

fix #1584