### PR TITLE
HdrProbe now tracks up to 24h of latency.

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
@@ -25,8 +25,8 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
  * HDR-Histogram implementation of the {@link Probe}.
  */
 public class HdrProbe implements Probe {
-    // we want to track up to an hour.
-    static final long HIGHEST_TRACKABLE_VALUE = HOURS.toNanos(1);
+    // we want to track up to 24-hour.
+    static final long HIGHEST_TRACKABLE_VALUE_NANOS = HOURS.toNanos(24);
 
     // we care only about microsecond accuracy.
     private static final long LOWEST_DISCERNIBLE_VALUE = MICROSECONDS.toNanos(1);
@@ -38,7 +38,7 @@ public class HdrProbe implements Probe {
     //https://github.com/HdrHistogram/HdrHistogram#histogram-variants-and-internal-representation
     private final Recorder recorder = new Recorder(
             LOWEST_DISCERNIBLE_VALUE,
-            HIGHEST_TRACKABLE_VALUE,
+            HIGHEST_TRACKABLE_VALUE_NANOS,
             NUMBER_OF_SIGNIFICANT_VALUE_DIGITS);
 
     private final boolean partOfTotalThroughput;
@@ -64,8 +64,8 @@ public class HdrProbe implements Probe {
 
     @Override
     public void recordValue(long latencyNanos) {
-        if (latencyNanos > HIGHEST_TRACKABLE_VALUE) {
-            latencyNanos = HIGHEST_TRACKABLE_VALUE;
+        if (latencyNanos > HIGHEST_TRACKABLE_VALUE_NANOS) {
+            latencyNanos = HIGHEST_TRACKABLE_VALUE_NANOS;
         }
         recorder.recordValue(latencyNanos);
     }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
@@ -18,7 +18,7 @@ package com.hazelcast.simulator.probes.impl;
 import com.hazelcast.simulator.probes.Probe;
 import org.HdrHistogram.Recorder;
 
-import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 /**
@@ -26,7 +26,7 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
  */
 public class HdrProbe implements Probe {
     // we want to track up to 24-hour.
-    static final long HIGHEST_TRACKABLE_VALUE_NANOS = HOURS.toNanos(24);
+    static final long HIGHEST_TRACKABLE_VALUE_NANOS = DAYS.toNanos(1);
 
     // we care only about microsecond accuracy.
     private static final long LOWEST_DISCERNIBLE_VALUE = MICROSECONDS.toNanos(1);

--- a/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrProbeTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrProbeTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.simulator.probes.impl.HdrProbe.HIGHEST_TRACKABLE_VALUE;
+import static com.hazelcast.simulator.probes.impl.HdrProbe.HIGHEST_TRACKABLE_VALUE_NANOS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -74,11 +74,11 @@ public class HdrProbeTest {
 
     @Test
     public void testRecord_whenTooLarge() {
-        long value = HIGHEST_TRACKABLE_VALUE * 2;
+        long value = HIGHEST_TRACKABLE_VALUE_NANOS * 2;
         probe.recordValue(value);
 
         Histogram histogram = probe.getRecorder().getIntervalHistogram();
-        assertHistogramContent(histogram, HIGHEST_TRACKABLE_VALUE);
+        assertHistogramContent(histogram, HIGHEST_TRACKABLE_VALUE_NANOS);
     }
 
     private void assertHistogramContent(Histogram histogram, long... requiredValues) {


### PR DESCRIPTION
Before it was 1 hour; now it is 24h.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2091