### PR TITLE
Get first data line of the file

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/ReportCsv.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/ReportCsv.java
@@ -77,7 +77,7 @@ public final class ReportCsv {
         File file = new File(hgrmFile.getParent(), stripExtension(hgrmFile.getName()));
         String[] lines = fileAsText(file).split("\n");
 
-        long startMillis = Math.round(Double.parseDouble(lines[4].split(",")[1]) * 1000);
+        long startMillis = Math.round(Double.parseDouble(lines[3].split(",")[1]) * 1000);
 
         String lastLine = lines[lines.length - 1];
 


### PR DESCRIPTION
We want to get first data line here if I understood correctly, which is the fourth line, which corresponds to the 3rd element of the array.

Why this is a problem?

Usually it's not because there are a lot of data lines, however in specific scenarios we may want to quit after doing few iterations, in that case reporting mechanism will be broken as there will be only one line and 4th element of the array will be out of the bounds.