### PR TITLE
2 fixes

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
@@ -233,7 +233,8 @@ public class Provisioner {
         String startHarakiriMonitorCommand = getStartHarakiriMonitorCommandOrNull(properties);
         try {
             log("Creating machines (can take a few minutes)...");
-            new BashCommand(getConfigurationFile("aws-ec2_provision.sh").getAbsolutePath())
+            String filename = properties.get("CLOUD_PROVIDER") + "_provision.sh";
+            new BashCommand(getConfigurationFile(filename).getAbsolutePath())
                     .addEnvironment(properties.asMap())
                     .addParams(delta)
                     .execute();
@@ -249,6 +250,7 @@ public class Provisioner {
                 future.get();
             }
         } catch (Exception e) {
+            LOGGER.error("Failed to provision machines",e);
             throw new CommandLineExitException("Failed to provision machines: " + e.getMessage());
         }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/FileUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/FileUtils.java
@@ -94,7 +94,9 @@ public final class FileUtils {
     public static void writeText(String text, File file) {
         checkNotNull(text, "Text can't be null");
         checkNotNull(file, "File can't be null");
-        ensureExistingDirectory(file.getParentFile());
+        if (file.getParentFile() != null) {
+            ensureExistingDirectory(file.getParentFile());
+        }
 
         FileOutputStream stream = null;
         OutputStreamWriter streamWriter = null;


### PR DESCRIPTION
npe when provisioning (also enabled logging)
picking the right cloud provider script based on cloud provider
instead of hardcoding.