### PR TITLE
perftest/perfregtest rsync detection added.

### DIFF
--- a/bin/perfregtest
+++ b/bin/perfregtest
@@ -19,5 +19,10 @@ if ! hash mvn 2>/dev/null ; then
     exit 1
 fi
 
+if ! hash rsync 2>/dev/null ; then
+    echo rsync is not detected! Aborting.
+    exit 1
+fi
+
 BINPATH=`dirname $0`
 python3 -u "$BINPATH/../src/perfregtest_cli.py" $@

--- a/bin/perftest
+++ b/bin/perftest
@@ -19,5 +19,10 @@ if ! hash java 2>/dev/null ; then
     exit 1
 fi
 
+if ! hash rsync 2>/dev/null ; then
+    echo rsync is not detected! Aborting.
+    exit 1
+fi
+
 BINPATH=`dirname $0`
 python3 -u "$BINPATH/../src/perftest_cli.py" $@


### PR DESCRIPTION
So when rsync not found, these commands don't run.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2015