### PR TITLE
Cleanup in call to CoordinatorClient.invokeAll(agents,..)

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/StartWorkersTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/StartWorkersTask.java
@@ -85,7 +85,7 @@ public class StartWorkersTask {
         // then create all clients
         startWorkers(clientDeploymentPlan);
 
-        client.invokeAll(registry.getAgents(), new StartTimeoutDetectionOperation(), MINUTES.toMillis(1));
+        client.invokeOnAllAgents(new StartTimeoutDetectionOperation(), MINUTES.toMillis(1));
 
         echoStartComplete();
         return result;

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/TerminateWorkersTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/TerminateWorkersTask.java
@@ -74,7 +74,7 @@ public class TerminateWorkersTask {
 
         LOGGER.info(format("Terminating %d Workers...", currentWorkerCount));
 
-        client.invokeAll(registry.getAgents(), new StopTimeoutDetectionOperation(), MINUTES.toMillis(1));
+        client.invokeOnAllAgents(new StopTimeoutDetectionOperation(), MINUTES.toMillis(1));
 
         // prevent any failures from being printed due to killing the members.
         Set<WorkerData> clients = new HashSet<WorkerData>();


### PR DESCRIPTION
Since the agent info is available locally anyway, no need to pass it as argument.