### PR TITLE
Fixes logging for HZ instances

### DIFF
--- a/dist/src/main/dist/conf/client-hazelcast.xml
+++ b/dist/src/main/dist/conf/client-hazelcast.xml
@@ -17,6 +17,10 @@
 
     <!--LICENSE-KEY-->
 
+    <properties>
+        <property name="hazelcast.logging.type">log4j</property>
+    </properties>
+
     <serialization>
         <data-serializable-factories>
             <data-serializable-factory factory-id="4000">

--- a/dist/src/main/dist/conf/hazelcast.xml
+++ b/dist/src/main/dist/conf/hazelcast.xml
@@ -21,6 +21,7 @@
 
     <properties>
         <property name="hazelcast.phone.home.enabled">false</property>
+        <property name="hazelcast.logging.type">log4j</property>
     </properties>
 
     <!--LICENSE-KEY-->

--- a/simulator/src/main/java/com/hazelcast/simulator/vendors/HazelcastDriver.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/vendors/HazelcastDriver.java
@@ -97,7 +97,7 @@ public class HazelcastDriver extends VendorDriver<HazelcastInstance> {
     }
 
     private String loadJvmOptions(String argsProperty) {
-        return get(argsProperty, "") + " -Dhazelcast.logging.type=log4j";
+        return get(argsProperty, "");
     }
 
     @Override


### PR DESCRIPTION
Instead of letting the driver automagically add the log4j hazelcast
logging property, it is now configured in the hazelcast xml.

The reason behind this is that we want to control the logging being used
e.g turn logging off due to overhead.