### PR TITLE
Handle negative elapsed time on HdrLatencyProbe.

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/LatencyProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/LatencyProbe.java
@@ -39,4 +39,12 @@ public interface LatencyProbe {
     void recordValue(long latencyNanos);
 
     void reset();
+
+    default long negativeCount(){
+        return 0;
+    }
+
+    default String name(){
+        return "";
+    }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbe.java
@@ -18,6 +18,8 @@ package com.hazelcast.simulator.probes.impl;
 import com.hazelcast.simulator.probes.LatencyProbe;
 import org.HdrHistogram.Recorder;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
@@ -27,6 +29,8 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 public class HdrLatencyProbe implements LatencyProbe {
     // we want to track up to 24-hour.
     static final long HIGHEST_TRACKABLE_VALUE_NANOS = DAYS.toNanos(1);
+
+    public static final AtomicLong NEG_ELAPSED_COUNT = new AtomicLong();
 
     // we care only about microsecond accuracy.
     private static final long LOWEST_DISCERNIBLE_VALUE = MICROSECONDS.toNanos(1);
@@ -64,6 +68,20 @@ public class HdrLatencyProbe implements LatencyProbe {
 
     @Override
     public void recordValue(long latencyNanos) {
+
+        if (latencyNanos < 0) {
+            NEG_ELAPSED_COUNT.incrementAndGet();
+
+            // Negative values should normally not happen.
+            // But it could happen when the clock jump or when there is an
+            // overflow. So lets convert it to a postive value and record it.
+            if (latencyNanos == Long.MIN_VALUE) {
+                latencyNanos = HIGHEST_TRACKABLE_VALUE_NANOS;
+            } else {
+                latencyNanos = -latencyNanos;
+            }
+        }
+
         if (latencyNanos > HIGHEST_TRACKABLE_VALUE_NANOS) {
             latencyNanos = HIGHEST_TRACKABLE_VALUE_NANOS;
         }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbe.java
@@ -30,7 +30,7 @@ public class HdrLatencyProbe implements LatencyProbe {
     // we want to track up to 24-hour.
     static final long HIGHEST_TRACKABLE_VALUE_NANOS = DAYS.toNanos(1);
 
-    private static final AtomicLong negativeCount = new AtomicLong();
+    private final AtomicLong negativeCount = new AtomicLong();
 
     // we care only about microsecond accuracy.
     private static final long LOWEST_DISCERNIBLE_VALUE = MICROSECONDS.toNanos(1);

--- a/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbe.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbe.java
@@ -30,7 +30,7 @@ public class HdrLatencyProbe implements LatencyProbe {
     // we want to track up to 24-hour.
     static final long HIGHEST_TRACKABLE_VALUE_NANOS = DAYS.toNanos(1);
 
-    public static final AtomicLong NEG_ELAPSED_COUNT = new AtomicLong();
+    private static final AtomicLong negativeCount = new AtomicLong();
 
     // we care only about microsecond accuracy.
     private static final long LOWEST_DISCERNIBLE_VALUE = MICROSECONDS.toNanos(1);
@@ -46,8 +46,10 @@ public class HdrLatencyProbe implements LatencyProbe {
             NUMBER_OF_SIGNIFICANT_VALUE_DIGITS);
 
     private final boolean includeInThroughput;
+    private final String name;
 
-    public HdrLatencyProbe(boolean includeInThroughput) {
+    public HdrLatencyProbe(String name, boolean includeInThroughput) {
+        this.name = name;
         this.includeInThroughput = includeInThroughput;
     }
 
@@ -70,7 +72,7 @@ public class HdrLatencyProbe implements LatencyProbe {
     public void recordValue(long latencyNanos) {
 
         if (latencyNanos < 0) {
-            NEG_ELAPSED_COUNT.incrementAndGet();
+            negativeCount.incrementAndGet();
 
             // Negative values should normally not happen.
             // But it could happen when the clock jump or when there is an
@@ -95,5 +97,15 @@ public class HdrLatencyProbe implements LatencyProbe {
     @Override
     public void reset() {
         recorder.reset();
+    }
+
+    @Override
+    public long negativeCount() {
+        return negativeCount.get();
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
@@ -18,10 +18,11 @@ package com.hazelcast.simulator.worker;
 import com.hazelcast.simulator.agent.workerprocess.WorkerParameters;
 import com.hazelcast.simulator.common.ProcessSuicideThread;
 import com.hazelcast.simulator.common.ShutdownThread;
+import com.hazelcast.simulator.drivers.Driver;
+import com.hazelcast.simulator.probes.impl.HdrLatencyProbe;
 import com.hazelcast.simulator.protocol.Server;
 import com.hazelcast.simulator.protocol.core.SimulatorAddress;
 import com.hazelcast.simulator.utils.ExceptionReporter;
-import com.hazelcast.simulator.drivers.Driver;
 import com.hazelcast.simulator.worker.operations.TerminateWorkerOperation;
 import com.hazelcast.simulator.worker.performance.PerformanceMonitor;
 import com.hazelcast.simulator.worker.testcontainer.TestManager;
@@ -34,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.hazelcast.simulator.agent.workerprocess.WorkerParameters.loadParameters;
 import static com.hazelcast.simulator.common.GitInfo.getBuildTime;
 import static com.hazelcast.simulator.common.GitInfo.getCommitIdAbbrev;
+import static com.hazelcast.simulator.drivers.Driver.loadDriver;
 import static com.hazelcast.simulator.utils.CommonUtils.closeQuietly;
 import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
 import static com.hazelcast.simulator.utils.CommonUtils.getSimulatorVersion;
@@ -44,7 +46,6 @@ import static com.hazelcast.simulator.utils.NativeUtils.getInputArgs;
 import static com.hazelcast.simulator.utils.NativeUtils.getPID;
 import static com.hazelcast.simulator.utils.NativeUtils.writePid;
 import static com.hazelcast.simulator.utils.SimulatorUtils.localIp;
-import static com.hazelcast.simulator.drivers.Driver.loadDriver;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 
@@ -101,6 +102,10 @@ public class Worker {
 
     public void shutdown(TerminateWorkerOperation op) {
         LOGGER.warn("Terminating worker");
+        long negCount = HdrLatencyProbe.NEG_ELAPSED_COUNT.get();
+        if (negCount > 0) {
+            LOGGER.warn("HdrLatencyProbe has encounter " + negCount + " negative measurements.");
+        }
         closeQuietly(server);
         shutdownThread = new WorkerShutdownThread(op.isRealShutdown());
         shutdownThread.start();

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
@@ -102,10 +102,6 @@ public class Worker {
 
     public void shutdown(TerminateWorkerOperation op) {
         LOGGER.warn("Terminating worker");
-        long negCount = HdrLatencyProbe.NEG_ELAPSED_COUNT.get();
-        if (negCount > 0) {
-            LOGGER.warn("HdrLatencyProbe has encounter " + negCount + " negative measurements.");
-        }
         closeQuietly(server);
         shutdownThread = new WorkerShutdownThread(op.isRealShutdown());
         shutdownThread.start();

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContainer.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContainer.java
@@ -199,9 +199,7 @@ public class TestContainer {
             if (testPhase == RUN) {
                 for (LatencyProbe probe : testContext.getLatencyProbes().values()) {
                     if (probe.negativeCount() > 0) {
-                        String msg = "HdrLatencyProbe [" + probe.name() + "] has encounter "
-                                + probe.negativeCount() + " negative measurements! Maybe there"
-                                + " is a clock problem.";
+                        String msg = MessageFormat.format("HdrLatencyProbe [{0}] has encountered {1} negative measurements! Maybe there is a clock problem.", probe.name(), probe.negativeCount());
                         System.err.println(msg);
                         testContext.echoCoordinator(msg);
                     }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContainer.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContainer.java
@@ -114,7 +114,7 @@ public class TestContainer {
         this.testPerformanceTracker = new TestPerformanceTracker(this);
     }
 
-    public void stop(){
+    public void stop() {
         testContext.stop();
         runner.stop();
     }
@@ -193,6 +193,20 @@ public class TestContainer {
                 throw e;
             }
         } finally {
+            // after the run phase we check if any negative latencies have
+            // been encountered.
+
+            if (testPhase == RUN) {
+                for (LatencyProbe probe : testContext.getLatencyProbes().values()) {
+                    if (probe.negativeCount() > 0) {
+                        String msg = "HdrLatencyProbe [" + probe.name() + "] has encounter "
+                                + probe.negativeCount() + " negative measurements! Maybe there"
+                                + " is a clock problem.";
+                        System.err.println(msg);
+                        testContext.echoCoordinator(msg);
+                    }
+                }
+            }
             currentPhase.set(null);
         }
     }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContextImpl.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/TestContextImpl.java
@@ -64,7 +64,7 @@ public class TestContextImpl implements TestContext {
 
         LatencyProbe probe = latencyProbes.get(probeName);
         if (probe == null) {
-            probe = new HdrLatencyProbe(includeInThroughput);
+            probe = new HdrLatencyProbe(probeName, includeInThroughput);
             LatencyProbe found = latencyProbes.putIfAbsent(probeName, probe);
             if (found != null) {
                 probe = found;
@@ -92,7 +92,6 @@ public class TestContextImpl implements TestContext {
     public void stop() {
         stopped = true;
     }
-
 
     @Override
     public void echoCoordinator(String msg, Object... args) {

--- a/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbeTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbeTest.java
@@ -74,9 +74,12 @@ public class HdrLatencyProbeTest {
 
     @Test
     public void testNegativeValue() {
+        HdrLatencyProbe probe = new HdrLatencyProbe("foo", false);
         long value1 = MILLISECONDS.toNanos(-200);
 
         probe.recordValue(value1);
+
+        assertEquals(1, probe.negativeCount());
 
         Histogram histogram = probe.getRecorder().getIntervalHistogram();
         assertHistogramContent(histogram, -value1);
@@ -84,9 +87,13 @@ public class HdrLatencyProbeTest {
 
     @Test
     public void testLongMinValue() {
+        HdrLatencyProbe probe = new HdrLatencyProbe("foo", false);
+
         long value1 = MILLISECONDS.toNanos(Long.MIN_VALUE);
 
         probe.recordValue(value1);
+
+        assertEquals(1, probe.negativeCount());
 
         Histogram histogram = probe.getRecorder().getIntervalHistogram();
         assertHistogramContent(histogram, HIGHEST_TRACKABLE_VALUE_NANOS);

--- a/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbeTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbeTest.java
@@ -16,17 +16,17 @@ import static org.junit.Assert.fail;
 
 public class HdrLatencyProbeTest {
 
-    private HdrLatencyProbe probe = new HdrLatencyProbe(false);
+    private HdrLatencyProbe probe = new HdrLatencyProbe("foo", false);
 
     @Test
     public void testConstructor_throughputProbe() {
-        LatencyProbe tmpProbe = new HdrLatencyProbe(true);
+        LatencyProbe tmpProbe = new HdrLatencyProbe("foo", true);
         assertTrue(tmpProbe.includeInThroughput());
     }
 
     @Test
     public void testConstructor_noThroughputProbe() {
-        LatencyProbe tmpProbe = new HdrLatencyProbe(false);
+        LatencyProbe tmpProbe = new HdrLatencyProbe("foo", false);
         assertFalse(tmpProbe.includeInThroughput());
     }
 
@@ -136,4 +136,6 @@ public class HdrLatencyProbeTest {
 
         assertEquals(3, probe.getRecorder().getIntervalHistogram().getTotalCount());
     }
+
+
 }

--- a/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbeTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/probes/impl/HdrLatencyProbeTest.java
@@ -73,6 +73,26 @@ public class HdrLatencyProbeTest {
     }
 
     @Test
+    public void testNegativeValue() {
+        long value1 = MILLISECONDS.toNanos(-200);
+
+        probe.recordValue(value1);
+
+        Histogram histogram = probe.getRecorder().getIntervalHistogram();
+        assertHistogramContent(histogram, -value1);
+    }
+
+    @Test
+    public void testLongMinValue() {
+        long value1 = MILLISECONDS.toNanos(Long.MIN_VALUE);
+
+        probe.recordValue(value1);
+
+        Histogram histogram = probe.getRecorder().getIntervalHistogram();
+        assertHistogramContent(histogram, HIGHEST_TRACKABLE_VALUE_NANOS);
+    }
+
+    @Test
     public void testRecord_whenTooLarge() {
         long value = HIGHEST_TRACKABLE_VALUE_NANOS * 2;
         probe.recordValue(value);


### PR DESCRIPTION
Apparently, it can happen that the elapsed time is negative:

```
cause=java.lang.ArrayIndexOutOfBoundsException: Histogram recorded value cannot be negative.
        at org.HdrHistogram.AbstractHistogram.countsArrayIndex(AbstractHistogram.java:2404)
        at org.HdrHistogram.AbstractHistogram.recordSingleValue(AbstractHistogram.java:559)
        at org.HdrHistogram.AbstractHistogram.recordValue(AbstractHistogram.java:467)
        at org.HdrHistogram.Recorder.recordValue(Recorder.java:136)
        at com.hazelcast.simulator.probes.impl.HdrProbe.recordValue(HdrProbe.java:70)
        at CreateDestroyICacheTestLoopCacheCreateDestroy.timeStepLoop(CreateDestroyICacheTestLoopCacheCreateDestroy.java:43)
        at com.hazelcast.simulator.worker.testcontainer.TimeStepLoop.run(TimeStepLoop.java:110)
        at java.lang.Thread.run(Thread.java:748)
        at com.hazelcast.simulator.utils.ThreadSpawner$ReportExceptionThread.run(ThreadSpawner.java:179)
```
        
This PR fixes that by converting the elapsed value to a positive value.

Also at the end of the test, the probes are checked if there are any negative values and the info is logged in the System.err + send to the coordinator.