### PR TITLE
Increate timeout for streamers

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AbstractAsyncStreamer.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/loadsupport/AbstractAsyncStreamer.java
@@ -32,7 +32,7 @@ abstract class AbstractAsyncStreamer<K, V> implements Streamer<K, V> {
 
     private static final ILogger LOGGER = Logger.getLogger(AbstractAsyncStreamer.class);
 
-    private static final long DEFAULT_TIMEOUT_MINUTES = 2;
+    private static final long DEFAULT_TIMEOUT_MINUTES = 5;
     private static final int MAXIMUM_LOGGING_RATE_MILLIS = 5000;
 
     private final int concurrencyLevel;


### PR DESCRIPTION
Sometimes initial inserting is taking longer, but it's still making progress before the tests, but hitting this timeout. I guess we don't need any parameter for this (at least now), but it should unblock me with 3.10 testing.