### PR TITLE
Fixed problem scaling down

### DIFF
--- a/dist/src/main/dist/conf/aws-ec2_terminate.sh
+++ b/dist/src/main/dist/conf/aws-ec2_terminate.sh
@@ -3,15 +3,17 @@
 # exit on failure
 set -e
 
-# comma seperated list of private ip's of the agents to destroy
+# comma separated list of private ip's of the agents to destroy
 private_ips=$1
+# comma separated list of public ip's of the agents to destroy.
+public_ips=$2
 
 export AWS_ACCESS_KEY_ID=$CLOUD_IDENTITY
 export AWS_SECRET_ACCESS_KEY=$CLOUD_CREDENTIAL
 
 instance_ids=$(aws ec2 describe-instances \
                 --region $REGION \
-                --filter Name=private-ip-address,Values=$private_ips \
+                --filter Name=ip-address,Values=$public_ips \
                 --output text \
                 --query 'Reservations[*].Instances[*].InstanceId')
 

--- a/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/provisioner/Provisioner.java
@@ -270,16 +270,21 @@ public class Provisioner {
         long started = System.nanoTime();
 
         int destroyedCount = 0;
-        List<String> privateIps = new LinkedList<String>();
+        List<String> privateIps = new LinkedList<>();
+        List<String> publicIps = new LinkedList<>();
         List<AgentData> agents = registry.getAgents();
         for (int k = 0; k < count; k++) {
-            privateIps.add(agents.get(k).getPrivateAddress());
+            AgentData agent = agents.get(k);
+            privateIps.add(agent.getPrivateAddress());
+            publicIps.add(agent.getPublicAddress());
             destroyedCount++;
         }
 
-        new BashCommand(getConfigurationFile("aws-ec2_terminate.sh").getAbsolutePath())
+        String cloudProvider = properties.get("CLOUD_PROVIDER");
+        new BashCommand(getConfigurationFile(cloudProvider + "_terminate.sh").getAbsolutePath())
                 .addEnvironment(properties.asMap())
                 .addParams(join(privateIps, ","))
+                .addParams(join(publicIps, ","))
                 .execute();
 
         for (int k = 0; k < count; k++) {


### PR DESCRIPTION
The issue was that private ip addresses were used and when there are
multiple vpc of a single user in the same region, there is no guarantee
that ip addresses are unique.

So sometimes based on private ip's the wrong machine id's were found.

This is fixed by making use of public ip address for lookup.