### PR TITLE
Make rsync compressing the test results during download

### DIFF
--- a/dist/src/main/dist/conf/download.sh
+++ b/dist/src/main/dist/conf/download.sh
@@ -29,7 +29,7 @@ function download_remote(){
 
     # copy the files
     # we exclude the uploads directory because it could be very big e.g jars
-    rsync --copy-links -avv -e "ssh ${SSH_OPTIONS}" --exclude 'upload' $SIMULATOR_USER@$agent:$download_path $root_dir
+    rsync --copy-links -avvz --compress-level=9 -e "ssh ${SSH_OPTIONS}" --exclude 'upload' $SIMULATOR_USER@$agent:$download_path $root_dir
 
     # delete the files on the agent (no point in keeping them around if they are already copied locally)
     if [ "$session_id" = "*" ] ; then


### PR DESCRIPTION
Simulator runs can produce large amount of data such as diagnostics, JVM
and other logs, JFR, perf and other recordings. Downloading these files
over VPN can be slow. Since typically the network bandwidth is the
bottleneck not the CPU, rsync compression is hardwired for downloading
benchmark results from the remote boxes. Uploading and installing
simulator doesn't need to compress since these phases deal with small
or compressed files.