### PR TITLE
Fix benchmark-report vertical drop in throughput charts + minor missing dstat fix

### DIFF
--- a/dist/src/main/dist/conf/init_report_files.sh
+++ b/dist/src/main/dist/conf/init_report_files.sh
@@ -20,8 +20,12 @@ for worker_dir_name in "${worker_dir_names[@]}"
 do
     worker_dir=$session_dir/$worker_dir_name
     if [ -d "${worker_dir}" ] ; then
-        mkdir -p $report_dir/tmp/$hdr_target_dir_name/$worker_dir_name
-        cp $session_dir/$worker_dir_name/*.hdr $report_dir/tmp/$hdr_target_dir_name/$worker_dir_name/ || true
+        # check if there are any .hdr files in the worker? Covering the case when latency is measured on clients, not on members
+        hdr_worker_files=(`find  $session_dir/$worker_dir_name -maxdepth 1 -name "*.hdr"`)
+        if [ ${#hdr_worker_files[@]} -gt 0 ]; then
+          mkdir -p $report_dir/tmp/$hdr_target_dir_name/$worker_dir_name
+          cp $session_dir/$worker_dir_name/*.hdr $report_dir/tmp/$hdr_target_dir_name/$worker_dir_name/ || true
+        fi
     fi
 done
 
@@ -97,7 +101,8 @@ do
     java -cp "${SIMULATOR_HOME}/lib/*"  com.hazelcast.simulator.utils.ReportCsv $hgrm_file $report_dir $session_dir
 done
 
-# copy the dstats files
-cp ${session_dir}/*_dstat.csv ${report_dir}/tmp/$hdr_target_dir_name
-
-
+# copy the dstats files if they exist
+dstat_worker_files=(`find  ${session_dir} -maxdepth 1 -name "*_dstat.csv"`)
+if [ ${#dstat_worker_files[@]} -gt 0 ]; then
+  cp ${session_dir}/*_dstat.csv ${report_dir}/tmp/$hdr_target_dir_name
+fi


### PR DESCRIPTION
This PR fixes two minor issues and one big with `benchmark-report` script for generating the charts:
* **Warning messages when HDR files are not present** - trivial fix. For example, if you configure Simulator to stress the cluster with clients, the number of operations is tracked only on the clients. Therefore, the member workers won't generate any HDR files (= files measuring latency of the operations). However, `benchmark-report` expects it there anyway and if it's not in the worker directory, it prints error like `cp ... ...: File not found` which looks annoying. The solution is to simply copy them only if they exist. Relevant part of the PR: https://github.com/hazelcast/hazelcast-simulator/pull/1943/files#diff-aff6d044ebd89a44be2da1b433372e8c47982d885a43f9377a4cf5513297b258R23-R28

* **Missing dstat files cause it to fail** - trivial fix. If you don't have dstat installed on your worker machines, Simulator won't generate the dstat files. However, benchmark-report expects it either way and if they are not present, the subprocess of copying them fails failing the whole benchmark-report execution. The solution is to simply copy them only if they exist. Relevant part of the PR: https://github.com/hazelcast/hazelcast-simulator/pull/1943/files#diff-aff6d044ebd89a44be2da1b433372e8c47982d885a43f9377a4cf5513297b258R104-R108

* **Fix vertical drop in the end of the throughput chart making it look terrible** - this one is a tricky one, so let me describe it extensively for the PR to make sense. 

The problem that we're talking about visualized:
![broken_throughput_chart](https://user-images.githubusercontent.com/4253850/118897836-667a4500-b90b-11eb-901c-f174b06a4dc4.png)

I believe it's quite obvious what's wrong with it, so let's explain what's happening. Here's another run where I demonstrate the root cause. Consider following "total" throughput chart aggregating all client workers into a single line that represents the performance of the cluster:
![aggregated_throughput_chart](https://user-images.githubusercontent.com/4253850/118897921-a04b4b80-b90b-11eb-8adc-0cd7a0cfc47e.png)

We see the dip again. Now let's look at the per-worker throughput charts of that run:
![per_worker_throughput_chart](https://user-images.githubusercontent.com/4253850/118897972-c7a21880-b90b-11eb-95a3-c4c3a1c37ea9.png)

What's happening - if you take a look at the per-worker chart, you see that in the end, one line ends further than the other 3. Because the aggregated throughput chart is a sum of all workers at the specific time, now it's it's obvious where the drop is coming - in the last data point, there's only a single number from one worker (the point is "alone" at that time). Given that in this case we have 4 workers, the resulting value is very roughly 1/4 of the total throughput. Hence, the last point in the total throughput chart is very low, thus creating the vertical dip. 

You can also note from the per-worker chart that even the difference in the beginning of the chart is suspicious. What's happening is that the other 3 lines got trimmed by one data point (the first one), thus moving the whole line to the left, leaving one point alone at the end.

Why did the other 3 got trimmed? `benchmark-report` selects the period of the test by timestamps, more specifically in epoch time in this loop: https://github.com/hazelcast/hazelcast-simulator/blob/master/dist/src/main/dist/conf/benchmark-report.py#L918 . By selecting the period, it in the end means filling the `self.period` field with `start_time` and `end_time` (https://github.com/hazelcast/hazelcast-simulator/blob/master/dist/src/main/dist/conf/benchmark-report.py#L946). How it does it - it goes through the worker reports and **every time, it replaces** the period boundaries, so that means that the period is chosen based on the last process worker results. In our case, it was A1_W5. It then simply trims **all the lines** based on that interval (https://github.com/hazelcast/hazelcast-simulator/blob/master/dist/src/main/dist/conf/benchmark-report.py#L411).

Coming to the end, what's happening here. The epoch time reported by Simulator worker is in milliseconds even though all the series where sent in the same second and that's also the minimal granularity of how often it can be send (see WORKER_PERFORMANCE_MONITOR_INTERVAL_SECONDS property). In our case, the starting times of each series were:
```
A1_W3 = 1621460611.392
A1_W4 = 1621460611.361
A1_W5 = 1621460611.412
A1_W6 = 1621460611.36
```

You can see, that our last process worker (A1_W5) has the latest starting time. Since it's setting the interval, that means that all the other series will get trimmed the first point away -> resulting in one less point trimmed from the beginning -> shift of the line to the left -> "orphaned" point at the end of A1_W5 line -> dip.

The solution makes sure that the interval takes the earliest starting time and also last ending time, because the issue happens also the other way around. Relevant part of the fix: https://github.com/hazelcast/hazelcast-simulator/pull/1943/files#diff-cf8eaa82e75afd8c8e2c7a63ee611f5da0c87e5b00d5183444af2cd8e4c49bdeR941-R951

Same results plotted in charts with the fix (note the aligned endings in the per-worker chart):
![fixed_aggregated_throughput](https://user-images.githubusercontent.com/4253850/118899297-c6beb600-b90e-11eb-9c83-cc718ec4401c.png)
![fixed_per_worker_throughput](https://user-images.githubusercontent.com/4253850/118899304-c9b9a680-b90e-11eb-8b05-0f4390c5dbb7.png)


Sorry for a long and maybe too detailed explanation. The reviewer gets a beer from me :) 