### PR TITLE
Fixes problem IBM 6/7

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/utils/NativeUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/NativeUtils.java
@@ -95,7 +95,7 @@ public final class NativeUtils {
             RuntimeMXBean runtime = java.lang.management.ManagementFactory.getRuntimeMXBean();
             java.lang.reflect.Field jvm = runtime.getClass().getDeclaredField("jvm");
             jvm.setAccessible(true);
-            sun.management.VMManagement management = (sun.management.VMManagement) jvm.get(runtime);
+            Object management = jvm.get(runtime);
             java.lang.reflect.Method pidMethod = management.getClass().getDeclaredMethod("getProcessId");
             pidMethod.setAccessible(true);
 


### PR DESCRIPTION
The problem is a bug in the IBM JVM that isn't too happy
when a method exists, that isn't called, in a class. And this
method is pointing to classes that don't exist.

Fix: the explicit casting to sun.management.VMManagement has been
removed. Fix has been verified with IBM 6.