### PR TITLE
hazelcast5-hd-ec2 unused instances

### DIFF
--- a/templates/hazelcast5-hd-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-hd-ec2/inventory_plan.yaml
@@ -16,7 +16,7 @@ keypair:
     private_key: key
 
 nodes:
-    count: 2
+    count: 1
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
@@ -26,7 +26,7 @@ nodes:
     tenancy: null
     
 loadgenerators:
-    count: 4
+    count: 1
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2

--- a/templates/hazelcast5-hd-ec2/tests.yaml
+++ b/templates/hazelcast5-hd-ec2/tests.yaml
@@ -3,7 +3,7 @@
   duration: 300s
   driver: hazelcast-enterprise5
   version: maven=5.3.0
-  clients: 2
+  clients: 1
   members: 1
   node_hosts: nodes
   loadgenerator_hosts: loadgenerators


### PR DESCRIPTION
Number of created instances is larger than number of used instances. So resources are wasted.

fixes https://github.com/hazelcast/hazelcast-simulator/issues/2089