### PR TITLE
Problem in SimulatorHistogramLogProcessor

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
@@ -187,7 +187,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
                     + "%.3f," //total-min
                     + "%.3f," //total-max
                     + "%.3f," //total-mean
-                    + "%.3f" //total std deviation
+                    + "%.3f," //total std deviation
                     + "%.3f" //total throughput
                     + "\n"
             ;


### PR DESCRIPTION
A comma was missing between the last 2 values (total std and total
throughput).