### PR TITLE
Fix latencies summary in the HTML report

### DIFF
--- a/simulator/src/main/java/com/hazelcast/simulator/utils/ReportCsv.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/ReportCsv.java
@@ -58,7 +58,7 @@ public final class ReportCsv {
             String[] tokens = line.split("\\s+");
             String token = tokens[1];
             if (token.startsWith(percentile)) {
-                outSb.append(',').append(tokens[1]);
+                outSb.append(',').append(tokens[0]);
                 percentile = importantPercentiles.poll();
                 if (percentile == null) {
                     break;


### PR DESCRIPTION
The `benchmark-report` tool generates a HTML report. The HTML report contains a "Summary" tab where the most important information (such as important percentiles and throughput) are printed in the table form. Currently the table is broken as seen on the screenshot below:

![Snímek z 2021-10-15 14-39-11](https://user-images.githubusercontent.com/4253850/137488637-f851f2f3-4315-47b5-b6f3-e0bd6868259c.png)

On the closer look, you'll notice that the values are not actually latencies but just the percentiles expressed as a decimal number (e.g. 90% - 0.9000000). There's obvious issue that the legend is printed as the actual value.

The root cause is happening during the parsing of the `report.csv` file. The information is there correctly, it just takes a wrong part of the line from the HDR files. 

This PR takes the first token instead of the second fixing the issue as shown below:

![Snímek z 2021-10-15 14-40-17](https://user-images.githubusercontent.com/4253850/137488966-f8af3577-3381-48e7-ac46-8237fcbb6f58.png)

