### PR TITLE
Fix faulty classpath when both bringmyown and maven is used

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessLauncher.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessLauncher.java
@@ -239,6 +239,13 @@ public class WorkerProcessLauncher {
             classpath += CLASSPATH_SEPARATOR + simulatorHome + "/drivers/driver-" + driver + "/*";
         }
 
+        // This will add all upload directory to classpath in case bringmyown
+        // option isn't used but since it will be after drivers the JVM will use
+        // correct JARs
+        if (!parameters.get("VERSION_SPEC").equals("bringmyown")) {
+            classpath += CLASSPATH_SEPARATOR + workerHome.getAbsolutePath() + "/upload/*";
+        }
+
         return classpath;
     }
 

--- a/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessLauncher.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerProcessLauncher.java
@@ -216,9 +216,11 @@ public class WorkerProcessLauncher {
 
     private String getClasspath(File workerHome) {
         String simulatorHome = getSimulatorHome().getAbsolutePath();
-        String classpath = new File(getSessionDirectory(), "lib/*").getAbsolutePath()
-                + CLASSPATH_SEPARATOR + workerHome.getAbsolutePath() + "/upload/*"
-                + CLASSPATH_SEPARATOR + simulatorHome + "/user-lib/*"
+        String classpath = new File(getSessionDirectory(), "lib/*").getAbsolutePath();
+        if (parameters.get("VERSION_SPEC").equals("bringmyown")) {
+            classpath += CLASSPATH_SEPARATOR + workerHome.getAbsolutePath() + "/upload/*";
+        }
+        classpath += CLASSPATH_SEPARATOR + simulatorHome + "/user-lib/*"
                 + uploadDirToClassPath(workerHome)
                 + CLASSPATH_SEPARATOR + CLASSPATH;
 


### PR DESCRIPTION
Currently upload directory added to classpath always. This fix aims to fix that by adding upload jar only if that specific run has bringmyown option. This way someone can run maven and bringmyown options sequently without having change the directory name(`upload` directory to `upload_` for example) manually. Otherwise both runs are going to use jar in the `upload` directory.