### PR TITLE
Relocate sonar plugin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -217,7 +217,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${maven.sonar.plugin.version}</version>
             </plugin>


### PR DESCRIPTION
Sonar plugin was relocated https://mvnrepository.com/artifact/org.codehaus.mojo/sonar-maven-plugin/3.3.0.603. For whatever reason it issues a lot of warning when clicking sync button in IntelliJ. I can also reproduce the issue if I wrote `mvn -U dependency:resolve-plugins`. Using relocated reps solved the issue.