### PR TITLE
Timestamp recording

### DIFF
--- a/dist/src/main/dist/conf/record_timestamp.sh
+++ b/dist/src/main/dist/conf/record_timestamp.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Record timestamps when a benchmark is starting/stopping
+# On each agent we want to know the exact time a benchmark is entering its 'running' phase and when it completes.
+# This way we can filter out data e.g. from dstat, that is recording during preparation, verification etc.
+# This is done by making a file
+
+# exit on failure
+set -e
+
+# comma separated list of agent ip addresses
+agents=$1
+session_id=$2
+test_id=$3
+label=$4
+
+record_timestamp_local(){
+    echo $label=$(date +%s)>> ${SIMULATOR_HOME}/workers/${session_id}/A1_${test_id}.time
+}
+
+record_timestamp_remote(){
+    agent=$1
+    agent_index=$2
+    cmd='$(date +%s)'
+    ssh ${SSH_OPTIONS} ${SIMULATOR_USER}@${agent} \
+        "echo $label=$cmd >> hazelcast-simulator-$SIMULATOR_VERSION/workers/${session_id}/A${agent_index}_${test_id}.time"
+}
+
+# Preparing session directory
+if [ "$CLOUD_PROVIDER" = "local" ]; then
+    record_timestamp_local
+else
+    agent_index=1
+    for agent in ${agents//,/ } ; do
+        record_timestamp_remote $agent $agent_index &
+        ((agent_index++))
+    done
+
+    wait
+fi

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/RunTestSuiteTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/RunTestSuiteTask.java
@@ -125,13 +125,13 @@ public class RunTestSuiteTask {
 
             TestCaseRunner runner = new TestCaseRunner(
                     test,
+                    coordinatorParameters,
                     targets,
                     client,
                     testPhaseSyncMap,
                     failureCollector,
                     registry,
-                    performanceStatsCollector,
-                    coordinatorParameters.getSimulatorProperties().getInt("WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS"));
+                    performanceStatsCollector);
             runners.add(runner);
         }
 


### PR DESCRIPTION
Creates a new file containing the timestamps on the remote machine
a test started/stopped.

This feature is needed to deal with proper warmup/cooldown and aligning
dstats data with the benchmark run.