### PR TITLE
Fix distribution to include the drivers JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,10 @@
 
     <modules>
         <module>archetype</module>
-        <module>dist</module>
         <module>simulator</module>
         <module>drivers</module>
         <module>integration-tests</module>
+        <module>dist</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
In the current state, if you run `mvn clean install -DskipTests`, the drivers won't get included in the `dist/target/<name>.zip` because the dist module gets executed *before* the drivers are built, therefore the JARs won't get included. 

This will result in errors like: `FATAL 17:39:44 Could not locate driver class [com.hazelcast.simulator.hazelcast4.Hazelcast4Driver]`

This PR fixes this by moving the `dist` module in the `<modules>` list to the end as according to the official Maven documentation  ( https://maven.apache.org/guides/mini/guide-multiple-modules.html):
```
    a project dependency on another module in the build
    a plugin declaration where the plugin is another module in the build
    a plugin dependency on another module in the build
    a build extension declaration on another module in the build
    the order declared in the <modules> element (if no other rule applies)
```