### PR TITLE
Added performance.csv that is generated when comparing benchmarks

### DIFF
--- a/dist/src/main/dist/conf/benchmark-report.py
+++ b/dist/src/main/dist/conf/benchmark-report.py
@@ -935,6 +935,7 @@ class Comparison:
         last_benchmark = None
 
         print("Loading benchmarks")
+        os.remove(report_dir+"/performance.csv")
 
         # collect all benchmark directories and the names for the benchmarks
         for benchmark_arg in benchmark_args:
@@ -957,7 +958,7 @@ class Comparison:
         # Make the benchmarks
         self.benchmarks = []
         for benchmark_dir in benchmark_dirs:
-            cmd = simulator_home + "/conf/hdr.sh " + benchmark_dir
+            cmd = simulator_home + "/conf/hdr.sh " + benchmark_dir+ " "+report_dir
             subprocess.check_output(cmd.split())
             self.benchmarks.append(Benchmark(benchmark_dir, benchmark_names[benchmark_dir]))
 

--- a/dist/src/main/dist/conf/hdr.sh
+++ b/dist/src/main/dist/conf/hdr.sh
@@ -9,6 +9,7 @@ set -e
 
 # the session id; could be a * om case everything needs to be downloaded
 session_dir=$1
+report_dir=$2
 
 # merge all hdr files of each member into a hdr file which gets stored in the target_directory
 probes=($(ls -R ${session_dir} | grep .hdr | sort | uniq))
@@ -46,4 +47,11 @@ do
     echo "[INFO]          $hdr_file"
 
     mv "${file_name}.hgrm.bak" "${file_name}.hgrm"
+done
+
+hgrm_files=($(find "${session_dir}" -maxdepth 1 -name *.hgrm ))
+echo HDR hgrm_files $hgrm_files
+for hgrm_file in "${hgrm_files[@]}"
+do
+    java -cp "${SIMULATOR_HOME}/lib/*"  com.hazelcast.simulator.utils.PerformanceCsv $hgrm_file $report_dir $session_dir
 done

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/FileUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/FileUtils.java
@@ -56,6 +56,10 @@ public final class FileUtils {
     private FileUtils() {
     }
 
+    public static String stripExtension(String filename) {
+        return filename.replaceFirst("[.][^.]+$", "");
+    }
+
     public static boolean isValidFileName(String fileName) {
         return VALID_FILE_NAME_PATTERN.matcher(fileName).matches();
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/PerformanceCsv.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/PerformanceCsv.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.utils;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static com.hazelcast.simulator.utils.FileUtils.appendText;
+import static com.hazelcast.simulator.utils.FileUtils.fileAsText;
+import static com.hazelcast.simulator.utils.FileUtils.stripExtension;
+import static java.util.Arrays.asList;
+
+public class PerformanceCsv {
+
+    public static void main(String[] args) {
+        File reportDir = new File(args[1]);
+        File sessionDir = new File(args[2]);
+        File out = new File(reportDir, "performance.csv");
+        if (!out.exists()) {
+            appendText(getHeader(), out);
+        }
+        File hgrmFile = new File(args[0]);
+
+        StringBuffer outSb = new StringBuffer();
+        outSb.append(sessionDir.getName());
+        outSb.append(",").append(stripExtension(hgrmFile.getName()));
+        addPercentiles(hgrmFile, outSb);
+        addOther(hgrmFile, outSb);
+        appendText(outSb.toString() + "\n", out);
+    }
+
+    private static void addPercentiles(File hgrmFile, StringBuffer outSb) {
+        String[] lines = fileAsText(hgrmFile).split("\n");
+        Queue<String> importantPercentiles = new LinkedList<>(asList("0.1", "0.2", "0.5", "0.75", "0.90", "0.95",
+                "0.99", "0.999", "0.9999", "1.00"));
+
+        String percentile = importantPercentiles.poll();
+        for (int k = 4; k < lines.length - 3; k++) {
+            String line = lines[k];
+            String[] tokens = line.split("\\s+");
+            if (tokens[2].startsWith(percentile)) {
+                outSb.append(',').append(tokens[1]);
+                percentile = importantPercentiles.poll();
+                if (percentile == null) {
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void addOther(File hgrmFile, StringBuffer outSb) {
+        File file = new File(hgrmFile.getParent(), FileUtils.stripExtension(hgrmFile.getName()));
+        String[] lines = fileAsText(file).split("\n");
+        long startMillis = Math.round(Double.parseDouble(lines[4].split(",")[1]) * 1000);
+
+        String lastLine = lines[lines.length - 1];
+
+        String[] lastLineFields = lastLine.split(",");
+        long totalCount = Long.parseLong(lastLineFields[16]);
+        outSb.append(",").append(totalCount);
+
+        long endMillis = Math.round(Double.parseDouble(lastLineFields[1]) * 1000);
+        long duration = endMillis - startMillis;
+        outSb.append(",").append(duration);
+
+        outSb.append(",").append(totalCount * 100d / duration);
+    }
+
+    private static String getHeader() {
+        return "\"session\",\"benchmark\",\"10%\",\"20%\",\"50%\",\"75%\",\"90%\",\"95%\",\"99%\",\"99.9%\"," +
+                "\"99.99%\",\"max\",\"operations\",\"duration\",\"throughput\"\n";
+    }
+}


### PR DESCRIPTION

Performance csv that is result of comparison:

```
"session","benchmark","10%","20%","50%","75%","90%","95%","99%","99.9%","99.99%","max","operations","duration","throughput"
hazelcast,LongStringCacheTest-get,245.759,261.631,307.711,338.943,373.759,395.263,446.463,587.263,4012.031,23789.567,74054815,178023,41598.45357060605
ignite,LongStringCacheTest-get,379.391,423.935,524.799,627.711,749.055,840.191,1065.983,1507.327,6094.847,31424.511,41661865,178033,23401.20370942466
```

Having a csv makes it a lot easier to process results compared to graphs.