### PR TITLE
Templates are missing ec2 user

### DIFF
--- a/templates/hazelcast5-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-ec2/inventory_plan.yaml
@@ -20,6 +20,7 @@ nodes:
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
@@ -30,6 +31,7 @@ loadgenerators:
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
@@ -40,6 +42,7 @@ mc:
     count: 1
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu

--- a/templates/hazelcast5-hd-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-hd-ec2/inventory_plan.yaml
@@ -20,6 +20,7 @@ nodes:
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
@@ -30,6 +31,7 @@ loadgenerators:
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
@@ -40,6 +42,7 @@ mc:
     count: 1
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu

--- a/templates/storage-ec2/inventory_plan.yaml
+++ b/templates/storage-ec2/inventory_plan.yaml
@@ -21,6 +21,7 @@ nodes:
     instance_type: i3en.2xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
@@ -32,6 +33,7 @@ loadgenerators:
     instance_type: c5.4xlarge
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu
@@ -43,6 +45,7 @@ mc:
     count: 0
     # default AWS AMI
     # ami: ami-05cafdf7c9f772ad2
+    # user: ec2-user
     # ubuntu
     ami: ami-0d527b8c289b4af7f
     user: ubuntu


### PR DESCRIPTION
The default AMI is listed, but the user isn't. This PR fixes that.

Fixes:
https://github.com/hazelcast/hazelcast-simulator/issues/2107