### PR TITLE
Fix demand for -all artifact in Hazelcast 5

### DIFF
--- a/drivers/driver-hazelcast4plus/conf/install-hazelcast-enterprise4plus.sh
+++ b/drivers/driver-hazelcast4plus/conf/install-hazelcast-enterprise4plus.sh
@@ -24,7 +24,7 @@ prepare()
         snapshot_repo="https://repository.hazelcast.com/snapshot"
         release_repo="https://repository.hazelcast.com/release"
 
-        prepare_using_maven "hazelcast-enterprise-all" "$version" ${release_repo} ${snapshot_repo}
+        prepare_using_maven "hazelcast-enterprise" "$version" ${release_repo} ${snapshot_repo}
     elif [[ ${version_spec} == git* ]] ; then
         git_branch=${version_spec#*=}
 


### PR DESCRIPTION
It's possible that I broke usage for 4.x but this is a quick fix for 5.0 as we're in the process of release verification. I'll take a look at it during the weekend.