### PR TITLE
Upload drivers with rsync instead of scp

### DIFF
--- a/src/simulator/ssh.py
+++ b/src/simulator/ssh.py
@@ -120,7 +120,17 @@ class Ssh:
         cmd = f'scp {self.options} -r -q {src} {self.user}@{self.ip}:{dst}'
         self.__scp(cmd)
 
+    def rsync_to_remote(self, src, dst):
+        cmd = f'rsync -P -e "ssh {self.options}" {src} {self.user}@{self.ip}:{dst}'
+        self.__rsync(cmd)
+
     def __scp(self, cmd):
         self.connect()
         exitcode = subprocess.call(cmd, shell=True)
         # raise Exception(f"Failed to execute {cmd} after {self.max_attempts} attempts")
+
+    def __rsync(self, cmd):
+        self.connect()
+        exitcode = subprocess.call(cmd, shell=True)
+        # raise Exception(f"Failed to execute {cmd} after {self.max_attempts} attempts")
+

--- a/src/simulator/ssh.py
+++ b/src/simulator/ssh.py
@@ -133,4 +133,3 @@ class Ssh:
         self.connect()
         exitcode = subprocess.call(cmd, shell=True)
         # raise Exception(f"Failed to execute {cmd} after {self.max_attempts} attempts")
-

--- a/src/upload_hazelcast_jars.py
+++ b/src/upload_hazelcast_jars.py
@@ -21,6 +21,18 @@ def __upload(agent, artifact_ids, version):
 
     print(f"[INFO]     {public_ip(agent)} done")
 
+def __upsync(agent, artifact_ids, version):
+    print(f"[INFO]     {public_ip(agent)} starting")
+    ssh = Ssh(public_ip(agent), ssh_user(agent), ssh_options(agent))
+    ssh.exec("mkdir -p hazelcast-simulator/driver-lib/")
+    dest = f"hazelcast-simulator/driver-lib/maven-{version}"
+    ssh.exec(f"mkdir -p {dest}")
+    for artifact_id in artifact_ids:
+        ssh.rsync_to_remote(f"{local_jar_path(artifact_id, version)}", f"{dest}")
+
+    print(f"[INFO]     {public_ip(agent)} done")
+
+
 
 def local_repo():
     cmd = "mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=settings.localRepository -q -DforceStdout"
@@ -136,5 +148,6 @@ for artifact_id in artifact_ids:
 for artifact_id in artifact_ids:
     print(f"[INFO]Uploading {artifact_id}")
 
-run_parallel(__upload, [(agent, artifact_ids, version) for agent in agents_yaml])
+# run_parallel(__upload, [(agent, artifact_ids, version) for agent in agents_yaml])
+run_parallel(__upsync, [(agent, artifact_ids, version) for agent in agents_yaml])
 print(f"[INFO]Uploading Hazelcast jars: done")

--- a/src/upload_hazelcast_jars.py
+++ b/src/upload_hazelcast_jars.py
@@ -148,6 +148,5 @@ for artifact_id in artifact_ids:
 for artifact_id in artifact_ids:
     print(f"[INFO]Uploading {artifact_id}")
 
-# run_parallel(__upload, [(agent, artifact_ids, version) for agent in agents_yaml])
 run_parallel(__upsync, [(agent, artifact_ids, version) for agent in agents_yaml])
 print(f"[INFO]Uploading Hazelcast jars: done")


### PR DESCRIPTION
The current method for uploading driver artifacts is deleting them from the target member and using `scp` for copying the entire files there. This is done even if the target file is identical to the version to be uploaded, making each test run to upload all drivers to all test machines, making testing slow on machines through slow networks. This commit changes the uploading method to using `rsync` over ssh to copy only if the driver files to upload are absent in the target or different to the version in local.