### PR TITLE
Version spec from coordinator

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -233,6 +233,8 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 #       https://jdk.java.net/
 #
 #       Example:
+#       JDK_URL=https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_windows-x64_bin.tar.gz
+#       JDK_URL=https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz
 #       JDK_URL=https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz
 #
 # AdoptOpenJDK
@@ -240,9 +242,12 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 #       https://github.com/AdoptOpenJDK/
 #
 #       Example of OpenJDK
+#       JDK_URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01_openj9-0.21.0/OpenJDK8U-jdk_x64_linux_openj9_8u265b01_openj9-0.21.0.tar.gz
+#       JDK_URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.8_10.tar.gz
 #       JDK_URL=https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk15u-2020-09-17-08-34/OpenJDK15U-jdk_x64_linux_hotspot_2020-09-17-08-34.tar.gz
 #
 #       Example of OpenJDK + J9
+#       JDK_URL=https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01_openj9-0.21.0/OpenJDK8U-jdk_x64_linux_openj9_8u265b01_openj9-0.21.0.tar.gz
 #       JDK_URL=https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10_openj9-0.21.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.8_10_openj9-0.21.0.tar.gz
 #
 # Graal:
@@ -251,12 +256,14 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 #
 #       Example:
 #       JDK_URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java8-linux-amd64-20.2.0.tar.gz
+#       JDK_URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-amd64-20.2.0.tar.gz
 #
 # Amazon Coretto:
 #
 #       https://aws.amazon.com/corretto/
 #
 #       Example:
+#       JDK_URL=https://corretto.aws/downloads/latest/amazon-corretto-8-x64-linux-jdk.tar.gz
 #       JDK_URL=https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz
 #
 # Zulu:
@@ -264,6 +271,8 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 #       https://cdn.azul.com/zulu/bin/
 #
 #       Example:
+#       JDK_URL=https://cdn.azul.com/zulu/bin/zulu8.48.0.53-ca-jdk8.0.265-linux_x64.tar.gz
+#       JDK_URL=https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-linux_x64.tar.gz
 #       JDK_URL=https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz
 #
 # Bellsoft:

--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/CoordinatorCli.java
@@ -80,6 +80,10 @@ final class CoordinatorCli {
                     + "ignite2,infinispan9,infinispan10,infinispan11,couchbase,lettuce5,lettucecluster5,jedis3")
             .withRequiredArg().ofType(String.class).defaultsTo("hazelcast4");
 
+    private final OptionSpec<String> versionSpec = parser.accepts("version",
+            "The version of the vendor to use. Only hazelcast3/4 (and enterprise) will use this version")
+            .withRequiredArg().ofType(String.class);
+
     private final OptionSpec<String> durationSpec = parser.accepts("duration",
             "Amount of time to execute the RUN phase per test, e.g. 10s, 1m, 2h or 3d. If duration is set to 0, "
                     + "the test will run until the test decides to stop.")
@@ -174,6 +178,10 @@ final class CoordinatorCli {
 
         if (!"fake".equals(properties.get("DRIVER"))) {
             properties.set("DRIVER", options.valueOf(driverSpec));
+        }
+
+        if (options.hasArgument(versionSpec)) {
+            properties.set("VERSION_SPEC", options.valueOf(versionSpec));
         }
 
         this.registry = newRegistry(properties);


### PR DESCRIPTION
The shared simulator.properties can sometimes be a problem if you need to
test with different settings e.g. version_spec.

So the version spec can now be configured fromt the coordinator.

--version maven=4.0.1

This feature is backwards compatible, so no compatibility problems.

Also added some additional examples to the JDK urls