### PR TITLE
Separate SCP options from SSH options

### DIFF
--- a/dist/src/main/dist/conf/prepare_session.sh
+++ b/dist/src/main/dist/conf/prepare_session.sh
@@ -50,7 +50,7 @@ upload_remote(){
     echo "[INFO]    Upload [A$agent_index] $agent starting..."
     # if the local upload directory exist, it needs to be uploaded
     echo "Uploading upload directory $src_dir to $agent:$target_dir"
-    scp ${SSH_OPTIONS} -r ${src_dir} ${SIMULATOR_USER}@${agent}:${target_dir}
+    scp ${SCP_OPTIONS} -r ${src_dir} ${SIMULATOR_USER}@${agent}:${target_dir}
     echo "[INFO]    Upload [A$agent_index] $agent completed"
 }
 

--- a/dist/src/main/dist/conf/simulator.properties
+++ b/dist/src/main/dist/conf/simulator.properties
@@ -64,6 +64,11 @@ SIMULATOR_USER=simulator
 SSH_OPTIONS=-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 
 #
+# The options added to SCP. Probably you don't need to change this.
+#
+SCP_OPTIONS=-o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+
+#
 # The name of the security group, the creates machines belong to.
 #
 # EC2:

--- a/simulator/src/main/java/com/hazelcast/simulator/common/SimulatorProperties.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/common/SimulatorProperties.java
@@ -180,6 +180,10 @@ public class SimulatorProperties {
         return get("SSH_OPTIONS", "");
     }
 
+    public String getScpOptions() {
+        return get("SCP_OPTIONS", "");
+    }
+
     public String getUser() {
         return get("SIMULATOR_USER", "simulator");
     }

--- a/simulator/src/main/java/com/hazelcast/simulator/utils/Bash.java
+++ b/simulator/src/main/java/com/hazelcast/simulator/utils/Bash.java
@@ -30,7 +30,7 @@ public class Bash {
     public Bash(SimulatorProperties simulatorProperties) {
         this.user = simulatorProperties.getUser();
         this.sshOptions = simulatorProperties.getSshOptions();
-        this.scpOptions = sshOptions.replace("-t ", "").replace("-tt ", "");
+        this.scpOptions = simulatorProperties.getScpOptions();
     }
 
     public String execute(String command) {


### PR DESCRIPTION
There are SCP options that require using different flags than with SSH,
like the `-p` and `-P` when defining the port to use. This change
introduces the `SCP_OPTIONS` simulator property to enable full control
of SCP options.