### PR TITLE
Fix local runs + enhanced the getting started experience with example configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vtune/
 .DS_Store
 *.class
 simulator-git.properties
+logs/

--- a/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
+++ b/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
@@ -180,7 +180,11 @@ upload() {
     if [ -z "$public_ips" ] ; then
         echo "Local install"
         mkdir -p ${SIMULATOR_HOME}/workers/${session_id}/lib
-        cp -r ${local_install_dir} ${SIMULATOR_HOME}/workers/${session_id}/lib
+
+        for dir in $(find ${local_install_dir} -maxdepth 1 -type d); do
+          cp -r ${dir}/* ${SIMULATOR_HOME}/workers/${session_id}/lib
+        done
+
         return
     fi
 

--- a/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
+++ b/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
@@ -180,7 +180,11 @@ upload() {
     if [ -z "$public_ips" ] ; then
         echo "Local install"
         mkdir -p ${SIMULATOR_HOME}/workers/${session_id}/lib
-        cp -r ${local_install_dir} ${SIMULATOR_HOME}/workers/${session_id}/lib
+
+        for dir in $(find ${local_install_dir} -maxdepth 1 -type d); do
+          cp -r ${dir}/* ${SIMULATOR_HOME}/workers/${session_id}/lib
+        done
+
         return
     fi
 

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
@@ -94,6 +94,8 @@ class Wizard {
 
         copyResourceFile(workDir, "runScript", "run");
         copyResourceFile(workDir, "testSuite", "test.properties");
+        copyResourceFile(workDir, "example-member-config.xml", "hazelcast.xml");
+        copyResourceFile(workDir, "example-client-config.xml", "client-hazelcast.xml");
 
         if (isLocal(cloudProvider)) {
             return;

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/WizardUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/WizardUtils.java
@@ -44,9 +44,9 @@ final class WizardUtils {
     }
 
     static void copyResourceFile(File workDir, String sourceFileName, String destinationFileName) {
-        File runScript = ensureExistingFile(workDir, destinationFileName);
-        writeText(toTextFromResourceFile(sourceFileName), runScript);
-        execute(format("chmod u+x %s", runScript.getAbsolutePath()));
+        File file = ensureExistingFile(workDir, destinationFileName);
+        writeText(toTextFromResourceFile(sourceFileName), file);
+        execute(format("chmod u+x %s", file.getAbsolutePath()));
     }
 
     static File getProfileFile(String directory) {

--- a/simulator/src/main/resources/example-client-config.xml
+++ b/simulator/src/main/resources/example-client-config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client
+        xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+            http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd"
+        xmlns="http://www.hazelcast.com/schema/client-config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <cluster-name>workers</cluster-name>
+
+    <network>
+        <cluster-members>
+            <!-- Don't remove the comment below. The IP addresses of the members are auto-filled by Simulator using this marker. -->
+            <!--MEMBERS-->
+        </cluster-members>
+    </network>
+
+    <properties>
+        <property name="hazelcast.logging.type">log4j</property>
+    </properties>
+
+</hazelcast-client>

--- a/simulator/src/main/resources/example-member-config.xml
+++ b/simulator/src/main/resources/example-member-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+
+    <cluster-name>workers</cluster-name>
+
+    <!-- Don't remove the comment below. The lite member configuration is auto-filled by Simulator using this marker. -->
+    <!--LITE_MEMBER_CONFIG-->
+
+    <network>
+        <port port-count="200" auto-increment="true">5701</port>
+
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <!-- Don't remove the comment below. The IP addresses of the members are auto-filled by Simulator using this marker. -->
+                <!--MEMBERS-->
+            </tcp-ip>
+        </join>
+    </network>
+
+    <properties>
+        <property name="hazelcast.phone.home.enabled">false</property>
+    </properties>
+
+    <!-- Don't remove the comment below. The license key is auto-filled by Simulator using this marker. -->
+    <!--LICENSE-KEY-->
+
+    <map name="*">
+    </map>
+</hazelcast>
+

--- a/simulator/src/main/resources/runScript
+++ b/simulator/src/main/resources/runScript
@@ -27,7 +27,8 @@ coordinator --members ${members} \
             --duration ${duration} \
             --memberArgs "${memberJvmArgs}" \
             --clientArgs "${clientJvmArgs}" \
-            --parallel \
+            --driver hazelcast4 \
+            --version maven=4.2 \
              ${testsuite}.properties
 
 coordinator --clean


### PR DESCRIPTION
This PR tries to simplify the onboarding of new users to Simulator. Namely:
* Fix running tests locally for Hazelcast 3 and 4 - the change needed is in the `install-hazelcast-support*.sh` scripts. The JARs weren't properly copied to the classpath of the workers.
* Often the first problem everybody faces when starting with Simulator is that they don't know where to put member config, where to put client config, what are the simple coordinator parameters etc. I added those example configs. Therefore, in order to get your first Simulator test running, you only need to do `simulator-wizard --createWorkDir tests` and then ./tests/run