### PR TITLE
Update the command to list example Java URLS and fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ To install Java on the remote machines call:
     inventory install java
     ```
 
-You can pass a custom URL to cofigure the correct JVM. To get a listing of examples URL's call:
+You can pass a custom URL to configure the correct JVM. To get a listing of examples URL's call:
     ```
-    inventory install java --list 
+    inventory install java --examples 
     ```
     
 And run the following to install a specific Java version.


### PR DESCRIPTION
Might be related to terraform or ansible version but `--list` did not exist for me, I think it is replaced with `--examples`:

```
$ inventory install java -h 
usage: inventory_cli.py [-h] [--url URL] [--examples] [--hosts HOSTS]

Install Java

options:
  -h, --help     show this help message and exit
  --url URL      The url of the JDK tar.gz file (default: https://download.java.net/java
                 /ga/jdk11/openjdk-11_linux-x64_bin.tar.gz)
  --examples     Shows example urls (default: False)
  --hosts HOSTS  The target hosts. (default: all:!mc)
```