### PR TITLE
Enhancements for simulator-wizard and provisioning in AWS

### DIFF
--- a/dist/src/main/dist/conf/aws-ec2_provision.sh
+++ b/dist/src/main/dist/conf/aws-ec2_provision.sh
@@ -111,8 +111,9 @@ EOL
     args="$args --instance-type $INSTANCE_TYPE"
     args="$args --instance-initiated-shutdown-behavior terminate"
 
-    if [ "$SUBNET_ID" = "default" ]; then
-        args="$args --security-groups $SECURITY_GROUP"
+    if [ "$SUBNET_ID" = "default" ] || [ "$SUBNET_ID" = "" ]; then
+        echo "[ERROR] Please specify a subnet ID via SUBNET_ID property."
+        exit 1
     else
         args="$args --subnet $SUBNET_ID"
     fi

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/CloudProviderUtils.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/CloudProviderUtils.java
@@ -17,11 +17,15 @@ package com.hazelcast.simulator.utils;
 
 import com.hazelcast.simulator.common.SimulatorProperties;
 
+import java.util.Arrays;
+
 public final class CloudProviderUtils {
 
     public static final String PROVIDER_LOCAL = "local";
     public static final String PROVIDER_STATIC = "static";
     public static final String PROVIDER_EC2 = "aws-ec2";
+
+    public static final String[] SUPPORTED_CLOUD_PROVIDERS = { PROVIDER_LOCAL, PROVIDER_STATIC, PROVIDER_EC2 };
 
     private CloudProviderUtils() {
     }
@@ -58,5 +62,9 @@ public final class CloudProviderUtils {
 
     public static boolean isEC2(String cloudProvider) {
         return PROVIDER_EC2.equals(cloudProvider);
+    }
+
+    public static boolean isSupported(String cloudProvider) {
+        return Arrays.asList(SUPPORTED_CLOUD_PROVIDERS).contains(cloudProvider);
     }
 }

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
@@ -24,6 +24,7 @@ import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.apache.log4j.Logger;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.TreeSet;
 
@@ -31,12 +32,7 @@ import static com.hazelcast.simulator.common.AgentsFile.preferredAgentsFile;
 import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_CREDENTIAL;
 import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_IDENTITY;
 import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_EC2;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_LOCAL;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_STATIC;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.isLocal;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.isStatic;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.*;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingDirectory;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingFile;
@@ -87,6 +83,10 @@ class Wizard {
         File workDir = new File(pathName).getAbsoluteFile();
         if (workDir.exists()) {
             throw new CommandLineExitException(format("Working directory '%s' already exists!", workDir));
+        }
+
+        if (!isSupported(cloudProvider)) {
+            throw new CommandLineExitException(format("Unsupported cloud provider %s. Must be one of: %s", workDir, Arrays.asList(SUPPORTED_CLOUD_PROVIDERS)));
         }
 
         echo("Will create working directory '%s' for cloud provider '%s'", workDir, cloudProvider);

--- a/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/wizard/Wizard.java
@@ -29,10 +29,15 @@ import java.util.Properties;
 import java.util.TreeSet;
 
 import static com.hazelcast.simulator.common.AgentsFile.preferredAgentsFile;
-import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_CREDENTIAL;
-import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_IDENTITY;
 import static com.hazelcast.simulator.common.SimulatorProperties.CLOUD_PROVIDER;
-import static com.hazelcast.simulator.utils.CloudProviderUtils.*;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_EC2;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_LOCAL;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.PROVIDER_STATIC;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.SUPPORTED_CLOUD_PROVIDERS;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isEC2;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isLocal;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isStatic;
+import static com.hazelcast.simulator.utils.CloudProviderUtils.isSupported;
 import static com.hazelcast.simulator.utils.FileUtils.appendText;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingDirectory;
 import static com.hazelcast.simulator.utils.FileUtils.ensureExistingFile;
@@ -86,7 +91,11 @@ class Wizard {
         }
 
         if (!isSupported(cloudProvider)) {
-            throw new CommandLineExitException(format("Unsupported cloud provider %s. Must be one of: %s", workDir, Arrays.asList(SUPPORTED_CLOUD_PROVIDERS)));
+            throw new CommandLineExitException(
+                    format("Unsupported cloud provider %s. Must be one of: %s",
+                            workDir,
+                            Arrays.asList(SUPPORTED_CLOUD_PROVIDERS))
+            );
         }
 
         echo("Will create working directory '%s' for cloud provider '%s'", workDir, cloudProvider);
@@ -106,14 +115,7 @@ class Wizard {
         File simulatorPropertiesFile = ensureExistingFile(workDir, SimulatorProperties.PROPERTIES_FILE_NAME);
         writeText(format("%s=%s%n", CLOUD_PROVIDER, cloudProvider), simulatorPropertiesFile);
         if (isEC2(cloudProvider)) {
-            appendText(format(
-                    "%n# These files contain your AWS access key ID and secret access key (change if needed)%n#%s=%s%n#%s=%s%n",
-                    CLOUD_IDENTITY, simulatorProperties.get(CLOUD_IDENTITY),
-                    CLOUD_CREDENTIAL, simulatorProperties.get(CLOUD_CREDENTIAL)),
-                    simulatorPropertiesFile);
-            appendText(format(
-                    "%n# Machine specification used for AWS (change if needed)%n#MACHINE_SPEC=%s%n",
-                    simulatorProperties.get("MACHINE_SPEC")), simulatorPropertiesFile);
+            copyResourceFile(workDir, "awsEc2SimulatorProperties", "simulator.properties");
         }
 
         if (isStatic(cloudProvider)) {

--- a/simulator/src/main/resources/awsEc2SimulatorProperties
+++ b/simulator/src/main/resources/awsEc2SimulatorProperties
@@ -1,0 +1,20 @@
+CLOUD_PROVIDER=aws-ec2
+
+# User to be logged in under. ("ec2-user" is the usual default in AWS images)
+SIMULATOR_USER=ec2-user
+
+# By default, Simulator looks into these files for your AWS access key ID and secret access key
+CLOUD_IDENTITY=~/ec2.identity
+CLOUD_CREDENTIAL=~/ec2.credential
+
+# Subnet to be used. Mandatory to specify.
+SUBNET_ID=
+
+# AWS EC2 instance type to be used AWS
+INSTANCE_TYPE=c4.xlarge
+
+# AWS region where the machines should be provisioned
+REGION=us-east-1
+
+# Image to be used for provisioning. Below, by default is Amazon Linux 2 AMI (HVM)
+IMAGE_ID=ami-0fc61db8544a617ed

--- a/simulator/src/main/resources/testSuite
+++ b/simulator/src/main/resources/testSuite
@@ -1,3 +1,5 @@
-IntByteMapTest@class = com.hazelcast.simulator.tests.map.IntByteMapTest
-IntByteMapTest@threadCount = 10
-IntByteMapTest@putProb = 0.1
+class = com.hazelcast.simulator.tests.map.IntByteMapTest
+threadCount = 10
+
+getProb = 0.9
+putProb = 0.1


### PR DESCRIPTION
This PR contains following enhancements for `simulator-wizard` command:
* Check whether a valid cloud provider is set through the `--cloudProvider` and throw a descriptive error if not, to prevent accidental typos like `aws` instead of `aws-ec2` and then chasing the root cause for a long time.
* Provide example `simulator.properties` with sensible defaults to illustrate the structure of the file to the new user and provide her a good starting point for editing. I'll probably add more example properties later (like selecting JDK version etc.).
* Make provisioner fail-fast when subnet ID is not specified. The change might look odd (like removing security groups config) but you'll find an explanation of the change directly on the line in this PR. (https://github.com/hazelcast/hazelcast-simulator/pull/1937#issue-628591725)