### PR TITLE
Fixes orphan worker problem

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -307,6 +307,13 @@ WORKER_PING_INTERVAL_SECONDS = 60
 MEMBER_WORKER_SHUTDOWN_DELAY_SECONDS = 5
 
 #
+# The frequency the worker should check if the agent it belongs to is still running. This prevents ending up with
+# workers that don't have a running agent
+# If set to 0, there is no check
+#
+WORKER_ORPHAN_INTERVAL_SECONDS=5
+
+#
 # Timeout to wait for Worker shutdown
 #
 # Defines the timeout for the Worker shutdown in the Coordinator. After the timeout occurred the Coordinator will

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/Agent.java
@@ -33,8 +33,7 @@ import static com.hazelcast.simulator.protocol.core.SimulatorAddress.agentAddres
 import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
 import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
 import static com.hazelcast.simulator.utils.FileUtils.getUserDir;
-import static com.hazelcast.simulator.utils.FileUtils.writeText;
-import static com.hazelcast.simulator.utils.NativeUtils.getPID;
+import static com.hazelcast.simulator.utils.NativeUtils.writePid;
 import static com.hazelcast.simulator.utils.SimulatorUtils.localIp;
 
 public class Agent implements Closeable {
@@ -80,10 +79,6 @@ public class Agent implements Closeable {
         Runtime.getRuntime().addShutdownHook(new AgentShutdownThread(true));
     }
 
-    private void createPidFile() {
-        deleteQuiet(pidFile);
-        writeText("" + getPID(), pidFile);
-    }
 
     public String getPublicAddress() {
         return publicAddress;
@@ -108,7 +103,7 @@ public class Agent implements Closeable {
 
         LOGGER.info("Agent started!");
 
-        createPidFile();
+        writePid(pidFile);
     }
 
     @Override

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
@@ -15,9 +15,15 @@
  */
 package com.hazelcast.simulator.agent.workerprocess;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+
+import static com.hazelcast.simulator.utils.FileUtils.fileAsText;
 
 /**
  * Parameters for a (single) Simulator Worker Process.
@@ -25,6 +31,14 @@ import java.util.Set;
 public class WorkerParameters {
 
     private final Map<String, String> map = new HashMap<String, String>();
+
+    public WorkerParameters() {
+    }
+
+    public WorkerParameters(Map<String, String> map) {
+        this.map.putAll(map);
+    }
+
 
     public Map<String, String> asMap() {
         return map;
@@ -59,5 +73,16 @@ public class WorkerParameters {
     @Override
     public String toString() {
         return "WorkerParameters" + map;
+    }
+
+    public static WorkerParameters loadParameters(File parametersFile) throws IOException {
+        Properties p = new Properties();
+        p.load(new StringReader(fileAsText(parametersFile)));
+
+        Map<String, String> properties = new HashMap<String, String>();
+        for (Map.Entry<Object, Object> entry : p.entrySet()) {
+            properties.put("" + entry.getKey(), "" + entry.getValue());
+        }
+        return new WorkerParameters(properties);
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManager.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.hazelcast.simulator.common.FailureType.WORKER_CREATE_ERROR;
 import static com.hazelcast.simulator.protocol.core.SimulatorAddress.workerAddress;
+import static com.hazelcast.simulator.utils.NativeUtils.getPID;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.log4j.Level.DEBUG;
@@ -66,8 +67,13 @@ public class WorkerProcessManager {
 
     // launching is done asynchronous so we don't block the calling thread (messaging thread)
     public void launch(CreateWorkerOperation op, Promise promise) throws Exception {
-        WorkerProcessLauncher launcher = new WorkerProcessLauncher(WorkerProcessManager.this, op.getWorkerParameters());
-        LaunchSingleWorkerTask task = new LaunchSingleWorkerTask(launcher, op.getWorkerParameters(), promise);
+        WorkerParameters workerParameters = op.getWorkerParameters();
+
+        // we add the pid to the worker-parameters so the worker can check if the agent is still alive.
+        workerParameters.set("agent.pid", getPID());
+
+        WorkerProcessLauncher launcher = new WorkerProcessLauncher(WorkerProcessManager.this, workerParameters);
+        LaunchSingleWorkerTask task = new LaunchSingleWorkerTask(launcher, workerParameters, promise);
         executorService.schedule(task, op.getDelayMs(), MILLISECONDS);
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/NativeUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/NativeUtils.java
@@ -17,9 +17,13 @@ package com.hazelcast.simulator.utils;
 
 import org.apache.log4j.Logger;
 
+import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.List;
+
+import static com.hazelcast.simulator.utils.FileUtils.deleteQuiet;
+import static com.hazelcast.simulator.utils.FileUtils.writeText;
 
 public final class NativeUtils {
 
@@ -88,7 +92,7 @@ public final class NativeUtils {
 
     static Integer getPidViaReflection() {
         try {
-            java.lang.management.RuntimeMXBean runtime = java.lang.management.ManagementFactory.getRuntimeMXBean();
+            RuntimeMXBean runtime = java.lang.management.ManagementFactory.getRuntimeMXBean();
             java.lang.reflect.Field jvm = runtime.getClass().getDeclaredField("jvm");
             jvm.setAccessible(true);
             sun.management.VMManagement management = (sun.management.VMManagement) jvm.get(runtime);
@@ -100,5 +104,11 @@ public final class NativeUtils {
             LOGGER.warn(e);
             return null;
         }
+    }
+
+    public static File writePid(File pidFile) {
+        deleteQuiet(pidFile);
+        writeText("" + getPID(), pidFile);
+        return pidFile;
     }
 }

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/WorkerTest.java
@@ -91,7 +91,7 @@ public class WorkerTest {
 
     @Test
     public void testStartWorker() throws Exception {
-        worker = new Worker(parameters.asMap());
+        worker = new Worker(parameters);
         worker.start();
         assertEquals(PUBLIC_ADDRESS, worker.getPublicIpAddress());
     }


### PR DESCRIPTION
The worker check if the agent is still alive. This is done by adding the
agent.pid to the worker parameters and the worker periodically checking if
the agent is still running.