### PR TITLE
Update maven command to get local repo path

### DIFF
--- a/src/upload_hazelcast_jars.py
+++ b/src/upload_hazelcast_jars.py
@@ -23,7 +23,7 @@ def __upload(agent, artifact_ids, version):
 
 
 def local_repo():
-    cmd = "mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout"
+    cmd = "mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=settings.localRepository -q -DforceStdout"
     return subprocess.check_output(cmd, shell=True, text=True)
 
 


### PR DESCRIPTION
Current command `mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout` 
was returning empty on MacOS so jars in local repo could not be find.
With the fix here, command is working expectedly and jars are found.