### PR TITLE
Fixed problems with placement groups.

### DIFF
--- a/templates/elasticache-cluster/aws/main.tf
+++ b/templates/elasticache-cluster/aws/main.tf
@@ -44,7 +44,8 @@ resource "aws_route_table_association" "route_table_association" {
 
 # ========== nodes ==========================
 
-# Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the loadgenerators section.
 resource "aws_placement_group" "cluster_placement_group" {
     name     = "simulator-placement-group-${local.settings.basename}"
     strategy = "cluster"
@@ -146,7 +147,7 @@ resource "aws_instance" "loadgenerators" {
     count                   = local.settings.loadgenerators.count
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.loadgenerators.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
     tags = {

--- a/templates/elasticache-cluster/inventory_plan.yaml
+++ b/templates/elasticache-cluster/inventory_plan.yaml
@@ -4,7 +4,6 @@ terraform_plan: aws
 basename: <id>-<rnd:5>
 # Enter something here that identifies you.
 owner: <id>
-placement_group_name: None
 region: eu-central-1
 availability_zone: eu-central-1a
 vpc_id: vpc-002b5a4e5f8b8ece2
@@ -36,5 +35,4 @@ loadgenerators:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null

--- a/templates/hazelcast5-ec2/aws/main.tf
+++ b/templates/hazelcast5-ec2/aws/main.tf
@@ -71,6 +71,8 @@ resource "aws_route_table_association" "route_table_association" {
 # ========== nodes ==========================
 
 # Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the nodes and loadgenerators sections.
 resource "aws_placement_group" "cluster_placement_group" {
     name     = "simulator-placement-group-${local.settings.basename}"
     strategy = "cluster"
@@ -132,7 +134,7 @@ resource "aws_instance" "nodes" {
     instance_type           = local.settings.nodes.instance_type
     count                   = local.settings.nodes.count
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.nodes.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
@@ -200,7 +202,7 @@ resource "aws_instance" "loadgenerators" {
     count                   = local.settings.loadgenerators.count
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.loadgenerators.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
     tags = {
@@ -267,7 +269,6 @@ resource "aws_instance" "mc" {
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
-    tenancy                 = local.settings.mc.tenancy
 
     tags = {
         Name  = "Simulator MC ${local.settings.basename}"

--- a/templates/hazelcast5-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-ec2/inventory_plan.yaml
@@ -4,7 +4,6 @@ terraform_plan: aws
 basename: <id>-<rnd:5>
 # Enter something here that identifies you.
 owner: <id>
-placement_group_name: None
 region: eu-central-1
 availability_zone: eu-central-1a
 vpc_id: vpc-002b5a4e5f8b8ece2
@@ -24,7 +23,6 @@ nodes:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
     
 loadgenerators:
@@ -35,7 +33,6 @@ loadgenerators:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 mc:
@@ -46,5 +43,4 @@ mc:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null

--- a/templates/hazelcast5-hd-ec2/aws/main.tf
+++ b/templates/hazelcast5-hd-ec2/aws/main.tf
@@ -71,6 +71,8 @@ resource "aws_route_table_association" "route_table_association" {
 # ========== nodes ==========================
 
 # Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the nodes and loadgenerators sections.
 resource "aws_placement_group" "cluster_placement_group" {
     name     = "simulator-placement-group-${local.settings.basename}"
     strategy = "cluster"
@@ -132,7 +134,7 @@ resource "aws_instance" "nodes" {
     instance_type           = local.settings.nodes.instance_type
     count                   = local.settings.nodes.count
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.nodes.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
@@ -200,7 +202,7 @@ resource "aws_instance" "loadgenerators" {
     count                   = local.settings.loadgenerators.count
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.loadgenerators.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
     tags = {

--- a/templates/hazelcast5-hd-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-hd-ec2/inventory_plan.yaml
@@ -4,7 +4,6 @@ terraform_plan: aws
 basename: <id>-<rnd:5>
 # Enter something here that identifies you.
 owner: <id>
-placement_group_name: None
 region: eu-central-1
 availability_zone: eu-central-1a
 vpc_id: vpc-002b5a4e5f8b8ece2
@@ -24,7 +23,6 @@ nodes:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
     
 loadgenerators:
@@ -35,7 +33,6 @@ loadgenerators:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 mc:
@@ -46,5 +43,4 @@ mc:
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null

--- a/templates/sql-ec2-tstore/aws/main.tf
+++ b/templates/sql-ec2-tstore/aws/main.tf
@@ -71,6 +71,8 @@ resource "aws_route_table_association" "route_table_association" {
 # ========== nodes ==========================
 
 # Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the nodes and loadgenerators sections.
 resource "aws_placement_group" "cluster_placement_group" {
     name     = "simulator-placement-group-${local.settings.basename}"
     strategy = "cluster"
@@ -124,7 +126,7 @@ resource "aws_instance" "nodes" {
     instance_type           = local.settings.nodes.instance_type
     count                   = local.settings.nodes.count
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.nodes.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
@@ -204,7 +206,7 @@ resource "aws_instance" "loadgenerators" {
     count                   = local.settings.loadgenerators.count
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.loadgenerators.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
     tags = {

--- a/templates/sql-ec2-tstore/inventory_plan.yaml
+++ b/templates/sql-ec2-tstore/inventory_plan.yaml
@@ -4,7 +4,6 @@ terraform_plan: aws
 basename: <id>-<rnd:5>
 # Enter something here that identifies you.
 owner: <id>
-placement_group_name: None
 region: us-east-1
 availability_zone: us-east-1b
 vpc_id: vpc-<your-vpc-id-here>
@@ -21,7 +20,6 @@ nodes:
     instance_type: i3.xlarge
     ami: ami-04505e74c0741db8d
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 loadgenerators:
@@ -29,7 +27,6 @@ loadgenerators:
     instance_type: c5.2xlarge
     ami: ami-04505e74c0741db8d
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 mc:
@@ -37,5 +34,3 @@ mc:
     count: 1
     ami: ami-04505e74c0741db8d
     user: ubuntu
-    placement_group: None
-    tenancy: null

--- a/templates/sql-ec2/aws/main.tf
+++ b/templates/sql-ec2/aws/main.tf
@@ -71,6 +71,8 @@ resource "aws_route_table_association" "route_table_association" {
 # ========== nodes ==========================
 
 # Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the nodes and loadgenerators sections.
 resource "aws_placement_group" "cluster_placement_group" {
     name     = "simulator-placement-group-${local.settings.basename}"
     strategy = "cluster"
@@ -124,7 +126,7 @@ resource "aws_instance" "nodes" {
     instance_type           = local.settings.nodes.instance_type
     count                   = local.settings.nodes.count
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.nodes.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
@@ -192,7 +194,7 @@ resource "aws_instance" "loadgenerators" {
     count                   = local.settings.loadgenerators.count
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.loadgenerators.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
     tags = {
@@ -259,7 +261,6 @@ resource "aws_instance" "mc" {
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
-    tenancy                 = local.settings.mc.tenancy
 
     tags = {
         Name  = "Simulator MC ${local.settings.basename}"

--- a/templates/sql-ec2/inventory_plan.yaml
+++ b/templates/sql-ec2/inventory_plan.yaml
@@ -4,7 +4,6 @@ terraform_plan: aws
 basename: <id>-<rnd:5>
 # Enter something here that identifies you.
 owner: <id>
-placement_group_name: None
 region: eu-central-1
 availability_zone: eu-central-1a
 vpc_id: vpc-002b5a4e5f8b8ece2
@@ -21,7 +20,6 @@ nodes:
     instance_type: c5.9xlarge
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
     
 loadgenerators:
@@ -29,7 +27,6 @@ loadgenerators:
     instance_type: c5.9xlarge
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 mc:
@@ -37,5 +34,3 @@ mc:
     count: 0
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
-    tenancy: null

--- a/templates/sql-prunability-ec2/inventory_plan.yaml
+++ b/templates/sql-prunability-ec2/inventory_plan.yaml
@@ -21,7 +21,6 @@ nodes:
     instance_type: c5.9xlarge
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 loadgenerators:
@@ -29,7 +28,6 @@ loadgenerators:
     instance_type: c5.4xlarge
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
     tenancy: null
 
 mc:
@@ -37,5 +35,3 @@ mc:
     count: 0
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
-    placement_group: None
-    tenancy: null

--- a/templates/storage-ec2/aws/main.tf
+++ b/templates/storage-ec2/aws/main.tf
@@ -71,6 +71,8 @@ resource "aws_route_table_association" "route_table_association" {
 # ========== nodes ==========================
 
 # Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the nodes and loadgenerators sections.
 resource "aws_placement_group" "cluster_placement_group" {
     name     = "simulator-placement-group-${local.settings.basename}"
     strategy = "cluster"
@@ -132,7 +134,7 @@ resource "aws_instance" "nodes" {
     instance_type           = local.settings.nodes.instance_type
     count                   = local.settings.nodes.count
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.nodes.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
@@ -218,7 +220,7 @@ resource "aws_instance" "loadgenerators" {
     count                   = local.settings.loadgenerators.count
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
-    #placement_group        = local.settings.loadgenerators.placement_group
+    #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
     tags = {
@@ -285,7 +287,6 @@ resource "aws_instance" "mc" {
     subnet_id               = aws_subnet.subnet.id
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
-    tenancy                 = local.settings.mc.tenancy
 
     tags = {
         Name  = "Simulator MC ${local.settings.basename}"


### PR DESCRIPTION
The current configuration didn't work properly without fixes.

The whole thing is now simplified, you just need to uncomment the placement groups setting on load generator and the nodes and you are good to go.

Also tenancy/placementgroup for mc has been removed since it provides no value.

fixes https://github.com/hazelcast/hazelcast-simulator/issues/2052