### PR TITLE
Uncomment run method in perfregtest_cli

### DIFF
--- a/src/perfregtest_cli.py
+++ b/src/perfregtest_cli.py
@@ -160,7 +160,7 @@ def run_all(commit_tuples, runs, build_paths, tests, debug):
                     info(f"Build failed {build_stats.failed}/{build_stats.count}, skipping runs.")
                     break
 
-            # run(test, commit, remaining, project_paths[-1], debug)
+            run(test, commit, remaining, build_paths[-1], debug)
             info(f"Testing {test_name} took {now_seconds() - start_test}s")
     duration = now_seconds() - start
     info(f"Duration: {duration}s")


### PR DESCRIPTION
I am not sure if I changed `project_paths[-1]` correctly. `project_paths` variable did not exist in the scope though. So I guessed it is build_paths