### PR TITLE
Fix sleep time in MapEntryListenerTest

### DIFF
--- a/drivers/driver-hazelcast4/src/main/java/com/hazelcast/simulator/tests/map/MapEntryListenerTest.java
+++ b/drivers/driver-hazelcast4/src/main/java/com/hazelcast/simulator/tests/map/MapEntryListenerTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class MapEntryListenerTest extends HazelcastTest {
 
-    private static final int SLEEP_CATCH_EVENTS_MILLIS = 8000;
+    private static final int SLEEP_CATCH_EVENTS_SECONDS = 8;
 
     // properties
     public int valueLength = 100;
@@ -172,9 +172,8 @@ public class MapEntryListenerTest extends HazelcastTest {
     public void afterRun(ThreadState state) {
         eventCounts.add(state.eventCount);
 
-
         if (threadsRemaining.decrementAndGet() == 0) {
-            sleepSeconds(SLEEP_CATCH_EVENTS_MILLIS);
+            sleepSeconds(SLEEP_CATCH_EVENTS_SECONDS);
 
             listeners.add(listener);
         }


### PR DESCRIPTION
The `sleepSeconds` method is expecting number of seconds, not milliseconds. Therefore, we passed 8000 seconds for a sleep.
This is the root cause why after every release verification, the run waits for 2 hours 13 minutes 23 seconds  for completion of the MapEntryListenerTest as seen from the logs of e.g. 5.0-BETA-1 run:
```
INFO  19:55:42 MapEntryListener Waiting for all performance info
INFO  19:56:42 Performance MapEntryListener
Total running time 02d 02h 13m 23s
```

2 hours (7200 seconds) + 13 minutes (780 seconds) + 23 seconds = 8003 seconds. 

This PR fixes the waiting but is unrelated to OOME described here: https://github.com/hazelcast/hazelcast-simulator/issues/1879
