### PR TITLE
Added support for rampup

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/test/annotations/TimeStep.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/test/annotations/TimeStep.java
@@ -282,6 +282,20 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
+ * <h1>Stress testing</h1>
+ * With stress testing you try to find the highest performance until you run into the breaking point of the system. In Simulator
+ * this is done by increasing the number of threads until the `threadCount` number of threads are all running. This can be done
+ * using the rampupSeconds:
+ * <pre>
+ * {@code
+ *     class=yourtest
+ *     threadCount=10
+ *     rampupSeconds=60
+ * }
+ * </pre>
+ * In this case every 6 seconds a new thread is added to the test until the maximum number of 10 threads; so after 60 seconds
+ * all the threads are running.
+ *
  * <h1>Measure latency</h1>
  * In some cases measuring the latency can be very expensive due to contention on HDR or because reading out the clock
  * can be expensive on certain environments (e.g. EC2 with XEN clock. By adding 'measureLatency=false' to the test,

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/MetronomeSupplier.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/MetronomeSupplier.java
@@ -21,6 +21,7 @@ import com.hazelcast.simulator.worker.metronome.SleepingMetronome;
 
 import java.lang.reflect.Constructor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.hazelcast.simulator.worker.testcontainer.PropertyBinding.toPropertyName;
 import static java.lang.Math.round;
@@ -33,13 +34,13 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class MetronomeConstructor {
+public class MetronomeSupplier implements Supplier<Metronome> {
 
     private final Class<? extends Metronome> metronomeClass;
     private final Metronome masterMetronome;
     private final long intervalNanos;
 
-    public MetronomeConstructor(String executionGroup, PropertyBinding binding, int threadCount) {
+    public MetronomeSupplier(String executionGroup, PropertyBinding binding, int threadCount) {
         String property = toPropertyName(executionGroup, "interval");
         String intervalString = binding.load(property);
 
@@ -124,7 +125,8 @@ public class MetronomeConstructor {
         return metronomeClass;
     }
 
-    Metronome newInstance() {
+    @Override
+    public Metronome get() {
         if (metronomeClass == EmptyMetronome.class) {
             return EmptyMetronome.INSTANCE;
         }

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
@@ -64,7 +64,7 @@ public class PropertyBinding {
     public int recordJitterThresholdNs = DEFAULT_RECORD_JITTER_THRESHOLD_NS;
 
     // this can be removed as soon as the @InjectMetronome/worker functionality is dropped
-    private MetronomeConstructor workerMetronomeConstructor;
+    private MetronomeSupplier workerMetronomeConstructor;
     private final Class<? extends Probe> probeClass;
     private TestContextImpl testContext;
     private final Map<String, Probe> probeMap = new ConcurrentHashMap<>();
@@ -76,7 +76,7 @@ public class PropertyBinding {
         this.testCase = testCase;
         this.unusedProperties.addAll(testCase.getProperties().keySet());
         unusedProperties.remove("class");
-        unusedProperties.remove("warmupMillis");
+        unusedProperties.remove("rampupSeconds");
 
         bind(this);
 
@@ -84,7 +84,7 @@ public class PropertyBinding {
             throw new IllegalTestException("recordJitterThresholdNs can't be smaller than 0");
         }
 
-        this.workerMetronomeConstructor = new MetronomeConstructor(
+        this.workerMetronomeConstructor = new MetronomeSupplier(
                 "", this, loadAsInt("threadCount", DEFAULT_THREAD_COUNT));
         this.probeClass = loadProbeClass();
     }
@@ -187,11 +187,7 @@ public class PropertyBinding {
     }
 
     public static String toPropertyName(String prefix, String name) {
-        if (prefix.equals("")) {
-            return name;
-        }
-
-        return prefix + capitalizeFirst(name);
+        return prefix.equals("") ? name : prefix + capitalizeFirst(name);
     }
 
     public static String capitalizeFirst(String s) {

--- a/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepRunner.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepRunner.java
@@ -49,6 +49,7 @@ public abstract class TimeStepRunner implements Runnable {
     protected final byte[] timeStepProbabilities;
     protected final Map<String, Probe> probeMap = new HashMap<>();
     protected long maxIterations;
+    protected long delayMillis;
 
     public TimeStepRunner(Object testInstance, TimeStepModel timeStepModel, String executionGroup) {
         this.testInstance = testInstance;
@@ -78,6 +79,16 @@ public abstract class TimeStepRunner implements Runnable {
     @Override
     public final void run() {
         String threadName = Thread.currentThread().getName();
+        if (delayMillis > 0) {
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(
+                       threadName + " got interrupted while waiting during rampup.");
+            }
+        }
+
         logger.info(threadName + " started");
         try {
             beforeRun();
@@ -111,7 +122,7 @@ public abstract class TimeStepRunner implements Runnable {
                 : new Object[]{testInstance};
 
         try {
-            return constructor.newInstance((Object[]) args);
+            return constructor.newInstance(args);
         } catch (Exception e) {
             throw new IllegalTestException(
                     format("Failed to create an instance of thread state class '%s'",

--- a/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/MetronomeSupplierTest.java
+++ b/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/MetronomeSupplierTest.java
@@ -16,7 +16,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
-public class MetronomeConstructorTest {
+public class MetronomeSupplierTest {
 
     @Test
     public void test() {
@@ -31,9 +31,9 @@ public class MetronomeConstructorTest {
 
     public void test(long expectedInterval, String actualInterval) {
         PropertyBinding propertyBinding = new PropertyBinding(new TestCase("foo").setProperty("interval", actualInterval));
-        MetronomeConstructor metronomeConstructor = new MetronomeConstructor("", propertyBinding, 1);
+        MetronomeSupplier supplier = new MetronomeSupplier("", propertyBinding, 1);
 
-        Metronome m = metronomeConstructor.newInstance();
+        Metronome m = supplier.get();
         assertEquals(SleepingMetronome.class, m.getClass());
         SleepingMetronome metronome = (SleepingMetronome) m;
 
@@ -43,27 +43,27 @@ public class MetronomeConstructorTest {
     @Test(expected = IllegalTestException.class)
     public void testNotInteger() {
         PropertyBinding propertyBinding = new PropertyBinding(new TestCase("foo").setProperty("interval", "foo"));
-        new MetronomeConstructor("", propertyBinding, 1);
+        new MetronomeSupplier("", propertyBinding, 1);
     }
 
     @Test(expected = IllegalTestException.class)
     public void testMissingTimeUnit() {
         PropertyBinding propertyBinding = new PropertyBinding(new TestCase("foo").setProperty("interval", "10"));
-        new MetronomeConstructor("", propertyBinding, 1);
+        new MetronomeSupplier("", propertyBinding, 1);
     }
 
     @Test(expected = IllegalTestException.class)
     public void negativeInterval() {
         PropertyBinding propertyBinding = new PropertyBinding(new TestCase("foo").setProperty("interval", "-1ns"));
-        new MetronomeConstructor("", propertyBinding, 1);
+        new MetronomeSupplier("", propertyBinding, 1);
     }
 
     @Test
     public void testThreadCount() {
         PropertyBinding propertyBinding = new PropertyBinding(new TestCase("foo").setProperty("interval", "20ns"));
-        MetronomeConstructor metronomeConstructor = new MetronomeConstructor("", propertyBinding, 10);
+        MetronomeSupplier supplier = new MetronomeSupplier("", propertyBinding, 10);
 
-        Metronome m = metronomeConstructor.newInstance();
+        Metronome m = supplier.get();
         assertEquals(SleepingMetronome.class, m.getClass());
         SleepingMetronome metronome = (SleepingMetronome) m;
 
@@ -76,9 +76,9 @@ public class MetronomeConstructorTest {
                 new TestCase("foo")
                         .setProperty("interval", "10ns")
                         .setProperty("metronomeClass", BusySpinningMetronome.class));
-        MetronomeConstructor metronomeConstructor = new MetronomeConstructor("", propertyBinding, 1);
+        MetronomeSupplier supplier = new MetronomeSupplier("", propertyBinding, 1);
 
-        Metronome m = metronomeConstructor.newInstance();
+        Metronome m = supplier.get();
         assertEquals(BusySpinningMetronome.class, m.getClass());
         BusySpinningMetronome metronome = (BusySpinningMetronome) m;
 
@@ -88,9 +88,9 @@ public class MetronomeConstructorTest {
     @Test
     public void whenZeroInterval() {
         PropertyBinding propertyBinding = new PropertyBinding(new TestCase("foo"));
-        MetronomeConstructor metronomeConstructor = new MetronomeConstructor("", propertyBinding, 5);
+        MetronomeSupplier supplier = new MetronomeSupplier("", propertyBinding, 5);
 
-        Metronome m = metronomeConstructor.newInstance();
+        Metronome m = supplier.get();
         assertEquals(EmptyMetronome.class, m.getClass());
     }
 }


### PR DESCRIPTION
Added support for rampup so that threads get added to the test over time. Example usage.

```
class=yourtest
threadCount=10
rampupSeconds=60
```

For this test, every 6 seconds a thread is added so that after 60 seconds there are 10 threads running.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/1805