### PR TITLE
Fixes orphan process problem

### DIFF
--- a/dist/src/main/dist/conf/agent_start.sh
+++ b/dist/src/main/dist/conf/agent_start.sh
@@ -52,7 +52,7 @@ start_local(){
     rm agent.out || true
     rm agent.err || true
 
-    args="--addressIndex 1 --publicAddress 127.0.0.1 --port $AGENT_PORT"
+    args="--addressIndex 1 --publicAddress 127.0.0.1 --port $AGENT_PORT --parentPid $parentPid"
 
     nohup $SIMULATOR_HOME/bin/agent $args > agent.out 2> agent.err < /dev/null &
 

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/AgentCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/AgentCli.java
@@ -54,6 +54,11 @@ public final class AgentCli {
             "Timeout value for worker timeout detection.")
             .withRequiredArg().ofType(Integer.class).defaultsTo(DEFAULT_WORKER_LAST_SEEN_TIMEOUT_SECONDS);
 
+    private final OptionSpec<String> parentPidSpec = parser.accepts("parentPid",
+            "The parentPid. Useful if the agent needs to terminate itself when the parent process has terminated. "
+                    + "Only makes sense to be used for local instance.")
+            .withRequiredArg().ofType(String.class);
+
     private final OptionSet options;
 
     AgentCli(String[] args) {
@@ -76,7 +81,10 @@ public final class AgentCli {
         }
         int port = options.valueOf(portSpec);
         int workerLastSeenTimeoutSeconds = options.valueOf(workerLastSeenTimeoutSecondsSpec);
-        this.agent = new Agent(addressIndex, publicAddress, port, workerLastSeenTimeoutSeconds);
+
+        String parentPid = options.valueOf(parentPidSpec);
+
+        this.agent = new Agent(addressIndex, publicAddress, port, workerLastSeenTimeoutSeconds, parentPid);
     }
 
     private static void logHeader() {

--- a/simulator/src/main/java/com/hazelcast/simulator/common/ProcessSuicideThread.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/ProcessSuicideThread.java
@@ -55,7 +55,7 @@ public final class ProcessSuicideThread extends Thread {
                 try {
                     bashCommand.execute();
                 } catch (Exception e) {
-                    String msg = "Worker terminating; agent with pid [" + parentPid + "] is not alive";
+                    String msg = "Process terminating; parent process with pid [" + parentPid + "] is not alive";
                     LOGGER.error(msg);
                     System.err.println(msg);
                     System.exit(1);

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/AgentUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/AgentUtils.java
@@ -18,6 +18,7 @@ package com.hazelcast.simulator.coordinator;
 import com.hazelcast.simulator.common.SimulatorProperties;
 import com.hazelcast.simulator.coordinator.registry.Registry;
 import com.hazelcast.simulator.utils.BashCommand;
+import com.hazelcast.simulator.utils.NativeUtils;
 
 import static com.hazelcast.simulator.coordinator.registry.AgentData.publicAddressesString;
 import static com.hazelcast.simulator.utils.FileUtils.getConfigurationFile;
@@ -42,6 +43,7 @@ public final class AgentUtils {
                 .ensureJavaOnPath()
                 .addParams(publicAddressesString(registry))
                 .addEnvironment(properties.asMap())
+                .addEnvironment("parentPid", NativeUtils.getPID())
                 .execute();
     }
 

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunMonolithTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorRunMonolithTest.java
@@ -47,7 +47,7 @@ public class CoordinatorRunMonolithTest {
                 .setSimulatorProperties(simulatorProperties)
                 .setSkipShutdownHook(true);
 
-        agent = new Agent(1, "127.0.0.1", simulatorProperties.getAgentPort(), 60);
+        agent = new Agent(1, "127.0.0.1", simulatorProperties.getAgentPort(), 60, null);
         agent.start();
 
         registry = new Registry();

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorTest.java
@@ -63,7 +63,7 @@ public class CoordinatorTest {
                 .setSimulatorProperties(simulatorProperties)
                 .setSkipShutdownHook(true);
 
-        agent = new Agent(1, "127.0.0.1", simulatorProperties.getAgentPort(), 60);
+        agent = new Agent(1, "127.0.0.1", simulatorProperties.getAgentPort(), 60, null);
         agent.start();
 
         registry = new Registry();


### PR DESCRIPTION
Agents/workers can keep dangling if the coordinator process is killed. This is
especially a problem if the process is run from the IDE.

To solve this problem the agent had the pid of the parent process (for local
setups) and the workers the pid of their agent. If they see that the parent process
is offline by using this parent pid, they terminate themselves.

fix #1598