### PR TITLE
Minor documentation fix

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -255,7 +255,7 @@ JDK_FLAVOR=oracle
 #       You can get a list of available versions here:
 #       https://cdn.azul.com/zulu/bin/
 #       An example:
-#       VERSION=zulu8.12.0.1-jdk8.0.71-linux_x64.tar.gz
+#       JDK_VERSION=zulu8.12.0.1-jdk8.0.71-linux_x64.tar.gz
 #       Keep in mind that you need to select a linux x86 JDK (JRE is not sufficient)
 #
 # When using Java 9+, add the following to the jvm arguments


### PR DESCRIPTION
I used the wrong property name in the documentation:

VERSION=zulu8.12.0.1-jdk8.0.71-linux_x64.tar.gz
Instead of 
JDK_VERSION=zulu8.12.0.1-jdk8.0.71-linux_x64.tar.gz