### PR TITLE
Fix problem with TimeStepLoop logger.

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepLoop.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepLoop.java
@@ -46,7 +46,7 @@ public abstract class TimeStepLoop implements Runnable {
     protected TestContext testContext;
     protected Metronome metronome;
 
-    private final Logger logger = LogManager.getLogger(getClass());
+    protected final Logger logger = LogManager.getLogger(getClass());
     protected final String executionGroup;
     protected final Object threadState;
     protected final Object testInstance;


### PR DESCRIPTION
The logger was private but should be protected so that subclasses can access it. Resolves a few test failures.