### PR TITLE
Fix deadlock when error occurs in DownloadTask during shutdown

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/DownloadTask.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/coordinator/tasks/DownloadTask.java
@@ -53,10 +53,14 @@ public class DownloadTask {
 
         String installFile = getConfigurationFile("download.sh").getAbsolutePath();
         String agentIps = join(agents, ",");
+        // setThrowsException(true), which causes to throw and exception rather than
+        // calling System.exit(), is set on purpose. DownloadTask is run in the shutdown hook mechanism.
+        // If an error occurs during DownloadTask in the shutdown process, without "true" it yields to deadlock.
         new BashCommand(installFile)
                 .ensureJavaOnPath()
                 .addEnvironment(simulatorProperties)
                 .addParams(rootDir.getAbsolutePath(), sessionId, agentIps)
+                .setThrowsException(true)
                 .execute();
 
         LOGGER.info("Downloading complete!");


### PR DESCRIPTION
This PR fixes an issue of coordinator hanging indefinitely under some conditions. Consider following scenario (which is actually a reproducer).

Set `CUSTOM_MAVEN_SETTINGS` to non-existing file. During the driver installation phase of coordinator, the `install-hazecast4.sh` script fails here: https://github.com/hazelcast/hazelcast-simulator/blob/master/drivers/driver-hazelcast4/src/main/java/com/hazelcast/simulator/hazelcast4/Hazelcast4Driver.java#L210 . This boils down to `System.exit()` being called (through here: https://github.com/hazelcast/hazelcast-simulator/blob/master/simulator/src/main/java/com/hazelcast/simulator/utils/BashCommand.java#L144) effectively shutting down the coordinator process.

Coordinator has a shutdown hook registered which contains a call of DownloadTask (https://github.com/hazelcast/hazelcast-simulator/blob/master/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java#L149 and https://github.com/hazelcast/hazelcast-simulator/blob/master/simulator/src/main/java/com/hazelcast/simulator/coordinator/Coordinator.java#L185 ).  

When the shutdown hook gets executed, DownloadTask gets executed. However, if a DownloadTask fails as well, which it will because it tries to download a result directory that isn't existing because we failed with Maven installation even before the test started, it boils down to another call of `System.exit()` in the same place in `BashCommand` mentioned above. And since one shutdown is already in place, this creates a deadlock.

The deadlock can be seen from thread dump:
```
"Thread-3" #13 prio=5 os_prio=0 tid=0x00007f52f16bc000 nid=0x9de2 waiting for monitor entry [0x00007f52d8813000]
   java.lang.Thread.State: BLOCKED (on object monitor)
    at java.lang.Shutdown.exit(Shutdown.java:215)
    - waiting to lock <0x00000000eeb00bb0> (a java.lang.Class for java.lang.Shutdown)
    at java.lang.Runtime.exit(Runtime.java:109)
    at java.lang.System.exit(System.java:971)
    at com.hazelcast.simulator.utils.CommonUtils.exit(CommonUtils.java:255)
    at com.hazelcast.simulator.utils.CommonUtils.exitWithError(CommonUtils.java:236)
    at com.hazelcast.simulator.utils.BashCommand.execute(BashCommand.java:146)
    at com.hazelcast.simulator.coordinator.tasks.DownloadTask.run(DownloadTask.java:60)
    at com.hazelcast.simulator.coordinator.Coordinator.close(Coordinator.java:189)

...

"main" #1 prio=5 os_prio=0 tid=0x00007f52f0021800 nid=0x9d4f in Object.wait() [0x00007f52f78b2000]
   java.lang.Thread.State: WAITING (on object monitor)
    at java.lang.Object.wait(Native Method)
    - waiting on <0x00000000eeb00a38> (a java.lang.Thread)
    at java.lang.Thread.join(Thread.java:1252)
    - locked <0x00000000eeb00a38> (a java.lang.Thread)
    at java.lang.Thread.join(Thread.java:1326)
    at java.lang.ApplicationShutdownHooks.runHooks(ApplicationShutdownHooks.java:107)
    at java.lang.ApplicationShutdownHooks$1.run(ApplicationShutdownHooks.java:46)
    at java.lang.Shutdown.runHooks(Shutdown.java:123)
    at java.lang.Shutdown.sequence(Shutdown.java:170)
    at java.lang.Shutdown.exit(Shutdown.java:216)
    - locked <0x00000000eeb00bb0> (a java.lang.Class for java.lang.Shutdown)
    at java.lang.Runtime.exit(Runtime.java:109)
    at java.lang.System.exit(System.java:971)
    at com.hazelcast.simulator.utils.CommonUtils.exit(CommonUtils.java:255)
    at com.hazelcast.simulator.utils.CommonUtils.exitWithError(CommonUtils.java:236)
    at com.hazelcast.simulator.utils.BashCommand.execute(BashCommand.java:146)
    at com.hazelcast.simulator.hazelcast4.Hazelcast4Driver.install(Hazelcast4Driver.java:213)
```

The solution is to fail the DownloadTask only with throwing the exception and continue the flow without calling `System.exit()`. The exception gets nicely printed in the coordinator output making it visible. Also the root cause exception (e.g. from the Maven installation) is printed in the `bash.log`. Therefore, all the errors are correctly reported and it's easy to find what went wrong + the coordinator process correctly terminates.