### PR TITLE
Cleaned up some ec2 templates

### DIFF
--- a/templates/hazelcast5-ec2/hazelcast.xml
+++ b/templates/hazelcast5-ec2/hazelcast.xml
@@ -26,7 +26,5 @@
 
     <!--LICENSE-KEY-->
 
-    <cache name="*">
-    </cache>
 </hazelcast>
 

--- a/templates/hazelcast5-ec2/tests.yaml
+++ b/templates/hazelcast5-ec2/tests.yaml
@@ -1,38 +1,10 @@
 - name: read_only
-  repetitions: 1
-  duration: 300s
-  clients: 1
-  members: 1
-  loadgenerator_hosts: loadgenerators
-  node_hosts: nodes
-  driver: hazelcast5
-  version: maven=5.1
-  client_args: >
-    -Xms3g
-    -Xmx3g
-  member_args: >
-    -Xms3g
-    -Xmx3g
-  performance_monitor_interval_seconds: 1
-  verify_enabled: True
-  warmup_seconds: 0
-  cooldown_seconds: 0
-  license_key: <add_key_here_if_using_ee>
-  test:
-    - class: com.hazelcast.simulator.tests.map.IntByteMapTest
-      name: MyByteTest
-      threadCount: 40
-      getProb: 1
-      putProb: 0
-      keyCount: 1_000_000
-
-- name: write_only
   duration: 300s
   repetitions: 1
   clients: 1
   members: 1
   driver: hazelcast5
-  version: maven=5.0
+  version: maven=5.3.0
   client_args: >
     -Xms3g
     -Xmx3g
@@ -58,8 +30,13 @@
   warmup_seconds: 0
   cooldown_seconds: 0
   test:
-      class: com.hazelcast.simulator.tests.map.IntByteMapTest
+    - class: com.hazelcast.simulator.tests.map.LongByteArrayMapTest
+      name: map
       threadCount: 40
-      getProb: 0
-      putProb: 1
-      keyCount: 1_000_000
+      getProb: 1
+      putProb: 0
+      keyDomain: 1_000_000
+      valueCount: 100
+      minValueLength: 1_000
+      maxValueLength: 1_000
+

--- a/templates/hazelcast5-hd-ec2/hazelcast.xml
+++ b/templates/hazelcast5-hd-ec2/hazelcast.xml
@@ -26,11 +26,11 @@
 
     <!--LICENSE-KEY-->
 
-    <map name="map_native">
+    <map name="mapnative">
         <in-memory-format>NATIVE</in-memory-format>
     </map>
 
-    <native-memory enabled="true" allocator-type="POOLED">
+    <native-memory enabled="true">
         <size value="10" unit="GIGABYTES"/>
     </native-memory>
 

--- a/templates/hazelcast5-hd-ec2/tests.yaml
+++ b/templates/hazelcast5-hd-ec2/tests.yaml
@@ -1,8 +1,8 @@
 - name: mixed
   repetitions: 1
   duration: 300s
-  driver: hazelcast5
-  version: maven=5.1
+  driver: hazelcast-enterprise5
+  version: maven=5.3.0
   clients: 2
   members: 1
   node_hosts: nodes
@@ -31,8 +31,12 @@
   cooldown_seconds: 0
   license_key: <add key here>
   test:
-      class: com.hazelcast.simulator.tests.map.IntByteMapTest
+    - class: com.hazelcast.simulator.tests.map.LongByteArrayMapTest
+      name: mapnative
       threadCount: 40
-      getProb: 80
-      putProb: 20
-      keyCount: 100_000_000
+      getProb: 1
+      putProb: 0
+      keyDomain: 1_000_000
+      valueCount: 10
+      minValueLength: 1_000
+      maxValueLength: 1_000


### PR DESCRIPTION
Both hazelcast5-ec2 and hazelcast5-hd-ec2 have been:

- upgraded to 5.3.0

- make use of LongByteArrayMapTest

Enterprise now makes use of an offheap map by default.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2076