### PR TITLE
Removed jdk bash functions

### DIFF
--- a/dist/src/main/dist/conf/worker-log4j.xml
+++ b/dist/src/main/dist/conf/worker-log4j.xml
@@ -19,16 +19,6 @@
         </layout>
     </appender>
 
-    <!--
-    <appender name="file" class="org.apache.log4j.FileAppender">
-        <param name="File" value="worker.log"/>
-        <param name="Threshold" value="debug"/>
-        <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%-5p %d [%t] %c: %m%n"/>
-        </layout>
-    </appender>
-    -->
-
     <logger name="org.jgroups">
         <level value="debug"/>
         <appender-ref ref="file"/>
@@ -38,12 +28,15 @@
         <level value="debug"/>
         <appender-ref ref="file"/>
     </logger>
+
     <logger name="org.infinispan">
         <level value="info"/>
         <appender-ref ref="file"/>
     </logger>
+
     <root>
         <priority value="info"/>
         <appender-ref ref="file"/>
     </root>
+
 </log4j:configuration>

--- a/dist/src/main/dist/jdk-install/jdk-support.sh
+++ b/dist/src/main/dist/jdk-install/jdk-support.sh
@@ -62,56 +62,6 @@ LICENSE_ACCEPTED=TRUE" >> ~/installer.properties
     addJavaHome ${TMP_JAVA_HOME}
 }
 
-function installOpenJdk {
-    JDK_BASE_NAME=$1
-    TMP_JAVA_HOME=$2
-
-    installPackage wget
-    installPackage unzip
-
-    echo "Installing OpenJDK $JDK_BASE_NAME"
-
-    cd ~
-    wget --no-verbose -N "$BASE_URL/$JDK_BASE_NAME.zip"
-    unzip -q -o "$JDK_BASE_NAME.zip"
-
-    addJavaHome ${TMP_JAVA_HOME}
-}
-
-function installOracleJdk {
-    JDK_FILE=$1
-    TMP_JAVA_HOME=$2
-
-    installPackage wget
-    installPackage tar
-
-    echo "Installing Oracle JDK $JDK_FILE"
-
-    cd ~
-    wget --no-verbose -N "$BASE_URL/$JDK_FILE"
-    tar xfz ${JDK_FILE}
-
-    addJavaHome ${TMP_JAVA_HOME}
-}
-
-function installZuluJdk {
-    VERSION=$1
-
-    installPackage wget
-    installPackage tar
-
-    echo "Installing Zulu JDK $VERSION"
-
-    cd ~
-    if [ ! -d $VERSION ]; then
-        wget --no-verbose -N --referer=http://www.azul.com/downloads/zulu/zulu-linux http://cdn.azul.com/zulu/bin/${VERSION}.tar.gz -O ${VERSION}.tar.gz
-        tar xfz ${VERSION}.tar.gz
-        echo [INFO] INSTALLING
-    fi
-
-    addJavaHome ${VERSION}
-}
-
 function addJavaHome {
     TMP_JAVA_HOME=$1
 


### PR DESCRIPTION
Removed the functions to install the different flavors of Java. Can
now be done through the JDK_URL.

Also minor worker-log4j.xml cleanup.