### PR TITLE
Removed oracle JDK install scripts.

### DIFF
--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -283,7 +283,7 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 #       JDK_URL=https://download.bell-sw.com/java/11.0.8+10/bellsoft-jdk11.0.8+10-linux-amd64.tar.gz
 #
 # ============================================================================
-#JDK_URL=
+JDK_URL=https://simulator-jdk.s3.amazonaws.com/jdk-8u261-linux-x64.tar.gz
 
 # =============================================================================
 # JDK Installation
@@ -296,7 +296,6 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 #
 # The following 4 flavors are available:
 #   ibm
-#   oracle
 #   outofthebox
 #
 # "outofthebox" is the Java version provided by the image, so no software is
@@ -304,11 +303,7 @@ GIT_BUILD_DIR=~/.hazelcast-build/
 # else that isn't X86-64, set the value to 'outofthebox' and take care
 # of the installation yourself. E.g. using agent-ssh 'sudo yum -y install whatever'
 #
-# If you want to use openjdk, it is best to use zulu since it is just an
-# openjdk distribution. The installation is more reliable and more versions
-# are supported.
-#
-JDK_FLAVOR=oracle
+JDK_FLAVOR=ibm
 
 #
 # The version of Java to install.

--- a/dist/src/main/dist/jdk-install/jdk-oracle-11-64.sh
+++ b/dist/src/main/dist/jdk-install/jdk-oracle-11-64.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-source jdk-support.sh
-
-installOracleJdk "jdk-11.0.8_linux-x64_bin.tar.gz" "~/jdk-11.0.8"

--- a/dist/src/main/dist/jdk-install/jdk-oracle-13-64.sh
+++ b/dist/src/main/dist/jdk-install/jdk-oracle-13-64.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-source jdk-support.sh
-
-installOracleJdk "jdk-13_linux-x64_bin.tar.gz" "~/jdk-13"

--- a/dist/src/main/dist/jdk-install/jdk-oracle-8-64.sh
+++ b/dist/src/main/dist/jdk-install/jdk-oracle-8-64.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-source jdk-support.sh
-
-installOracleJdk "jdk-8u261-linux-x64.tar.gz" "~/jdk1.8.0_261"

--- a/dist/src/main/dist/jdk-install/jdk-oracle-9-64.sh
+++ b/dist/src/main/dist/jdk-install/jdk-oracle-9-64.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-source jdk-support.sh
-
-installOracleJdk "jdk-9.0.4_linux-x64_bin.tar.gz" "~/jdk-9.0.4"

--- a/dist/src/main/dist/jdk-install/jdk-support.sh
+++ b/dist/src/main/dist/jdk-install/jdk-support.sh
@@ -5,19 +5,6 @@
 # IBM
 # http://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/
 #
-# OpenJDK
-# https://github.com/alexkasko/openjdk-unofficial-builds
-# https://github.com/ojdkbuild/ojdkbuild
-# https://adopt-openjdk.ci.cloudbees.com/job/openjdk-1.9-linux-x86_64/lastSuccessfulBuild/artifact/openjdk-1.9-linux-x86_64-jdk.tar.gz
-#
-# Oracle
-# http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz
-# http://www.java.net/download/java/jdk9/archive/158/binaries/jdk-9-ea+158_linux-x64_bin.tar.gz
-#
-# Zulu
-# http://cdn.azul.com/zulu/bin/zulu7.17.0.5-jdk7.0.131-linux_x64.tar.gz
-# http://cdn.azul.com/zulu/bin/zulu8.20.0.5-jdk8.0.121-linux_x64.tar.gz
-#
 
 set -e
 #set -x


### PR DESCRIPTION
This can be done through the JDK_URL, no need for duplication.