### PR TITLE
Fix sed issues during Hazelcast downloading of Maven artifacts

### DIFF
--- a/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
+++ b/drivers/driver-hazelcast3/conf/install-hazelcast-support3.sh
@@ -73,11 +73,12 @@ prepare_using_maven() {
     cp -r ${SIMULATOR_HOME}/conf/mvnw/.mvn .
     cp ${SIMULATOR_HOME}/conf/dependency-copy.xml pom.xml
 
-    sed -i'' "s|@hz-repo-release|${release_repo}|" pom.xml
-    sed -i'' "s|@hz-repo-snapshot|${snapshot_repo}|" pom.xml
-    sed -i'' "s|@hz-artifact|${artifact_id}|" pom.xml
-    sed -i'' "s|@hz-version|${version}|" pom.xml
-    sed -i'' "s|@hz-output|${destination}|" pom.xml
+    # For the '.bak', see: https://stackoverflow.com/a/22084103/1514241
+    sed -i.bak "s|@hz-repo-release|${release_repo}|" pom.xml
+    sed -i.bak "s|@hz-repo-snapshot|${snapshot_repo}|" pom.xml
+    sed -i.bak "s|@hz-artifact|${artifact_id}|" pom.xml
+    sed -i.bak "s|@hz-version|${version}|" pom.xml
+    sed -i.bak "s|@hz-output|${destination}|" pom.xml
 
     custom_maven_settings=""
     if [ ! -z ${CUSTOM_MAVEN_SETTINGS} ]; then

--- a/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
+++ b/drivers/driver-hazelcast4/conf/install-hazelcast-support4.sh
@@ -74,11 +74,12 @@ prepare_using_maven() {
     cp -r ${SIMULATOR_HOME}/conf/mvnw/.mvn .
     cp ${SIMULATOR_HOME}/conf/dependency-copy.xml pom.xml
 
-    sed -i '' "s|@hz-repo-release|${release_repo}|" pom.xml
-    sed -i '' "s|@hz-repo-snapshot|${snapshot_repo}|" pom.xml
-    sed -i '' "s|@hz-artifact|${artifact_id}|" pom.xml
-    sed -i '' "s|@hz-version|${version}|" pom.xml
-    sed -i '' "s|@hz-output|${destination}|" pom.xml
+    # For the '.bak', see: https://stackoverflow.com/a/22084103/1514241
+    sed -i.bak "s|@hz-repo-release|${release_repo}|" pom.xml
+    sed -i.bak "s|@hz-repo-snapshot|${snapshot_repo}|" pom.xml
+    sed -i.bak "s|@hz-artifact|${artifact_id}|" pom.xml
+    sed -i.bak "s|@hz-version|${version}|" pom.xml
+    sed -i.bak "s|@hz-output|${destination}|" pom.xml
 
     custom_maven_settings=""
     if [ ! -z ${CUSTOM_MAVEN_SETTINGS} ]; then


### PR DESCRIPTION
Fix a bug  introduced by https://github.com/hazelcast/hazelcast-simulator/commit/20c4ac2777130e879203917bbba12e7878b1197e which fixed it for OS X but broke it for Linux.

This fix works on both platforms.