### PR TITLE
Added thread affinity libraries

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -41,11 +41,11 @@
             <artifactId>driver-ignite2</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.hazelcast.simulator</groupId>
-            <artifactId>driver-infinispan10</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.hazelcast.simulator</groupId>-->
+<!--            <artifactId>driver-infinispan10</artifactId>-->
+<!--            <version>${project.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>com.hazelcast.simulator</groupId>
             <artifactId>driver-infinispan9</artifactId>

--- a/dist/src/main/config/build-distribution-archive.xml
+++ b/dist/src/main/config/build-distribution-archive.xml
@@ -103,26 +103,26 @@
             </includes>
         </dependencySet>
 
-        <dependencySet>
-            <outputDirectory>drivers/driver-infinispan10</outputDirectory>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>com.hazelcast.simulator:driver-infinispan10</include>
-                <include>org.infinispan:*</include>
-                <include>org.javassist:javassist</include>
-                <include>com.fasterxml.jackson.core:*</include>
-                <include>io.netty:netty-handler</include>
-                <include>io.netty:netty-buffer</include>
-                <include>io.netty:netty-transport</include>
-                <include>io.netty:netty-resolver</include>
-                <include>io.netty:netty-transport-native-epoll</include>
-                <include>io.netty:netty-transport-native-unix-common</include>
-                <include>io.netty:netty-codec</include>
-                <include>io.netty:netty-common</include>
-                <include>io.reactivex.rxjava2:*</include>
-            </includes>
-        </dependencySet>
+<!--        <dependencySet>-->
+<!--            <outputDirectory>drivers/driver-infinispan10</outputDirectory>-->
+<!--            <useProjectArtifact>false</useProjectArtifact>-->
+<!--            <useTransitiveFiltering>true</useTransitiveFiltering>-->
+<!--            <includes>-->
+<!--                <include>com.hazelcast.simulator:driver-infinispan10</include>-->
+<!--                <include>org.infinispan:*</include>-->
+<!--                <include>org.javassist:javassist</include>-->
+<!--                <include>com.fasterxml.jackson.core:*</include>-->
+<!--                <include>io.netty:netty-handler</include>-->
+<!--                <include>io.netty:netty-buffer</include>-->
+<!--                <include>io.netty:netty-transport</include>-->
+<!--                <include>io.netty:netty-resolver</include>-->
+<!--                <include>io.netty:netty-transport-native-epoll</include>-->
+<!--                <include>io.netty:netty-transport-native-unix-common</include>-->
+<!--                <include>io.netty:netty-codec</include>-->
+<!--                <include>io.netty:netty-common</include>-->
+<!--                <include>io.reactivex.rxjava2:*</include>-->
+<!--            </includes>-->
+<!--        </dependencySet>-->
 
         <dependencySet>
             <outputDirectory>drivers/driver-infinispan9</outputDirectory>
@@ -133,15 +133,9 @@
                 <include>org.infinispan:*</include>
                 <include>org.javassist:javassist</include>
                 <include>com.fasterxml.jackson.core:*</include>
-                <include>io.netty:netty-handler</include>
-                <include>io.netty:netty-buffer</include>
-                <include>io.netty:netty-transport</include>
-                <include>io.netty:netty-resolver</include>
-                <include>io.netty:netty-transport-native-epoll</include>
-                <include>io.netty:netty-transport-native-unix-common</include>
-                <include>io.netty:netty-codec</include>
-                <include>io.netty:netty-common</include>
+                <include>io.netty:netty-*</include>
                 <include>io.reactivex.rxjava2:*</include>
+                <include>org.reactivestreams:reactive-streams</include>
             </includes>
         </dependencySet>
 

--- a/drivers/driver-hazelcast4/pom.xml
+++ b/drivers/driver-hazelcast4/pom.xml
@@ -53,6 +53,22 @@
         </dependency>
 
         <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>affinity</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>4.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>4.2.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>${netty-tcnative.artifactId}</artifactId>
             <version>${netty-tcnative.version}</version>

--- a/drivers/driver-infinispan9/pom.xml
+++ b/drivers/driver-infinispan9/pom.xml
@@ -32,13 +32,13 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <version>${infinispan.version}</version>
+            <version>9.4.8.Final</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-hotrod</artifactId>
-            <version>${infinispan.version}</version>
+            <version>9.4.8.Final</version>
 
             <exclusions>
                 <exclusion>

--- a/drivers/pom.xml
+++ b/drivers/pom.xml
@@ -25,8 +25,8 @@
         <module>driver-hazelcast4</module>
         <module>driver-hazelcast3</module>
         <module>driver-ignite2</module>
-        <module>driver-infinispan10</module>
         <module>driver-infinispan9</module>
+<!--        <module>driver-infinispan10</module>-->
         <module>driver-couchbase</module>
         <module>driver-memcached</module>
         <module>driver-mongodb</module>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven.source.plugin.version>3.0.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
-        <maven.assembly.plugin.version>3.1.1</maven.assembly.plugin.version>
+        <maven.assembly.plugin.version>3.2.0</maven.assembly.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>


### PR DESCRIPTION
Also fixes problem with infinispan 9. Sohow when the infinispan10
driver is included, the infinispan 10 dependencies get add to
the infinispan9 driver. So for the time being the infinspan10 driver
has been deactivated.