### PR TITLE
fix for install-hazelcast-support4.sh not working on MacOS

### DIFF
--- a/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
+++ b/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
@@ -74,11 +74,11 @@ prepare_using_maven() {
     cp -r ${SIMULATOR_HOME}/conf/mvnw/.mvn .
     cp ${SIMULATOR_HOME}/conf/dependency-copy.xml pom.xml
 
-    sed -i'' "s|@hz-repo-release|${release_repo}|" pom.xml
-    sed -i'' "s|@hz-repo-snapshot|${snapshot_repo}|" pom.xml
-    sed -i'' "s|@hz-artifact|${artifact_id}|" pom.xml
-    sed -i'' "s|@hz-version|${version}|" pom.xml
-    sed -i'' "s|@hz-output|${destination}|" pom.xml
+    sed -i '' "s|@hz-repo-release|${release_repo}|" pom.xml
+    sed -i '' "s|@hz-repo-snapshot|${snapshot_repo}|" pom.xml
+    sed -i '' "s|@hz-artifact|${artifact_id}|" pom.xml
+    sed -i '' "s|@hz-version|${version}|" pom.xml
+    sed -i '' "s|@hz-output|${destination}|" pom.xml
 
     custom_maven_settings=""
     if [ ! -z ${CUSTOM_MAVEN_SETTINGS} ]; then


### PR DESCRIPTION
In the training given by Jiri today we were not able to run a local test on MacOS.  The problem occurred when executing the "run" command, specifically while downloading Hazelcast 4.2 into the m2 repo. It does not affect Mac users who already have it downloaded.  The fix was in the "sed" commands that applies substitutions in  the "dependency-copy" pom.  I have made sure this works on MacOS BigSur but have not verified that this on Linux.