### PR TITLE
Probes exposed through TestContext.

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/Probe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/Probe.java
@@ -22,7 +22,7 @@ public interface Probe {
      *
      * @return {@code true} if probe is relevant for throughput, {@code false} otherwise
      */
-    boolean isPartOfTotalThroughput();
+    boolean isPartOfThroughput();
 
     /**
      * Calculates the latency from an external start time and records the value.

--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/EmptyProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/EmptyProbe.java
@@ -29,7 +29,7 @@ public class EmptyProbe implements Probe {
     public static final EmptyProbe INSTANCE = new EmptyProbe();
 
     @Override
-    public boolean isPartOfTotalThroughput() {
+    public boolean isPartOfThroughput() {
         return false;
     }
 

--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrProbe.java
@@ -41,15 +41,15 @@ public class HdrProbe implements Probe {
             HIGHEST_TRACKABLE_VALUE_NANOS,
             NUMBER_OF_SIGNIFICANT_VALUE_DIGITS);
 
-    private final boolean partOfTotalThroughput;
+    private final boolean partOfThroughput;
 
-    public HdrProbe(boolean partOfTotalThroughput) {
-        this.partOfTotalThroughput = partOfTotalThroughput;
+    public HdrProbe(boolean partOfThroughput) {
+        this.partOfThroughput = partOfThroughput;
     }
 
     @Override
-    public boolean isPartOfTotalThroughput() {
-        return partOfTotalThroughput;
+    public boolean isPartOfThroughput() {
+        return partOfThroughput;
     }
 
     @Override

--- a/java/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
@@ -15,10 +15,38 @@
  */
 package com.hazelcast.simulator.test;
 
+import com.hazelcast.simulator.probes.Probe;
+
 /**
  * The TestContext is they way for a test to get access to test related information. Most importantly if a test is running.
  */
 public interface TestContext {
+
+    /**
+     * Gets a probe with the given name.
+     *
+     * @param name the name of the probe
+     * @return the Probe
+     * @throws NullPointerException if name is null.
+     */
+    default Probe getProbe(String name) {
+        return getProbe(name, true);
+    }
+
+    /**
+     * Gets a probe with the given name.
+     *
+     * @param name             the name of the probe
+     * @param partOfThroughput if the measurements of this probe are part of the
+     *                         throughput. Within timestep methods, the throughput
+     *                         is already accounted for by tracking it in a counter.
+     *                         So in that case probes need to be created where
+     *                         the throughput is ignored; otherwise it would lead
+     *                         to double counting.
+     * @return the Probe
+     * @throws NullPointerException if name is null.
+     */
+    Probe getProbe(String name, boolean partOfThroughput);
 
     /**
      * Returns the id of the current test.
@@ -48,7 +76,7 @@ public interface TestContext {
      * Stops the run or warmup phase. In most cases an outside duration is passed and the test will run as long as needed or
      * until an exception is thrown. But in certain condition the implementer of a test wants to stop the run/warmup phase
      * directly.
-     *
+     * <p>
      * Once stopped, the test moves on to the next phase. If the warmup is stopped, the test will eventually move on to the
      * run phase.
      */
@@ -56,12 +84,12 @@ public interface TestContext {
 
     /**
      * Echoes a message to coordinator.
-     *
+     * <p>
      * Be very careful sending huge quantities of messages to the coordinator because it cause stability issues. Messages are
      * written async, so you could easily kill the by flooding it or causing other problems. So don't use this as a debug logging
      * alternative.
      *
-     * @param msg the message to send
+     * @param msg  the message to send
      * @param args the arguments
      */
     void echoCoordinator(String msg, Object... args);

--- a/java/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/test/TestContext.java
@@ -25,6 +25,8 @@ public interface TestContext {
 
     /**
      * Gets a probe with the given name.
+     * <p/>
+     * This method is threadsafe.
      *
      * @param name the name of the probe
      * @return the Probe
@@ -36,6 +38,8 @@ public interface TestContext {
 
     /**
      * Gets a probe with the given name.
+     * <p/>
+     * This method is threadsafe.
      *
      * @param name             the name of the probe
      * @param partOfThroughput if the measurements of this probe are part of the

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/performance/TestPerformanceTracker.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/performance/TestPerformanceTracker.java
@@ -19,6 +19,7 @@ import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.probes.impl.HdrProbe;
 import com.hazelcast.simulator.test.TestException;
 import com.hazelcast.simulator.worker.testcontainer.TestContainer;
+import com.hazelcast.simulator.worker.testcontainer.TestContextImpl;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.HistogramLogWriter;
 
@@ -49,6 +50,7 @@ public final class TestPerformanceTracker {
     private final TestContainer testContainer;
     private final Map<String, HistogramLogWriter> histogramLogWriterMap = new HashMap<>();
     private final PerformanceLogWriter performanceLogWriter;
+    private final TestContextImpl testContext;
     private long lastUpdateMillis;
     private Map<String, Histogram> intervalHistogramMap;
 
@@ -65,6 +67,7 @@ public final class TestPerformanceTracker {
 
     public TestPerformanceTracker(TestContainer container) {
         this.testContainer = container;
+        this.testContext = container.getTestContext();
         this.performanceLogWriter = new PerformanceLogWriter(
                 new File(getUserDir(), "performance-" + container.getTestCase().getId() + ".csv"));
     }
@@ -96,7 +99,7 @@ public final class TestPerformanceTracker {
         if (lastUpdateMillis == 0) {
             // first time
             iterationsDuringWarmup = testContainer.iteration();
-            for (Probe probe : testContainer.getProbeMap().values()) {
+            for (Probe probe : testContext.getProbeMap().values()) {
                 probe.reset();
             }
             lastUpdateMillis = currentTimeMillis;
@@ -108,7 +111,7 @@ public final class TestPerformanceTracker {
     }
 
     private void makeUpdate(long updateIntervalMillis, long currentTimeMillis) {
-        Map<String, Probe> probeMap = testContainer.getProbeMap();
+        Map<String, Probe> probeMap = testContext.getProbeMap();
         Map<String, Histogram> intervalHistograms = new HashMap<>(probeMap.size());
 
         long intervalPercentileLatency = -1;
@@ -146,7 +149,7 @@ public final class TestPerformanceTracker {
                 intervalMaxLatency = maxValue;
             }
 
-            if (probe.isPartOfTotalThroughput()) {
+            if (probe.isPartOfThroughput()) {
                 intervalOperationCount += intervalHistogram.getTotalCount();
             }
         }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
@@ -67,7 +67,6 @@ public class PropertyBinding {
     private MetronomeSupplier workerMetronomeConstructor;
     private final Class<? extends Probe> probeClass;
     private TestContextImpl testContext;
-    private final Map<String, Probe> probeMap = new ConcurrentHashMap<>();
     private final TestCase testCase;
     private final Set<String> unusedProperties = new HashSet<>();
     private Object driverInstance;
@@ -104,10 +103,6 @@ public class PropertyBinding {
             throw new BindException(format("The following properties %s have not been used on '%s'"
                     , unusedProperties, testCase.getClassname()));
         }
-    }
-
-    public Map<String, Probe> getProbeMap() {
-        return probeMap;
     }
 
     public String load(String property) {
@@ -239,19 +234,6 @@ public class PropertyBinding {
 
     private Class<? extends Probe> loadProbeClass() {
         return measureLatency ? HdrProbe.class : null;
-    }
-
-    public Probe getOrCreateProbe(String probeName, boolean partOfTotalThroughput) {
-        if (probeClass == null) {
-            return EmptyProbe.INSTANCE;
-        }
-
-        Probe probe = probeMap.get(probeName);
-        if (probe == null) {
-            probe = new HdrProbe(partOfTotalThroughput);
-            probeMap.put(probeName, probe);
-        }
-        return probe;
     }
 
     public TestCase getTestCase() {

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContainer.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContainer.java
@@ -96,7 +96,7 @@ public class TestContainer {
                 .setTestContext(testContext);
 
         propertyBinding.bind(this);
-
+        testContext.setProbeClass(propertyBinding.getProbeClass());
         if (givenTestInstance == null) {
             this.testInstance = newTestInstance();
         } else {
@@ -151,7 +151,7 @@ public class TestContainer {
         return testInstance;
     }
 
-    public TestContext getTestContext() {
+    public TestContextImpl getTestContext() {
         return testContext;
     }
 
@@ -169,10 +169,6 @@ public class TestContainer {
 
     public long iteration() {
         return runner == null ? 0 : runner.iterations();
-    }
-
-    public Map<String, Probe> getProbeMap() {
-        return propertyBinding.getProbeMap();
     }
 
     public void invoke(TestPhase testPhase) throws Exception {
@@ -210,7 +206,7 @@ public class TestContainer {
 
             taskPerPhaseMap.put(RUN, () -> {
                 if (propertyBinding.recordJitter) {
-                    Probe probe = propertyBinding.getOrCreateProbe("jitter", false);
+                    Probe probe = testContext.getProbe("jitter", false);
                     new JitterThread(testContext, probe, propertyBinding.recordJitterThresholdNs).start();
                 }
                 runner.run();

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContextImpl.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContextImpl.java
@@ -93,7 +93,6 @@ public class TestContextImpl implements TestContext {
         stopped = true;
     }
 
-
     @Override
     public void echoCoordinator(String msg, Object... args) {
         String message = format(msg, args);

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContextImpl.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContextImpl.java
@@ -15,9 +15,16 @@
  */
 package com.hazelcast.simulator.worker.testcontainer;
 
+import com.hazelcast.simulator.probes.Probe;
+import com.hazelcast.simulator.probes.impl.EmptyProbe;
+import com.hazelcast.simulator.probes.impl.HdrProbe;
 import com.hazelcast.simulator.protocol.Server;
 import com.hazelcast.simulator.protocol.operation.LogOperation;
 import com.hazelcast.simulator.test.TestContext;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static java.lang.String.format;
 
@@ -26,7 +33,9 @@ public class TestContextImpl implements TestContext {
     private final String testId;
     private final String publicIpAddress;
     private final Server server;
+    private final ConcurrentMap<String, Probe> probeMap = new ConcurrentHashMap<>();
     private volatile boolean stopped;
+    private Class probeClass;
 
     public TestContextImpl(String testId,
                            String publicIpAddress,
@@ -34,6 +43,34 @@ public class TestContextImpl implements TestContext {
         this.testId = testId;
         this.publicIpAddress = publicIpAddress;
         this.server = server;
+    }
+
+    public void setProbeClass(Class probeClass) {
+        this.probeClass = probeClass;
+    }
+
+    public Map<String, Probe> getProbeMap() {
+        return probeMap;
+    }
+
+    public Probe getProbe(String probeName, boolean partOfThroughput) {
+        if (probeName == null) {
+            throw new RuntimeException("probeName can't be null");
+        }
+
+        if (probeClass == null) {
+            return EmptyProbe.INSTANCE;
+        }
+
+        Probe probe = probeMap.get(probeName);
+        if (probe == null) {
+            probe = new HdrProbe(partOfThroughput);
+            Probe found = probeMap.putIfAbsent(probeName, probe);
+            if (found != null) {
+                probe = found;
+            }
+        }
+        return probe;
     }
 
     @Override
@@ -55,6 +92,7 @@ public class TestContextImpl implements TestContext {
     public void stop() {
         stopped = true;
     }
+
 
     @Override
     public void echoCoordinator(String msg, Object... args) {

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestManager.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestManager.java
@@ -37,7 +37,7 @@ import static java.lang.String.format;
 
 /**
  * Responsible for managing the TestContainers.
- *
+ * <p/>
  * So creating them, starting their phases, and termination.
  */
 public class TestManager {

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepLoop.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TimeStepLoop.java
@@ -18,7 +18,6 @@ package com.hazelcast.simulator.worker.testcontainer;
 
 import com.hazelcast.simulator.probes.Probe;
 import com.hazelcast.simulator.test.StopException;
-import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.worker.metronome.Metronome;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,7 +42,7 @@ import static java.lang.String.format;
  */
 public abstract class TimeStepLoop implements Runnable {
 
-    protected TestContext testContext;
+    protected TestContextImpl testContext;
     protected Metronome metronome;
 
     protected final Logger logger = LogManager.getLogger(getClass());
@@ -77,7 +76,7 @@ public abstract class TimeStepLoop implements Runnable {
 
     public void bind(PropertyBinding binding) {
         for (Method method : timeStepModel.getActiveTimeStepMethods(executionGroup)) {
-            Probe probe = binding.getOrCreateProbe(method.getName(), false);
+            Probe probe = testContext.getProbe(method.getName(), false);
             if (probe != null) {
                 probeMap.put(method.getName(), probe);
             }

--- a/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/EmptyProbeTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/EmptyProbeTest.java
@@ -12,6 +12,6 @@ public class EmptyProbeTest {
         emptyProbe.reset();
         emptyProbe.done(10);
         emptyProbe.recordValue(20);
-        assertFalse(emptyProbe.isPartOfTotalThroughput());
+        assertFalse(emptyProbe.isPartOfThroughput());
     }
 }

--- a/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrProbeTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrProbeTest.java
@@ -21,13 +21,13 @@ public class HdrProbeTest {
     @Test
     public void testConstructor_throughputProbe() {
         Probe tmpProbe = new HdrProbe(true);
-        assertTrue(tmpProbe.isPartOfTotalThroughput());
+        assertTrue(tmpProbe.isPartOfThroughput());
     }
 
     @Test
     public void testConstructor_noThroughputProbe() {
         Probe tmpProbe = new HdrProbe(false);
-        assertFalse(tmpProbe.isPartOfTotalThroughput());
+        assertFalse(tmpProbe.isPartOfThroughput());
     }
 
     @Test

--- a/java/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/TestContainer_BasicTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/worker/testcontainer/TestContainer_BasicTest.java
@@ -88,13 +88,6 @@ public class TestContainer_BasicTest extends TestContainer_AbstractTest {
     }
 
     @Test
-    public void testGetProbeMap() {
-        testContainer = createTestContainer(new BaseTest());
-
-        assertEquals(0, testContainer.getProbeMap().size());
-    }
-
-    @Test
     public void testAnnotationInheritance_withSetupInBaseClass_withRunInChildClass() throws Exception {
         // @Setup method will be called from base class, not from child class
         // @Run method will be called from child class, not from base class


### PR DESCRIPTION
Tests that rely on @Run, need to have access to Probe instances otherwise they can't record latency. So probe instances can now be obtained through the TestContext.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2099