### PR TITLE
Install either dstat or pcp

### DIFF
--- a/playbooks/install_simulator.yaml
+++ b/playbooks/install_simulator.yaml
@@ -12,12 +12,21 @@
       apt-get update || true
     become: yes
 
-  # needed for pcp dstat.
+  # we want to install either dstat or pcp.
+  # pcp is a replacement for dstat and will
+  # provide the dstat command
   - name: Install pcp
     ansible.builtin.package:
       name: pcp
       state: present
     become: yes
+    ignore_errors: yes
+  - name: Install dstat
+    ansible.builtin.package:
+      name: dstat
+      state: present
+    become: yes
+    ignore_errors: yes
 
   - name: Delete simulator directory
     file:


### PR DESCRIPTION
dstat is a mess because the project was abandoned. RHEL releases a new tool PCP that provides a drop in replacement for dstat and later dstat continues and now there are 2. Both provide dstat.