### PR TITLE
Removed a directory upload from install-simulator.sh

### DIFF
--- a/dist/src/main/dist/conf/install-simulator.sh
+++ b/dist/src/main/dist/conf/install-simulator.sh
@@ -95,6 +95,5 @@ fi
 uploadToRemoteSimulatorDir "$SIMULATOR_HOME/bin/" "bin"
 uploadToRemoteSimulatorDir "$SIMULATOR_HOME/conf/" "conf"
 uploadToRemoteSimulatorDir "$SIMULATOR_HOME/jdk-install/" "jdk-install"
-uploadToRemoteSimulatorDir "$SIMULATOR_HOME/tests/" "tests"
 uploadToRemoteSimulatorDir "$SIMULATOR_HOME/test-lib/" "test-lib/"
 uploadToRemoteSimulatorDir "$SIMULATOR_HOME/user-lib/" "user-lib/"


### PR DESCRIPTION
The `tests` directory is not part of the distribution anymore.