### PR TITLE
Improvements to version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1853,6 +1853,8 @@ benchmark-report mybenchmark 2016-08-02__22_08_09 2016-08-02__22_18_21
 The file `simulator.properties` is placed at the `conf` folder of your Hazelcast Simulator. This file is used to prepare the 
 Simulator tests for their proper executions according to your business needs.
 
+For the full reference of available settings and their explanation, please refer to [default simulator.properties](dist/src/main/dist/conf/simulator.properties).
+
 ![](images/NoteSmall.jpg)***NOTE:*** *Currently, the main focuses are on the Simulator tests of Hazelcast on Amazon EC2 and
  Google Compute Engine (GCE). For the preparation of `simulator.properties` for GCE, please refer to the
   [Setting Up For GCE section](#setting-up-for-google-compute-engine). The following `simulator.properties` file description is mainly for Amazon EC2.*

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@
 
 Hazelcast Simulator is a production simulator used to test Hazelcast and Hazelcast-based applications in clustered environments. 
 It also allows you to create your own tests and perform them on your Hazelcast clusters and applications that are deployed to 
-cloud computing environments. In your tests, you can provide any property that can be specified on these environments (Amazon EC2, 
-Google Compute Engine(GCE), or your own environment): properties such as hardware specifications, operating system, Java version, etc.
+cloud computing environments. In your tests, you can provide any property that can be specified on these environments (Amazon EC2 or your own environment): properties such as hardware specifications, operating system, Java version, etc.
 
 Hazelcast Simulator allows you to add potential production problems, such as real-life failures, network problems, overloaded CPU,
  and failing nodes to your tests. It also provides a benchmarking and performance testing platform by supporting performance 
@@ -164,7 +163,7 @@ Congratulations, you successfully ran Simulator for the first time! Please refer
 ## Preparations to setup Remote Machines
 
 Beside the local setup, there are also static setups (fixed list of given remote machines, e.g. your local machines, a test laboratory) 
-and cloud setups (e.g. Amazon EC2, Google Compute Engine). For all those remote machines, you need to configure a password free SSH
+and cloud setups (e.g. Amazon EC2). For all those remote machines, you need to configure a password free SSH
  access. You may also need to configure the firewall between your local and the remote machines.
 
 ## Firewall Settings
@@ -1854,10 +1853,6 @@ The file `simulator.properties` is placed at the `conf` folder of your Hazelcast
 Simulator tests for their proper executions according to your business needs.
 
 For the full reference of available settings and their explanation, please refer to [default simulator.properties](dist/src/main/dist/conf/simulator.properties).
-
-![](images/NoteSmall.jpg)***NOTE:*** *Currently, the main focuses are on the Simulator tests of Hazelcast on Amazon EC2 and
- Google Compute Engine (GCE). For the preparation of `simulator.properties` for GCE, please refer to the
-  [Setting Up For GCE section](#setting-up-for-google-compute-engine). The following `simulator.properties` file description is mainly for Amazon EC2.*
 
 # Run Simulator with MongoDB
 

--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -6,7 +6,6 @@
 # local = statically configured to run on the local machine.
 # static = statically configured set of machines.
 # aws-ec2 = Amazon EC2
-# google-compute-engine = The Google Compute Engine.
 
 #
 # If you are using aws-ec, make sure the SUBNET_ID and PLACEMENT_GROUP

--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -154,20 +154,19 @@ INSTANCE_TYPE=c5.2xlarge
 #                             Local Hazelcast artifacts will be preferred, so you
 #                             can checkout e.g. an experimental branch, build the
 #                             artifacts locally. This will all be done on the local
-#                             machine, not
-#                             on the agent machine.
+#                             machine, not on the agent machine.
 #   bringmyown              : if you want to bring your own dependencies. To upload your
 #                             dependencies, in the working dir, create an 'upload'
 #                             directory. The content of this directory will be
 #                             uploaded to the agents and automatically
-#   added to the classpath of the workers.
+#                             added to the classpath of the workers.
 #   git=version             : if you want Simulator to use a specific version of
 #                             Hazelcast from Git, e.g.:
 #                                   git=f0288f713    to build a specific revision
 #                                   git=v3.2.3       to build a version from a Git tag
 #                                   git=myRepository/myBranch - to build a version
 #                                   from a branch in a specific repository.
-#   Use GIT_CUSTOM_REPOSITORIES to specify custom repositories. The main Hazelcast
+#                             Use GIT_CUSTOM_REPOSITORIES to specify custom repositories. The main Hazelcast
 #                             repository is always named "origin".
 #
 VERSION_SPEC=outofthebox

--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -438,3 +438,9 @@ COORDINATOR_PORT=0
 # The timeout in seconds waiting for a test to complete after it ends the run phase.
 #
 TEST_COMPLETION_TIMEOUT_SECONDS=300
+
+#
+# Path to a settings.xml to be used when retrieving artifacts via Maven.
+#
+#
+# CUSTOM_MAVEN_SETTINGS=/path/to/settings.xml

--- a/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
+++ b/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
@@ -79,9 +79,15 @@ prepare_using_maven() {
     sed -i'' "s|@hz-version|${version}|" pom.xml
     sed -i'' "s|@hz-output|${destination}|" pom.xml
 
+    custom_maven_settings=""
+    if [ ! -z ${CUSTOM_MAVEN_SETTINGS} ]; then
+        echo "Using custom Maven settings: ${CUSTOM_MAVEN_SETTINGS}"
+        custom_maven_settings="-s ${CUSTOM_MAVEN_SETTINGS}"
+    fi
+
     # The Maven Dependency plugin actually checks whether the artifact is already present and picks it if it is.
     # Therefore, it won't re-download it every time and there's no need for extra handling of this case.
-    ${SIMULATOR_HOME}/conf/mvnw/mvnw dependency:copy-dependencies -Dmaven.repo.local=${SIMULATOR_HOME}/m2 -q -U
+    ${SIMULATOR_HOME}/conf/mvnw/mvnw $custom_maven_settings dependency:copy-dependencies -Dmaven.repo.local=${SIMULATOR_HOME}/m2 -q -U
 
     rm pom.xml
     rm -r .mvn

--- a/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
+++ b/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
@@ -47,10 +47,19 @@ prepare_using_maven() {
     destination=${local_install_dir}/maven-${version}
     mkdir -p ${destination}
 
+    # get the configured local Maven repository
+    pushd ${local_install_dir} > /dev/null
+    cp -r ${SIMULATOR_HOME}/conf/mvnw/.mvn .
+
+    local_repository_path=`${SIMULATOR_HOME}/conf/mvnw/mvnw help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`
+
+    rm -r .mvn
+    popd > /dev/null
+
     # we first have a look at the local Maven repository, so it's easy to provide a custom built version
-    hazelcast_jar="$HOME/.m2/repository/com/hazelcast/${artifact_id}/${version}/${artifact_id}-${version}.jar"
+    hazelcast_jar="$local_repository_path/com/hazelcast/${artifact_id}/${version}/${artifact_id}-${version}.jar"
     if [[ "${SKIP_LOCAL_MAVEN_REPO_LOOKUP}" == "false" ]] ; then
-        echo "Searching for $hazelcast_jar in local Maven repo"
+        echo "Searching for $hazelcast_jar in local Maven repo ($local_repository_path)"
         if [[ -f "${hazelcast_jar}" ]] ; then
             echo "Found $hazelcast_jar in local Maven repo, copying to $destination"
             cp ${hazelcast_jar} ${destination}
@@ -70,6 +79,8 @@ prepare_using_maven() {
     sed -i'' "s|@hz-version|${version}|" pom.xml
     sed -i'' "s|@hz-output|${destination}|" pom.xml
 
+    # The Maven Dependency plugin actually checks whether the artifact is already present and picks it if it is.
+    # Therefore, it won't re-download it every time and there's no need for extra handling of this case.
     ${SIMULATOR_HOME}/conf/mvnw/mvnw dependency:copy-dependencies -Dmaven.repo.local=${SIMULATOR_HOME}/m2 -q -U
 
     rm pom.xml

--- a/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
+++ b/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
@@ -198,7 +198,7 @@ upload() {
         echo "Local install"
         mkdir -p ${SIMULATOR_HOME}/workers/${session_id}/lib
 
-        for dir in $(find ${local_install_dir} -maxdepth 1 -type d); do
+        for dir in $(find ${local_install_dir} -maxdepth 1 -type d -not -empty); do
           cp -r ${dir}/* ${SIMULATOR_HOME}/workers/${session_id}/lib
         done
 

--- a/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
+++ b/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
@@ -199,7 +199,7 @@ upload() {
         echo "Local install"
         mkdir -p ${SIMULATOR_HOME}/workers/${session_id}/lib
 
-        for dir in $(find ${local_install_dir} -maxdepth 1 -type d); do
+        for dir in $(find ${local_install_dir} -maxdepth 1 -type d -not -empty); do
           cp -r ${dir}/* ${SIMULATOR_HOME}/workers/${session_id}/lib
         done
 

--- a/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
+++ b/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
@@ -80,9 +80,15 @@ prepare_using_maven() {
     sed -i'' "s|@hz-version|${version}|" pom.xml
     sed -i'' "s|@hz-output|${destination}|" pom.xml
 
+    custom_maven_settings=""
+    if [ ! -z ${CUSTOM_MAVEN_SETTINGS} ]; then
+        echo "Using custom Maven settings: ${CUSTOM_MAVEN_SETTINGS}"
+        custom_maven_settings="-s ${CUSTOM_MAVEN_SETTINGS}"
+    fi
+
     # The Maven Dependency plugin actually checks whether the artifact is already present and picks it if it is.
     # Therefore, it won't re-download it every time and there's no need for extra handling of this case.
-    ${SIMULATOR_HOME}/conf/mvnw/mvnw dependency:copy-dependencies -Dmaven.repo.local=${SIMULATOR_HOME}/m2 -q -U
+    ${SIMULATOR_HOME}/conf/mvnw/mvnw $custom_maven_settings dependency:copy-dependencies -Dmaven.repo.local=${SIMULATOR_HOME}/m2 -q -U
 
     rm pom.xml
     rm -r .mvn

--- a/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
+++ b/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
@@ -47,10 +47,20 @@ prepare_using_maven() {
     destination=${local_install_dir}/maven-${version}
     mkdir -p ${destination}
 
+    # get the configured local Maven repository
+    pushd ${local_install_dir} > /dev/null
+    cp -r ${SIMULATOR_HOME}/conf/mvnw/.mvn .
+
+    local_repository_path=`${SIMULATOR_HOME}/conf/mvnw/mvnw help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`
+
+    rm -r .mvn
+    popd > /dev/null
+
+    hazelcast_jar="$local_repository_path/com/hazelcast/${artifact_id}/${version}/${artifact_id}-${version}.jar"
+
     # we first have a look at the local Maven repository, so it's easy to provide a custom built version
-    hazelcast_jar="$HOME/.m2/repository/com/hazelcast/${artifact_id}/${version}/${artifact_id}-${version}.jar"
     if [[ "${SKIP_LOCAL_MAVEN_REPO_LOOKUP}" == "false" ]] ; then
-        echo "Searching for $hazelcast_jar in local Maven repo"
+        echo "Searching for $hazelcast_jar in local Maven repo ($local_repository_path)"
         if [[ -f "${hazelcast_jar}" ]] ; then
             echo "Found $hazelcast_jar in local Maven repo, copying to $destination"
             cp ${hazelcast_jar} ${destination}
@@ -70,6 +80,8 @@ prepare_using_maven() {
     sed -i'' "s|@hz-version|${version}|" pom.xml
     sed -i'' "s|@hz-output|${destination}|" pom.xml
 
+    # The Maven Dependency plugin actually checks whether the artifact is already present and picks it if it is.
+    # Therefore, it won't re-download it every time and there's no need for extra handling of this case.
     ${SIMULATOR_HOME}/conf/mvnw/mvnw dependency:copy-dependencies -Dmaven.repo.local=${SIMULATOR_HOME}/m2 -q -U
 
     rm pom.xml


### PR DESCRIPTION
This PR contains small improvements to the ways of  specifying which version of Hazelcast you want to use for the test and where it comes from. In other words, these enhancements are related to `--version` flag. Namely:

* Undo hardcoded local Maven repository path. The user might have specified a custom one in her settings.xml, so Simulator should respect that. Newly, the script first reads the currently set path and then uses that.
* Provide ability to specify custom Maven settings.xml via `CUSTOM_MAVEN_SETTINGS` property in `simulator.properties`. This settings.xml will be used when using Maven for the retrieval of artifacts. This enables a use case that we had recently with a customer - customer couldn't access Maven Central due to security policies, but they had a company Nexus instance with approved artifacts. We had no way how to configure Simulator to look there (also needed authentication) and not in Maven Central. 
* Fix "bringmyown" version spec on local which was failing. 

I also slipped a trivial indentation adjustment in the `simulator.properties` comments in this PR.
