### PR TITLE
Perftest run auto_gen_report flag addition & some bug fixes

### DIFF
--- a/src/perftest_cli.py
+++ b/src/perftest_cli.py
@@ -14,8 +14,8 @@ The available commands are:
     create      Creates a new performance test based on a template.
     clone       Clones an existing performance test.
     collect     Collects the performance test data and stores it in result.yaml.
-    exec        Executes a performance test.'
-    run         Runs a tests.yaml which is a self contained set of tests'
+    exec        Executes a performance test.
+    run         Runs a tests.yaml which is a self contained set of tests
     kill_java   Kills all Java processes   
     report      Generate performance report 
 '''

--- a/src/simulator/perftest.py
+++ b/src/simulator/perftest.py
@@ -180,9 +180,12 @@ class PerfTest:
         with tempfile.NamedTemporaryFile(mode="w", delete=False, prefix="perftest_", suffix=".txt") as tmp:
             if isinstance(test, list):
                 for t in test:
-                    clazzName = t['class'].split('.')[-1]
+                    if 'name' in t:
+                        test_name = t['name']
+                    else:
+                        test_name = t['class'].split('.')[-1]
                     for key, value in t.items():
-                        tmp.write(clazzName+'@')
+                        tmp.write(test_name+'@')
                         tmp.write(f"{key}={value}\n")
             else:
                 for key, value in test.items():

--- a/src/simulator/perftest.py
+++ b/src/simulator/perftest.py
@@ -446,7 +446,7 @@ class PerftestRunCli:
         #                     nargs=1,
         #                     help="The path where the result of the run need to be stored.")
 
-        parser.add_argument('-agr', '--skip_auto_gen_report',
+        parser.add_argument('-agr', '--skipReport',
                             action='store_false', dest='auto_gen_report', default=True,
                             help="When set, this flag stops the automatic generation of reports after test completion.")
 

--- a/src/simulator/perftest.py
+++ b/src/simulator/perftest.py
@@ -198,7 +198,7 @@ class PerfTest:
                 exit_with_error(f"Failed run coordinator, exitcode={self.exitcode}")
             return self.exitcode
 
-    def run(self, tests, tags, auto_gen_report=True):
+    def run(self, tests, tags, skip_report=False):
         for test in tests:
             repetitions = test.get('repetitions')
             if repetitions < 0:
@@ -210,7 +210,7 @@ class PerfTest:
             for i in range(0, repetitions):
                 exitcode, run_path = self.run_test(test)
 
-                if exitcode == 0 and auto_gen_report:
+                if exitcode == 0 and not skip_report:
                     self.collect(run_path,
                                  tags,
                                  warmup_seconds=test.get('warmup_seconds'),
@@ -447,7 +447,7 @@ class PerftestRunCli:
         #                     help="The path where the result of the run need to be stored.")
 
         parser.add_argument('-agr', '--skipReport',
-                            action='store_false', dest='auto_gen_report', default=True,
+                            action='store_true', dest='skip_report', default=False,
                             help="When set, this flag stops the automatic generation of reports after test completion.")
 
         args = parser.parse_args(argv)
@@ -458,7 +458,7 @@ class PerftestRunCli:
         tests = load_yaml_file(args.file)
         perftest = PerfTest()
 
-        perftest.run(tests, tags, args.auto_gen_report)
+        perftest.run(tests, tags, args.skip_report)
 
 
 class PerftestExecCli:


### PR DESCRIPTION
This commit adds the `--skip_auto_gen_report` flag that allows the skipping of the `perftest report` execution after tests have been run if provided. This is particularly useful for situations such as release verification that are focused on pass/fail instead of performance analysis.

This commit also fixes an issue where some flags were only added to the coordinator arguments list if set to `True`, not when set to `False`.

This commit also changes the `test.properties` generation to use the `name` variable as the UID of test cases if provided, instead of always using the `class` name. This allows multiple test cases using the same test class in 1 test suite.

Also some typo fixes.