### PR TITLE
Warmup and cooldown simplification.

### DIFF
--- a/simulator-boot/src/main/java/com/hazelcast/simulator/boot/Options.java
+++ b/simulator-boot/src/main/java/com/hazelcast/simulator/boot/Options.java
@@ -23,17 +23,16 @@ import com.hazelcast.simulator.common.TestCase;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.simulator.utils.SimulatorUtils.loadSimulatorProperties;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class Options {
     final SimulatorProperties simulatorProperties = loadSimulatorProperties();
     final Set<String> ignoredClasspath = new HashSet<String>();
     int memberCount = 1;
     int clientCount;
-    long durationSeconds = TimeUnit.MINUTES.toSeconds(1);
-    long warmupSeconds;
+    long durationSeconds = MINUTES.toSeconds(1);
     String memberArgs = "";
     String clientArgs = "";
     Config memberConfig;

--- a/simulator-boot/src/main/java/com/hazelcast/simulator/boot/OptionsBuilder.java
+++ b/simulator-boot/src/main/java/com/hazelcast/simulator/boot/OptionsBuilder.java
@@ -137,19 +137,6 @@ public class OptionsBuilder {
         return duration(durationSeconds, SECONDS);
     }
 
-    public OptionsBuilder warmup(long warmupDuration, TimeUnit timeUnit) {
-        if (warmupDuration < 0) {
-            throw new IllegalArgumentException("warmupDuration can't be smaller than 0");
-        }
-
-        this.options.warmupSeconds = timeUnit.toSeconds(warmupDuration);
-        return this;
-    }
-
-    public OptionsBuilder warmupSeconds(long warmupSeconds) {
-        return warmup(warmupSeconds, SECONDS);
-    }
-
     public OptionsBuilder memberCount(int memberCount) {
         if (memberCount < 0) {
             throw new IllegalArgumentException("memberCount can't be smaller than 0");

--- a/simulator-boot/src/main/java/com/hazelcast/simulator/boot/Runner.java
+++ b/simulator-boot/src/main/java/com/hazelcast/simulator/boot/Runner.java
@@ -174,7 +174,6 @@ public class Runner {
     private TestSuite newTestSuite() {
         return new TestSuite()
                 .addTest(options.testCase)
-                .setWarmupSeconds((int) options.warmupSeconds)
                 .setDurationSeconds((int) options.durationSeconds)
                 .setWorkerQuery(new WorkerQuery()
                         .setTargetType(TargetType.PREFER_CLIENT));

--- a/simulator/src/main/java/com/hazelcast/simulator/common/TestCase.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/TestCase.java
@@ -39,8 +39,6 @@ public class TestCase implements Serializable {
 
     public TestCase(String id, Map<String, String> properties) {
         this.id = checkNotNull(id, "id can't be null");
-        // make sure that warmupSeconds is always set
-        setWarmupMillis(0);
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             setProperty(entry.getKey(), entry.getValue());
         }
@@ -56,14 +54,6 @@ public class TestCase implements Serializable {
 
     public String getClassname() {
         return properties.get("class");
-    }
-
-    public void setWarmupMillis(long warmupSeconds) {
-        setProperty("warmupMillis", warmupSeconds);
-    }
-
-    public long getWarmupMillis() {
-        return Long.parseLong(properties.get("warmupMillis"));
     }
 
     public String getProperty(String name) {

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -79,12 +79,6 @@ final class CoordinatorCli {
                     + "the test will run until the test decides to stop.")
             .withRequiredArg().ofType(String.class).defaultsTo(format("%ds", DEFAULT_DURATION_SECONDS));
 
-    private final OptionSpec<String> warmupSpec = parser.accepts("warmup",
-            "Amount of time for the warmup period. During the warmup period no throughput/latency metrics are tracked."
-                    + "This can be used to give the JIT the time to warmup etc. So if you have a duration of 180 seconds, "
-                    + "and a warmup of 30 seconds, only for the last 150 seconds of the run performance information is tracked.")
-            .withRequiredArg().ofType(String.class).defaultsTo("0s");
-
     private final OptionSpec<Integer> membersSpec = parser.accepts("members",
             "Number of cluster member Worker JVMs. If no value is specified and no mixed members are specified,"
                     + " then the number of cluster members will be equal to the number of machines in the agents file.")
@@ -270,13 +264,8 @@ final class CoordinatorCli {
         }
 
         int durationSeconds = getDurationSeconds(options, durationSpec);
-        int warmupSeconds = getDurationSeconds(options, warmupSpec);
-        if (durationSeconds != 0 && warmupSeconds > durationSeconds) {
-            throw new CommandLineExitException("warmup can't be larger than duration");
-        }
 
         testSuite.setDurationSeconds(durationSeconds)
-                .setWarmupSeconds(warmupSeconds)
                 .setFailFast(options.valueOf(failFastSpec))
                 .setVerifyEnabled(options.valueOf(verifyEnabledSpec))
                 .setParallel(options.has(parallelSpec))

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorRemoteCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorRemoteCli.java
@@ -256,9 +256,6 @@ public final class CoordinatorRemoteCli implements Closeable {
                         + "\tsetup\n"
                         + "\tlocal prepare\n"
                         + "\tglobal prepare\n"
-                        + "\twarmup\n"
-                        + "\tlocal after warmup\n"
-                        + "\tglobal after warmup\n"
                         + "\trun\n"
                         + "\tglobal verify\n"
                         + "\tlocal verify\n"
@@ -299,7 +296,7 @@ public final class CoordinatorRemoteCli implements Closeable {
         static final String NAME = "test-stop";
 
         private final String help =
-                "Ask a test to stop its warmup or running phase. It is especially useful for tests that run without a\n"
+                "Ask a test to stop its running phase. It is especially useful for tests that run without a\n"
                         + "duration.\n"
                         + "This commands waits for the test to complete and returns the result status of the test\n"
                         + " ('completed' for success)\n"
@@ -715,11 +712,6 @@ public final class CoordinatorRemoteCli implements Closeable {
                         + "the test will run until the test decides to stop.")
                 .withRequiredArg().ofType(String.class).defaultsTo(format("%ds", DEFAULT_DURATION_SECONDS));
 
-        final OptionSpec<String> warmupSpec = parser.accepts("warmup",
-                "Amount of time to execute the warmup per test, e.g. 10s, 1m, 2h or 3d. If warmup is set to 0, "
-                        + "the test will warmup until the test decides to stop.")
-                .withRequiredArg().ofType(String.class).defaultsTo(format("%ds", 0));
-
         final OptionSpec<TargetType> targetTypeSpec = parser.accepts("targetType",
                 format("Defines the type of Workers which execute the RUN phase."
                         + " The type PREFER_CLIENT selects client Workers if they are available, member Workers otherwise."
@@ -761,21 +753,12 @@ public final class CoordinatorRemoteCli implements Closeable {
             LOGGER.info("File: " + testSuiteFile);
 
             int durationSeconds = getDurationSeconds(options, durationSpec);
-            int warmupSeconds = getDurationSeconds(options, warmupSpec);
-            if (durationSeconds != 0 && warmupSeconds > durationSeconds) {
-                throw new CommandLineExitException("warmup can't be larger than duration");
-            }
             TestSuite suite = new TestSuite(testSuiteFile)
                     .setDurationSeconds(durationSeconds)
-                    .setWarmupSeconds(warmupSeconds)
                     .setWorkerQuery(newQuery())
                     .setParallel(options.has(parallelSpec))
                     .setVerifyEnabled(options.valueOf(verifyEnabledSpec))
                     .setFailFast(options.valueOf(failFastSpec));
-
-            if (options.has(warmupSpec)) {
-                suite.setWarmupSeconds(getDurationSeconds(options, warmupSpec));
-            }
 
             LOGGER.info("Running testSuite: " + testSuiteFile.getAbsolutePath());
             return new RcTestRunOperation(suite, isAsync(), newQuery());
@@ -802,8 +785,8 @@ public final class CoordinatorRemoteCli implements Closeable {
                 + "coordinator-remote test-run\n\n"
                 + "# runs atomiclong.properties for 1 minute\n"
                 + "coordinator-remote test-run atomiclong.properties\n\n"
-                + "# runs a test with a warmup period of 5 minute and a duration of 1 hour\n"
-                + "coordinator-remote test-run --warmup 5m --duration 1h\n\n"
+                + "# runs a test with duration of 1 hour\n"
+                + "coordinator-remote test-run --duration 1h\n\n"
                 + "# runs a test by running all tests in the suite in parallel for 10m.\n"
                 + "coordinator-remote test-run --duration 10m --parallel suite.properties\n\n"
                 + "# run a test but disable the verification\n"
@@ -847,8 +830,8 @@ public final class CoordinatorRemoteCli implements Closeable {
                 + "coordinator-remote test-start\n\n"
                 + "# runs atomiclong.properties for 1 minute\n"
                 + "coordinator-remote test-start atomiclong.properties\n\n"
-                + "# runs a test with a warmup period of 5 minute and a duration of 1 hour\n"
-                + "coordinator-remote test-start --warmup 5m --duration 1h\n\n"
+                + "# runs a test with a duration of 1 hour\n"
+                + "coordinator-remote test-start --duration 1h\n\n"
                 + "# runs a test by running all tests in the suite in parallel for 10m.\n"
                 + "coordinator-remote test-start --duration 10m --parallel suite.properties\n\n"
                 + "# run a test but disable the verification\n"

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestCaseRunner.java
@@ -243,14 +243,7 @@ public final class TestCaseRunner {
             durationMs = Long.MAX_VALUE;
         } else {
             durationMs = SECONDS.toMillis(durationSeconds);
-            long warmupSeconds = MILLISECONDS.toSeconds(testCase.getWarmupMillis());
-            if (warmupSeconds > 0) {
-                log(format("Test will run for %s with a warmup period of %s",
-                        secondsToHuman(durationSeconds),
-                        secondsToHuman(warmupSeconds)));
-            } else {
-                log(format("Test will run for %s without warmup", secondsToHuman(durationSeconds)));
-            }
+            log(format("Test will run for %s", secondsToHuman(durationSeconds)));
             timeoutMs = startMs + durationMs;
         }
 
@@ -299,10 +292,7 @@ public final class TestCaseRunner {
     private void logFinalPerformanceInfo(long startMs) {
         // the running time of the test is current time minus the start time. We can't rely on testsuite duration
         // due to premature abortion of a test. Or if the test has no explicit duration configured
-        long durationWithWarmupMillis = currentTimeMillis() - startMs;
-
-        // then we need to subtract the warmup.
-        long durationMillis = durationWithWarmupMillis - testCase.getWarmupMillis();
+        long durationMillis = currentTimeMillis() - startMs;
 
         if (performanceMonitorIntervalSeconds > 0) {
             LOGGER.info(testCase.getId() + " Waiting for all performance info");

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestSuite.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/TestSuite.java
@@ -32,7 +32,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static com.hazelcast.simulator.utils.CommonUtils.rethrow;
@@ -171,13 +170,6 @@ public class TestSuite implements Serializable {
 
     public TestSuite addTest(TestCase testCase) {
         testCaseList.add(testCase);
-        return this;
-    }
-
-    public TestSuite setWarmupSeconds(long warmupSeconds) {
-        for (TestCase testCase : testCaseList) {
-            testCase.setWarmupMillis(TimeUnit.SECONDS.toMillis(warmupSeconds));
-        }
         return this;
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/test/annotations/TimeStep.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/annotations/TimeStep.java
@@ -157,7 +157,7 @@ import java.lang.annotation.Target;
  *     producerIterations=1000000
  * }
  * </pre>
- * In this example the producer has a configured number of iterations for warmup and running, the consumer has no such limitation.
+ * In this example the producer has a configured number of iterations for running, the consumer has no such limitation.
  *
  * <h1>Stopping a timestep thread</h1>
  * A Timestep thread can also stop itself by throwing the {@link com.hazelcast.simulator.test.StopException}. This doesn't lead
@@ -197,7 +197,7 @@ import java.lang.annotation.Target;
  * but that doesn't need to mean completion of the async call.
  *
  * <h1>Logging</h1>
- * By default a timestep based thread will not log anything during the run/warmup period. But sometimes some logging is required,
+ * By default a timestep based thread will not log anything during the run period. But sometimes some logging is required,
  * e.g. when needing to do some debugging. There are 2 out of the box options for logging:
  * <ol>
  * <li>frequency based: e.g. every 1000th iteration</li>

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
@@ -82,7 +82,6 @@ public class PropertyBinding {
         this.testCase = testCase;
         this.unusedProperties.addAll(testCase.getProperties().keySet());
         unusedProperties.remove("class");
-        unusedProperties.remove("warmupMillis");
 
         bind(this);
 

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/RunStrategy.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/RunStrategy.java
@@ -42,7 +42,7 @@ abstract class RunStrategy {
     }
 
     /**
-     * Checks if the run strategy is running. This is true in case of warmup and actual running.
+     * Checks if the run strategy is running the test.
      *
      * This method is thread-safe.
      *

--- a/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/coordinator/CoordinatorCliTest.java
@@ -243,33 +243,6 @@ public class CoordinatorCliTest {
     }
 
     @Test
-    public void testInit_warmup() {
-        args.add("--duration");
-        args.add("10s");
-        args.add("--warmup");
-        args.add("5s");
-        args.add(testSuiteFile.getAbsolutePath());
-
-        CoordinatorCli cli = createCoordinatorCli();
-
-        TestSuite testSuite = cli.testSuite;
-        assertEquals(10, testSuite.getDurationSeconds());
-        assertEquals(5000, testSuite.getTestCaseList().get(0).getWarmupMillis());
-    }
-
-    @Test
-    public void testInit_warmup_withZero() {
-        args.add("--warmup");
-        args.add("0s");
-        args.add(testSuiteFile.getAbsolutePath());
-
-        CoordinatorCli cli = createCoordinatorCli();
-
-        TestSuite testSuite = cli.testSuite;
-        assertEquals(0, testSuite.getTestCaseList().get(0).getWarmupMillis());
-    }
-
-    @Test
     public void testInit_waitForDuration() {
         args.add("--duration");
         args.add("42s");


### PR DESCRIPTION
So instead of getting the warmup/cooldown integrated in the coordinator and add complexity to the whole system,the warmup and cooldown is just a reporting issue. So by specifying a warmup/cooldown period the beginning and end of the performance data is cut off.