### PR TITLE
inventory install simulator should include rsync

### DIFF
--- a/playbooks/install_simulator.yaml
+++ b/playbooks/install_simulator.yaml
@@ -12,6 +12,11 @@
       apt-get update || true
     become: yes
 
+  - name: Install rsync
+    ansible.builtin.package:
+      name: rsync
+      state: present
+    become: yes
 
   # we want to install either dstat or pcp.
   # pcp is a replacement for dstat. dstat project


### PR DESCRIPTION
When 'inventory install simulator' is called, it should ensure that rsync is installed on the remote machines since rsync is used to upload the hazelcast jars.