### PR TITLE
Use Python from environment

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import shutil

--- a/playbooks/install_simulator.yaml
+++ b/playbooks/install_simulator.yaml
@@ -33,7 +33,7 @@
     loop:
        - "{{ simulator_dir }}/drivers"
 
-  # The rscyn is can't resolve the key properly if it uses relative path, so this hack is needed.
+  # The rsync is can't resolve the key properly if it uses relative path, so this hack is needed.
   # https://github.com/ansible/ansible-modules-core/issues/18
   - name: Set correct ssh key path
     set_fact:

--- a/src/agents_clear.py
+++ b/src/agents_clear.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/src/agents_download.py
+++ b/src/agents_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/src/agents_start.py
+++ b/src/agents_start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/src/agents_stop.py
+++ b/src/agents_stop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/src/agents_upload_driver.py
+++ b/src/agents_upload_driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import yaml
 import sys

--- a/src/commit_sorter.py
+++ b/src/commit_sorter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import os
 import subprocess

--- a/src/inventory_cli.py
+++ b/src/inventory_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import sys
 import argparse

--- a/src/load_hosts.py
+++ b/src/load_hosts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os.path
 import subprocess
 import sys

--- a/src/perf_analysis_cli.py
+++ b/src/perf_analysis_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import os
 import statistics

--- a/src/perfregtest_cli.py
+++ b/src/perfregtest_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import os
 import subprocess

--- a/src/perftest_cli.py
+++ b/src/perftest_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os
 import sys
 import argparse

--- a/src/prepare_run.py
+++ b/src/prepare_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os.path
 import sys
 import yaml

--- a/src/upload_hazelcast_jars.py
+++ b/src/upload_hazelcast_jars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import os.path
 import subprocess
 

--- a/templates/storage-ec2/aws/auto_mount.py
+++ b/templates/storage-ec2/aws/auto_mount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import threading


### PR DESCRIPTION
This PR changes Python used in scripts from `#!/usr/bin/python3` to `#!/usr/bin/env python3`. This is good because in some environments we may not want to use python3 found in /usr/bin directory but rather get it from path. Also fixes one typo.