### PR TITLE
Synchronize tests folders between driver3 and driver4

### DIFF
--- a/drivers/driver-hazelcast3/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
+++ b/drivers/driver-hazelcast3/src/main/java/com/hazelcast/simulator/tests/map/IntByteMapTest.java
@@ -15,22 +15,22 @@
  */
 package com.hazelcast.simulator.tests.map;
 
-import com.hazelcast.map.IMap;
+import com.hazelcast.core.IMap;
 import com.hazelcast.simulator.hz.HazelcastTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
-import com.hazelcast.simulator.tests.helpers.KeyLocality;
+import com.hazelcast.simulator.utils.KeyLocality;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.simulator.tests.helpers.KeyUtils.generateIntKeys;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateByteArray;
+import static com.hazelcast.simulator.utils.KeyUtils.generateIntKeys;
 
 public class IntByteMapTest extends HazelcastTest {
 

--- a/drivers/driver-hazelcast3/src/main/java/com/hazelcast/simulator/utils/KeyLocality.java
+++ b/drivers/driver-hazelcast3/src/main/java/com/hazelcast/simulator/utils/KeyLocality.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.utils;
+
+/**
+ * Indicates if a key should be:
+ * <ol>
+ * <li>LOCAL: random generated local keys (perfectly balanced)</li>
+ * <li>REMOTE: random generated remote keys (perfectly balanced)</li>
+ * <li>RANDOM: random generated keys (perfectly balanced)</li>
+ * <li>SHARED: random generated keys (same sequence on all Workers)</li>
+ * <li>SINGLE_PARTITION: constant key for hitting a single partition</li>
+ * </ol>
+ */
+public enum KeyLocality {
+
+    /**
+     * Generates random generated local keys (keys that point to locally owned partitions).
+     *
+     * The keys will be perfectly balanced over the partitions.
+     */
+    LOCAL,
+
+    /**
+     * Generates random generated remote keys.
+     *
+     * Each worker will generate it own random set of keys, so it is very unlikely they are going to be shared.
+     *
+     * The keys will be perfectly balanced over remote partitions.
+     */
+    REMOTE,
+
+    /**
+     * Generates random generated keys.
+     *
+     * Each worker will generate it own random set of keys, so it is very unlikely they are going to be shared. Also becase
+     * each worker generates its own keys, the total size of key domain is 'load-generating-worker * keycount'.
+     *
+     * If you want to pound the same keys by all members, use {@link #SHARED}.
+     *
+     * The keys will be perfectly balanced over the partitions.
+     */
+    RANDOM,
+
+    /**
+     * Generates random generated keys (same sequence on all Workers).
+     *
+     * In doubt, this is the keyLocality you want to use. All keys will be shared by all members.
+     *
+     * Since all keys are shared, the total size of the key domain is equal to the keyCount configured on the member.
+     */
+    SHARED,
+
+    /**
+     * Generates a constant key for hitting a single partition
+     */
+    SINGLE_PARTITION,
+}

--- a/drivers/driver-hazelcast3/src/main/java/com/hazelcast/simulator/utils/KeyUtils.java
+++ b/drivers/driver-hazelcast3/src/main/java/com/hazelcast/simulator/utils/KeyUtils.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.simulator.utils;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.Partition;
+import com.hazelcast.core.PartitionService;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
+import static com.hazelcast.simulator.utils.GeneratorUtils.generateAsciiString;
+import static java.lang.String.format;
+
+public final class KeyUtils {
+
+    private KeyUtils() {
+    }
+
+    /**
+     * Checks if a key is located on a Hazelcast instance.
+     *
+     * @param instance the HazelcastInstance the key should belong to
+     * @param key      the key to check
+     * @return <tt>true</tt> if the key belongs to the Hazelcast instance, <tt>false</tt> otherwise
+     */
+    public static boolean isLocalKey(HazelcastInstance instance, Object key) {
+        PartitionService partitionService = instance.getPartitionService();
+        Partition partition = partitionService.getPartition(key);
+        Member owner;
+        while (true) {
+            owner = partition.getOwner();
+            if (owner != null) {
+                break;
+            }
+            sleepSeconds(1);
+        }
+        return owner.equals(instance.getLocalEndpoint());
+    }
+
+    private static KeyGenerator<Integer> newIntKeyGenerator(HazelcastInstance hz, KeyLocality keyLocality, int keyCount) {
+        switch (keyLocality) {
+            case LOCAL:
+                return new BalancedIntKeyGenerator(hz, keyLocality, keyCount);
+            case REMOTE:
+                return new BalancedIntKeyGenerator(hz, keyLocality, keyCount);
+            case RANDOM:
+                return new BalancedIntKeyGenerator(hz, keyLocality, keyCount);
+            case SINGLE_PARTITION:
+                return new SinglePartitionIntKeyGenerator();
+            default:
+                return new SharedIntKeyGenerator();
+        }
+    }
+
+    private static KeyGenerator<String> newStringKeyGenerator(
+            HazelcastInstance hz, KeyLocality keyLocality, int keyCount, int keyLength, String prefix) {
+        switch (keyLocality) {
+            case LOCAL:
+                return new BalancedStringKeyGenerator(hz, keyLocality, keyCount, keyLength, prefix);
+            case REMOTE:
+                return new BalancedStringKeyGenerator(hz, keyLocality, keyCount, keyLength, prefix);
+            case RANDOM:
+                return new BalancedStringKeyGenerator(hz, keyLocality, keyCount, keyLength, prefix);
+            case SINGLE_PARTITION:
+                return new SinglePartitionStringKeyGenerator(keyLength, prefix);
+            default:
+                return new SharedStringKeyGenerator(keyLength, prefix);
+        }
+    }
+
+    /**
+     * Generates an array of int keys with a configurable keyLocality.
+     *
+     * If the instance is a client, keyLocality is ignored.
+     *
+     * @param keyCount    the number of keys in the array
+     * @param keyLocality if the key is local/remote/random
+     * @param hz          the HazelcastInstance that is used for keyLocality
+     * @return the created array of keys
+     */
+    public static int[] generateIntKeys(int keyCount, KeyLocality keyLocality, HazelcastInstance hz) {
+        KeyGenerator<Integer> keyGenerator = newIntKeyGenerator(hz, keyLocality, keyCount);
+
+        int[] keys = new int[keyCount];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = keyGenerator.next();
+        }
+        return keys;
+    }
+
+    /**
+     * Generates an array of int keys with a configurable keyLocality.
+     *
+     * If the instance is a client, keyLocality is ignored.
+     *
+     * @param keyCount    the number of keys in the array
+     * @param keyLocality if the key is local/remote/random
+     * @param hz          the HazelcastInstance that is used for keyLocality
+     * @return the created array of keys
+     */
+    public static Integer[] generateIntegerKeys(int keyCount, KeyLocality keyLocality, HazelcastInstance hz) {
+        KeyGenerator<Integer> keyGenerator = newIntKeyGenerator(hz, keyLocality, keyCount);
+
+        Integer[] keys = new Integer[keyCount];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = keyGenerator.next();
+        }
+        return keys;
+    }
+
+    /**
+     * Generates a string key with a configurable keyLocality.
+     *
+     * @param keyLength   the length of each string key
+     * @param keyLocality if the key is local/remote/random
+     * @param hz          the HazelcastInstance that is used for keyLocality
+     * @return the created key
+     */
+    public static String generateStringKey(int keyLength, KeyLocality keyLocality, HazelcastInstance hz) {
+        KeyGenerator<String> keyGenerator = newStringKeyGenerator(hz, keyLocality, Integer.MAX_VALUE, keyLength, "");
+        return keyGenerator.next();
+    }
+
+    /**
+     * Generates an array of string keys with a configurable keyLocality.
+     *
+     * If the instance is a client, keyLocality is ignored.
+     *
+     * @param keyCount    the number of keys in the array
+     * @param keyLength   the length of each string key
+     * @param keyLocality if the key is local/remote/random
+     * @param hz          the HazelcastInstance that is used for keyLocality
+     * @return the created array of keys
+     */
+    public static String[] generateStringKeys(int keyCount, int keyLength, KeyLocality keyLocality, HazelcastInstance hz) {
+        return generateStringKeys("", keyCount, keyLength, keyLocality, hz);
+    }
+
+    /**
+     * Generates an array of string keys with a configurable keyLocality.
+     *
+     * If the hz is a client, keyLocality is ignored.
+     *
+     * @param prefix      prefix for the generated keys
+     * @param keyCount    the number of keys in the array
+     * @param keyLocality if the key is local/remote/random
+     * @param hz          the HazelcastInstance that is used for keyLocality
+     * @return the created array of keys
+     */
+    public static String[] generateStringKeys(String prefix, int keyCount, KeyLocality keyLocality, HazelcastInstance hz) {
+        int keyLength = (int) (prefix.length() + Math.ceil(Math.log10(keyCount))) + 2;
+        return generateStringKeys(prefix, keyCount, keyLength, keyLocality, hz);
+    }
+
+    /**
+     * Generates an array of string keys with a configurable keyLocality.
+     *
+     * If the hz is a client, keyLocality is ignored.
+     *
+     * @param prefix      prefix for the generated keys
+     * @param keyCount    the number of keys in the array
+     * @param keyLength   the length of each string key
+     * @param keyLocality if the key is local/remote/random
+     * @param hz          the HazelcastInstance that is used for keyLocality
+     * @return the created array of keys
+     */
+    public static String[] generateStringKeys(String prefix, int keyCount, int keyLength, KeyLocality keyLocality,
+                                              HazelcastInstance hz) {
+
+
+        String[] keys = new String[keyCount];
+        KeyGenerator<String> keyGenerator = newStringKeyGenerator(hz, keyLocality, keyCount, keyLength, prefix);
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = keyGenerator.next();
+        }
+
+        return keys;
+    }
+
+    interface KeyGenerator<K> {
+        K next();
+    }
+
+    abstract static class BalancedKeyGenerator<K> implements KeyGenerator<K> {
+
+        protected final Random random = new Random();
+        protected final HazelcastInstance hz;
+        protected final int keyCount;
+
+        private final Set<K>[] keysPerPartition;
+        private final PartitionService partitionService;
+        private final int maxKeysPerPartition;
+        private final KeyLocality keyLocality;
+
+        @SuppressWarnings("unchecked")
+        BalancedKeyGenerator(HazelcastInstance hz, KeyLocality keyLocality, int keyCount) {
+            this.hz = hz;
+            this.keyLocality = keyLocality;
+            this.keyCount = keyCount;
+
+            this.partitionService = hz.getPartitionService();
+
+            Set<Integer> targetPartitions = getTargetPartitions();
+            this.maxKeysPerPartition = (int) Math.ceil(keyCount / (float) targetPartitions.size());
+
+            int partitionCount = partitionService.getPartitions().size();
+            this.keysPerPartition = new Set[partitionCount];
+            for (Integer partitionId : targetPartitions) {
+                keysPerPartition[partitionId] = new HashSet<>();
+            }
+        }
+
+        @Override
+        public final K next() {
+            for (; ; ) {
+                K key = generateKey();
+
+                Partition partition = partitionService.getPartition(key);
+
+                Set<K> keys = keysPerPartition[partition.getPartitionId()];
+                if (keys == null) {
+                    continue;
+                }
+
+                if (keys.contains(key)) {
+                    continue;
+                }
+
+                if (keys.size() == maxKeysPerPartition) {
+                    continue;
+                }
+
+                keys.add(key);
+                return key;
+            }
+        }
+
+        protected abstract K generateKey();
+
+        private Set<Integer> getTargetPartitions() {
+            Set<Integer> targetPartitions = new HashSet<>();
+            Member localMember = getLocalMember(hz);
+
+            switch (keyLocality) {
+                case LOCAL:
+                    for (Partition partition : partitionService.getPartitions()) {
+                        if (localMember == null || localMember.equals(partition.getOwner())) {
+                            targetPartitions.add(partition.getPartitionId());
+                        }
+                    }
+                    break;
+                case REMOTE:
+                    for (Partition partition : partitionService.getPartitions()) {
+                        if (localMember == null || !localMember.equals(partition.getOwner())) {
+                            targetPartitions.add(partition.getPartitionId());
+                        }
+                    }
+                    break;
+                case RANDOM:
+                    for (Partition partition : partitionService.getPartitions()) {
+                        targetPartitions.add(partition.getPartitionId());
+                    }
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported keyLocality: " + keyLocality);
+            }
+
+            verifyHasPartitions(targetPartitions);
+
+            return targetPartitions;
+        }
+
+        private void verifyHasPartitions(Set<Integer> targetPartitions) {
+            if (targetPartitions.isEmpty()) {
+                Map<Member, Integer> partitionsPerMember = new HashMap<>();
+                for (Partition partition : partitionService.getPartitions()) {
+                    Member owner = partition.getOwner();
+                    if (owner == null) {
+                        throw new IllegalStateException("Owner is null for partition: " + partition);
+                    }
+                    Integer value = partitionsPerMember.get(owner);
+                    Integer result = value == null ? 1 : value + 1;
+                    partitionsPerMember.put(owner, result);
+                }
+                throw new IllegalStateException("No partitions found, partitionsPerMember: " + partitionsPerMember);
+            }
+        }
+
+        private Member getLocalMember(HazelcastInstance hz) {
+            try {
+                return hz.getCluster().getLocalMember();
+            } catch (UnsupportedOperationException ignore) {
+                // clients throw UnsupportedOperationExceptions
+                return null;
+            }
+        }
+    }
+
+    private static final class SharedIntKeyGenerator implements KeyGenerator<Integer> {
+
+        private int current;
+
+        @Override
+        public Integer next() {
+            int value = current;
+            current++;
+            return value;
+        }
+    }
+
+    private static final class SinglePartitionIntKeyGenerator implements KeyGenerator<Integer> {
+
+        @Override
+        public Integer next() {
+            return 0;
+        }
+    }
+
+    private static final class BalancedIntKeyGenerator extends BalancedKeyGenerator<Integer> {
+
+        private BalancedIntKeyGenerator(HazelcastInstance hz, KeyLocality keyLocality, int keyCount) {
+            super(hz, keyLocality, keyCount);
+        }
+
+        @Override
+        protected Integer generateKey() {
+            return random.nextInt(Integer.MAX_VALUE);
+        }
+    }
+
+    private static final class BalancedStringKeyGenerator extends BalancedKeyGenerator<String> {
+
+        private final int keyLength;
+        private final String prefix;
+
+        private BalancedStringKeyGenerator(
+                HazelcastInstance hz, KeyLocality keyLocality, int keyCount, int keyLength, String prefix) {
+            super(hz, keyLocality, keyCount);
+            this.keyLength = keyLength;
+            this.prefix = prefix;
+        }
+
+        @Override
+        protected String generateKey() {
+            if (prefix.length() == 0) {
+                return generateAsciiString(keyLength);
+            } else {
+                return prefix + generateAsciiString(keyLength - prefix.length());
+            }
+        }
+    }
+
+    private static final class SinglePartitionStringKeyGenerator implements KeyGenerator<String> {
+
+        private final String key;
+
+        SinglePartitionStringKeyGenerator(int keyLength, String prefix) {
+            key = padWithZero(new StringBuilder(prefix), keyLength).toString();
+        }
+
+        @Override
+        public String next() {
+            return key;
+        }
+    }
+
+    private static StringBuilder padWithZero(StringBuilder sb, int length) {
+        int count = length - sb.length();
+
+        for (int i = 0; i < count; i++) {
+            sb.append('0');
+        }
+        return sb;
+    }
+
+    private static final class SharedStringKeyGenerator implements KeyGenerator<String> {
+
+        private int current;
+        private final int keyLength;
+        private final String prefix;
+
+        SharedStringKeyGenerator(int keyLength, String prefix) {
+            this.keyLength = keyLength;
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String next() {
+            int id = current;
+            current++;
+
+            int x = keyLength - prefix.length();
+            return prefix + format("%0" + x + "d", id);
+        }
+    }
+}

--- a/drivers/driver-hazelcast4/src/main/java/com/hazelcast/simulator/tests/map/MapTxTest.java
+++ b/drivers/driver-hazelcast4/src/main/java/com/hazelcast/simulator/tests/map/MapTxTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hazelcast.simulator.hz.map;
+package com.hazelcast.simulator.tests.map;
 
 import com.hazelcast.map.IMap;
 import com.hazelcast.simulator.hz.HazelcastTest;


### PR DESCRIPTION
Out-of-the-box test support to easily compare hz 3 and 4 versions. Having same tests for driver3 and driver4 makes life easier.