### PR TITLE
Add --last flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,14 @@ You can create a single report plotting those two benchmarks in the same chart a
 perftest report -o my-comparison-report 2021-05-31__23_19_13 2021-05-31__23_35_40
 ```
 
+By default the `perftest run` creates a directory for each run inside
+`runs/BenchmarkName` with timestamp as the directory name. To automate comparisons of last runs of some benchmarks,
+you can simply run the `perftest report` with `-l` flag (or `--last`):
+
+```shell
+perftest report -o my-comparison-report runs/MyTestA runs/MyTestB
+```
+
 ## Extensive reports
 
 You can create a very detailed report with more charts with `-f` switch:

--- a/src/simulator/perftest_report.py
+++ b/src/simulator/perftest_report.py
@@ -4,6 +4,7 @@
 import argparse
 import csv
 import os
+import glob
 import re
 import subprocess
 import shutil
@@ -897,6 +898,18 @@ class Comparison:
                     exit()
                 benchmark_names[last_benchmark] = benchmark_arg[1:len(benchmark_arg) - 1]
                 last_benchmark = None
+            elif compare_last:
+                benchmark_root = benchmark_arg
+                subdirectories = sorted(filter(os.path.isdir, glob.glob(benchmark_root + "/*")))
+
+                benchmark_dir = subdirectories[-1]
+                if not os.path.exists(benchmark_dir):
+                    error("benchmark directory '" + benchmark_dir + "' does not exist!")
+                    exit(1)
+                last_benchmark = benchmark_arg
+                benchmark_dirs.append(benchmark_dir)
+                name = os.path.basename(os.path.normpath(benchmark_root))
+                benchmark_names[benchmark_dir] = name
             else:
                 benchmark_dir = benchmark_arg
                 if not os.path.exists(benchmark_dir):
@@ -1088,6 +1101,7 @@ class PerfTestReportCli:
         parser.add_argument('-c', '--cooldown', nargs=1, default=[0], type=int,
                     help='The cooldown period in seconds. The cooldown removes datapoints from the end.')
         parser.add_argument('-f', '--full', help='Enable individual worker level diagrams.', action="store_true")
+        parser.add_argument('-cl', '--compare-last', help='Compare last results from each benchmark', action='store_true')
         parser.add_argument('--svg', help='SVG instead of PNG graphics.', action="store_true")
 
         global args
@@ -1110,6 +1124,9 @@ class PerfTestReportCli:
         warmup_seconds = int(args.warmup[0])
         global cooldown_seconds
         cooldown_seconds = int(args.cooldown[0])
+
+        global compare_last
+        compare_last = args['compare-last']
 
         info("Report directory '" + report_dir + "'")
 

--- a/src/simulator/perftest_report.py
+++ b/src/simulator/perftest_report.py
@@ -1101,7 +1101,7 @@ class PerfTestReportCli:
         parser.add_argument('-c', '--cooldown', nargs=1, default=[0], type=int,
                     help='The cooldown period in seconds. The cooldown removes datapoints from the end.')
         parser.add_argument('-f', '--full', help='Enable individual worker level diagrams.', action="store_true")
-        parser.add_argument('-cl', '--compare-last', help='Compare last results from each benchmark', action='store_true')
+        parser.add_argument('-l', '--last', help='Compare last results from each benchmark', action='store_true')
         parser.add_argument('--svg', help='SVG instead of PNG graphics.', action="store_true")
 
         global args
@@ -1126,7 +1126,7 @@ class PerfTestReportCli:
         cooldown_seconds = int(args.cooldown[0])
 
         global compare_last
-        compare_last = args['compare-last']
+        compare_last = args.last
 
         info("Report directory '" + report_dir + "'")
 


### PR DESCRIPTION
I saw that it's a common theme to run the benchmarks and then do a comparison report using `perftest report`.  By default each `perftest run` creates a folder under `runs/BenchmarkName/` with current date and time as the folder name.

I found that each time I was checking what was the last folder name and copy-pasting... It's error-prone and irritating. I saw that Krzysztof used some script to automate getting simply last run of each benchmark.

This PR adds such possibility as a new flag of `perftest report`:
- `-l` or `--last` - take just the last (alphabetically) folder inside given directories to compare.