### PR TITLE
Add hotset long key selection support

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -73,6 +73,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
             keySelector = new RandomKeySelector(keyDomain);
         }
         logger.info("Using " + keySelector);
+        keySelector.prepareKeyDistributionFile();
     }
 
     @Prepare(global = true)
@@ -163,16 +164,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
     @Teardown
     public void tearDown() {
         map.destroy();
-        logger.info("Key bucket hits:");
-        long allHits = 0;
-        for (int i = 0; i < buckets.length(); i++) {
-            allHits += buckets.get(i);
-        }
 
-        for (int i = 0; i < buckets.length(); i++) {
-            long bucketHits = buckets.get(i);
-            double bucketHitPercentage = (double) bucketHits / allHits * 100;
-            logger.info(String.format("\tBucket %2d = %.2f%%", i, bucketHitPercentage));
-        }
+        keySelector.dumpKeyDistribution(testContext.getTestId());
     }
 }

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -69,7 +69,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
         } else {
             keySelector = new RandomKeySelector(keyDomain);
         }
-        logger.info("Using " + keySelector.getClass().getSimpleName() + " key selector");
+        logger.info("Using " + keySelector);
     }
 
     @Prepare(global = true)

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -69,6 +69,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
         } else {
             keySelector = new RandomKeySelector(keyDomain);
         }
+        logger.info("Using " + keySelector.getClass().getSimpleName() + " key selector");
     }
 
     @Prepare(global = true)

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -26,6 +26,9 @@ import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.StartNanos;
 import com.hazelcast.simulator.test.annotations.Teardown;
 import com.hazelcast.simulator.test.annotations.TimeStep;
+import com.hazelcast.simulator.utils.HotSetKeySelector;
+import com.hazelcast.simulator.utils.KeySelector;
+import com.hazelcast.simulator.utils.RandomKeySelector;
 import com.hazelcast.simulator.worker.loadsupport.Streamer;
 import com.hazelcast.simulator.worker.loadsupport.StreamerFactory;
 
@@ -48,6 +51,10 @@ public class LongByteArrayMapTest extends HazelcastTest {
     public int pipelineDepth = 10;
     public int pipelineIterations = 100;
     public int getAllSize = 5;
+    public String selector = "random";
+    public int hotSetPercentage = 10;
+    public int hotSetAccessPercentage = 90;
+    private KeySelector keySelector;
 
     private IMap<Long, byte[]> map;
     private byte[][] values;
@@ -57,6 +64,11 @@ public class LongByteArrayMapTest extends HazelcastTest {
     public void setUp() {
         map = targetInstance.getMap(name);
         values = generateByteArrays(valueCount, minValueLength, maxValueLength);
+        if ("hotset".equalsIgnoreCase(selector)) {
+            keySelector = new HotSetKeySelector(0, keyDomain, hotSetAccessPercentage, hotSetPercentage);
+        } else {
+            keySelector = new RandomKeySelector(keyDomain);
+        }
     }
 
     @Prepare(global = true)
@@ -131,7 +143,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
         private int i;
 
         private long randomKey() {
-            return randomLong(keyDomain);
+            return keySelector.nextKey(this::randomLong);
         }
 
         private byte[] randomValue() {

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -68,7 +68,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
         map = targetInstance.getMap(name);
         values = generateByteArrays(valueCount, minValueLength, maxValueLength);
         if ("hotset".equalsIgnoreCase(selector)) {
-            keySelector = new HotSetKeySelector(0, keyDomain, hotSetAccessPercentage, hotSetPercentage);
+            keySelector = new HotSetKeySelector(0, keyDomain - 1, hotSetAccessPercentage, hotSetPercentage);
         } else {
             keySelector = new RandomKeySelector(keyDomain);
         }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/AbstractKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/AbstractKeySelector.java
@@ -1,0 +1,51 @@
+package com.hazelcast.simulator.utils;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.IntToLongFunction;
+
+import static com.hazelcast.simulator.utils.FileUtils.getUserDir;
+
+abstract class AbstractKeySelector implements KeySelector {
+    private final AtomicLongArray buckets = new AtomicLongArray(100);
+    private final long keyDomain;
+    private final File bucketsCsv;
+
+    AbstractKeySelector(long keyDomain) {
+        this.keyDomain = keyDomain;
+        this.bucketsCsv = new File(getUserDir(), "key_bucket_dist.csv");
+    }
+
+    @Override
+    public void prepareKeyDistributionFile() {
+        FileUtils.appendText("test_id,bucket,hits,percentage\n", bucketsCsv);
+    }
+
+    @Override
+    public long nextKey(IntToLongFunction randomFn) {
+        long rndKey = nextKey0(randomFn);
+        int bucketIdx = (int) ((double) rndKey / keyDomain * 100);
+        buckets.incrementAndGet(bucketIdx);
+        return rndKey;
+    }
+
+
+    protected abstract long nextKey0(IntToLongFunction randomFn);
+
+    @Override
+    public void dumpKeyDistribution(String testId) {
+        long allHits = 0;
+        for (int i = 0; i < buckets.length(); i++) {
+            allHits += buckets.get(i);
+        }
+
+        for (int bucket = 0; bucket < buckets.length(); bucket++) {
+            long bucketHits = buckets.get(bucket);
+            double bucketHitPercentage = (double) bucketHits / allHits * 100;
+            FileUtils.appendText(String.format("%s,%d,%d,%.4f", testId, bucket, bucketHits, bucketHitPercentage),
+                    bucketsCsv);
+        }
+
+    }
+
+}

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/AbstractKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/AbstractKeySelector.java
@@ -42,7 +42,7 @@ abstract class AbstractKeySelector implements KeySelector {
         for (int bucket = 0; bucket < buckets.length(); bucket++) {
             long bucketHits = buckets.get(bucket);
             double bucketHitPercentage = (double) bucketHits / allHits * 100;
-            FileUtils.appendText(String.format("%s,%d,%d,%.4f", testId, bucket, bucketHits, bucketHitPercentage),
+            FileUtils.appendText(String.format("%s,%d,%d,%.4f\n", testId, bucket, bucketHits, bucketHitPercentage),
                     bucketsCsv);
         }
 

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
@@ -32,7 +32,7 @@ public class HotSetKeySelector implements KeySelector {
         this.min = min;
         this.max = max;
         this.hotSetAccessPercentage = hotSetAccessPercentage;
-        this.hotSetThreshold = max - (int) (((max - min) * (float) hotSetPercentage / 100));
+        this.hotSetThreshold = max - (int) ((max - min) * (float) hotSetPercentage / 100);
     }
 
     public int getHotSetThreshold() {
@@ -48,5 +48,15 @@ public class HotSetKeySelector implements KeySelector {
         } else {
             return randomFn.applyAsLong(max + 1 - hotSetThreshold) + hotSetThreshold;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "HotSetKeySelector{"
+                + "min=" + min
+                + ", max=" + max
+                + ", hotSetAccessPercentage=" + hotSetAccessPercentage
+                + ", hotSetThreshold=" + hotSetThreshold
+                + '}';
     }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
@@ -1,0 +1,52 @@
+package com.hazelcast.simulator.utils;
+
+import java.util.function.IntToLongFunction;
+
+/**
+ * {@link KeySelector} implementation making record accesses
+ * randomized with hot/cold data set classification. With the
+ * help of this implementation tests can be setup to access
+ * a hot set of records with probability expressed in percentage.
+ * The hot set of the records is expressed as percentage of the
+ * interval.
+ * <p/>
+ * Within the hot and cold set classes the access aims to be
+ * uniformly distributed by using the random function provided
+ * to the {@link #nextKey(IntToLongFunction)}.
+ */
+public class HotSetKeySelector implements KeySelector {
+    private final int hotSetThreshold;
+    private final int hotSetAccessPercentage;
+    private final int min;
+    private final int max;
+
+    /**
+     * @param min                    The lower bound of the key interval
+     * @param max                    The higher bound of the key interval
+     * @param hotSetAccessPercentage The probability of accessing
+     *                               hot set records
+     * @param hotSetPercentage       The percentage of the hot set
+     *                               records in the interval
+     */
+    public HotSetKeySelector(int min, int max, int hotSetAccessPercentage, int hotSetPercentage) {
+        this.min = min;
+        this.max = max;
+        this.hotSetAccessPercentage = hotSetAccessPercentage;
+        this.hotSetThreshold = max - (int) (((max - min) * (float) hotSetPercentage / 100));
+    }
+
+    public int getHotSetThreshold() {
+        return hotSetThreshold;
+    }
+
+    @Override
+    public long nextKey(IntToLongFunction randomFn) {
+        long clazz = randomFn.applyAsLong(100);
+        boolean hotSet = clazz >= hotSetAccessPercentage;
+        if (hotSet) {
+            return randomFn.applyAsLong(hotSetThreshold) + min;
+        } else {
+            return randomFn.applyAsLong(max + 1 - hotSetThreshold) + hotSetThreshold;
+        }
+    }
+}

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
@@ -15,7 +15,7 @@ import java.util.function.IntToLongFunction;
  * uniformly distributed by using the random function provided
  * to the {@link #nextKey(IntToLongFunction)}.
  */
-public class HotSetKeySelector implements KeySelector {
+public class HotSetKeySelector extends AbstractKeySelector {
     private final int hotSetThreshold;
     private final int hotSetAccessPercentage;
     private final int min;
@@ -30,6 +30,7 @@ public class HotSetKeySelector implements KeySelector {
      *                               records in the interval
      */
     public HotSetKeySelector(int min, int max, int hotSetAccessPercentage, int hotSetPercentage) {
+        super(max + 1 - min);
         this.min = min;
         this.max = max;
         this.hotSetAccessPercentage = hotSetAccessPercentage;
@@ -41,7 +42,7 @@ public class HotSetKeySelector implements KeySelector {
     }
 
     @Override
-    public long nextKey(IntToLongFunction randomFn) {
+    protected long nextKey0(IntToLongFunction randomFn) {
         long clazz = randomFn.applyAsLong(100);
         boolean hotSet = clazz >= hotSetAccessPercentage;
         if (hotSet) {

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HotSetKeySelector.java
@@ -1,5 +1,6 @@
 package com.hazelcast.simulator.utils;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntToLongFunction;
 
 /**
@@ -58,5 +59,31 @@ public class HotSetKeySelector implements KeySelector {
                 + ", hotSetAccessPercentage=" + hotSetAccessPercentage
                 + ", hotSetThreshold=" + hotSetThreshold
                 + '}';
+    }
+
+    public static void main(String[] args) {
+        int keyDomain = 1000;
+        HotSetKeySelector selector = new HotSetKeySelector(0, keyDomain - 1, 95, 10);
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        long[] buckets = new long[100];
+        for (int i = 0; i < 1000_000; i++) {
+            long l = selector.nextKey(x -> (long) (rnd.nextDouble() * x));
+            int bucketIdx = (int) ((double) l / keyDomain * 100);
+            buckets[bucketIdx]++;
+//            System.out.println(bucketIdx);
+//            System.out.println(l);
+        }
+
+        long allHits = 0;
+        for (int i = 0; i < buckets.length; i++) {
+            allHits += buckets[i];
+        }
+
+        for (int i = 0; i < buckets.length; i++) {
+            long bucketHits = buckets[i];
+            double bucketHitPercentage = (double) bucketHits / allHits * 100;
+            System.out.println(String.format("Bucket %2d = %.2f%%", i, bucketHitPercentage));
+        }
+
     }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/KeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/KeySelector.java
@@ -7,6 +7,8 @@ import java.util.function.IntToLongFunction;
  * the next long key the test to operate with.
  */
 public interface KeySelector {
+    void prepareKeyDistributionFile();
+
     /**
      * Retrieves the next long key with the provided random function
      * used to randomize the next keys.
@@ -15,4 +17,6 @@ public interface KeySelector {
      * @return the next long key to operate with
      */
     long nextKey(IntToLongFunction randomFn);
+
+    void dumpKeyDistribution(String testId);
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/KeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/KeySelector.java
@@ -1,0 +1,18 @@
+package com.hazelcast.simulator.utils;
+
+import java.util.function.IntToLongFunction;
+
+/**
+ * Interface of the long key selection algorithm to be used for selecting
+ * the next long key the test to operate with.
+ */
+public interface KeySelector {
+    /**
+     * Retrieves the next long key with the provided random function
+     * used to randomize the next keys.
+     *
+     * @param randomFn The random function.
+     * @return the next long key to operate with
+     */
+    long nextKey(IntToLongFunction randomFn);
+}

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
@@ -21,4 +21,11 @@ public class RandomKeySelector implements KeySelector {
     public long nextKey(IntToLongFunction randomFn) {
         return randomFn.applyAsLong(keyDomain);
     }
+
+    @Override
+    public String toString() {
+        return "RandomKeySelector{" +
+                "keyDomain=" + keyDomain +
+                '}';
+    }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
@@ -1,5 +1,6 @@
 package com.hazelcast.simulator.utils;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.IntToLongFunction;
 
 /**
@@ -27,5 +28,32 @@ public class RandomKeySelector implements KeySelector {
         return "RandomKeySelector{" +
                 "keyDomain=" + keyDomain +
                 '}';
+    }
+
+    public static void main(String[] args) {
+        int keyDomain = 25769803;
+        RandomKeySelector selector = new RandomKeySelector(keyDomain);
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        long[] buckets = new long[100];
+        for (int i = 0; i < 1000_000; i++) {
+            long l = selector.nextKey(x -> (long) (rnd.nextDouble() * x));
+            int bucketIdx = (int) ((double) l / keyDomain * 100);
+            buckets[bucketIdx]++;
+
+//            System.out.println(bucketIdx);
+        }
+
+
+        long allHits = 0;
+        for (int i = 0; i < buckets.length; i++) {
+            allHits += buckets[i];
+        }
+
+        for (int i = 0; i < buckets.length; i++) {
+            long bucketHits = buckets[i];
+            double bucketHitPercentage = (double) bucketHits / allHits * 100;
+            System.out.println(String.format("Bucket %2d = %.2f%%", i, bucketHitPercentage));
+        }
+
     }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
@@ -1,0 +1,24 @@
+package com.hazelcast.simulator.utils;
+
+import java.util.function.IntToLongFunction;
+
+/**
+ * {@link KeySelector} implementation to make the IMap records
+ * randomly accessed.
+ */
+public class RandomKeySelector implements KeySelector {
+
+    private final int keyDomain;
+
+    /**
+     * @param keyDomain The key domain of the test.
+     */
+    public RandomKeySelector(int keyDomain) {
+        this.keyDomain = keyDomain;
+    }
+
+    @Override
+    public long nextKey(IntToLongFunction randomFn) {
+        return randomFn.applyAsLong(keyDomain);
+    }
+}

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/RandomKeySelector.java
@@ -7,7 +7,7 @@ import java.util.function.IntToLongFunction;
  * {@link KeySelector} implementation to make the IMap records
  * randomly accessed.
  */
-public class RandomKeySelector implements KeySelector {
+public class RandomKeySelector extends AbstractKeySelector {
 
     private final int keyDomain;
 
@@ -15,11 +15,12 @@ public class RandomKeySelector implements KeySelector {
      * @param keyDomain The key domain of the test.
      */
     public RandomKeySelector(int keyDomain) {
+        super(keyDomain);
         this.keyDomain = keyDomain;
     }
 
     @Override
-    public long nextKey(IntToLongFunction randomFn) {
+    protected long nextKey0(IntToLongFunction randomFn) {
         return randomFn.applyAsLong(keyDomain);
     }
 

--- a/java/simulator/src/test/java/com/hazelcast/simulator/utils/HotSetKeySelectorTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/utils/HotSetKeySelectorTest.java
@@ -1,0 +1,112 @@
+package com.hazelcast.simulator.utils;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class HotSetKeySelectorTest {
+    private static final int SELECTIONS = 10_000_000;
+
+    @Parameters(name = "max:{0}, hsAccPerc: {1}, hsPerc: {2}")
+    public static Collection primeNumbers() {
+        return Arrays.asList(new Object[][]{
+                {100, 80, 20, 4.0D, 0.25D, 10E-0, 10E-2},
+                {100, 95, 10, 9.50D, 0.055D, 10E-1, 10E-3},
+                {1000, 99, 30, 0.33D, 0.0014D, 10E-2, 10E-4},
+        });
+    }
+
+    /**
+     * The size of the key domain to be tested.
+     */
+    @Parameter(0)
+    public int keyDomain;
+
+    /**
+     * The percentage of all accesses hitting the hot set.
+     */
+    @Parameter(1)
+    public int hotSetAccessPercentage;
+
+    /**
+     * The percentage of all accesses hitting the cold set.
+     */
+    @Parameter(2)
+    public int hotSetPercentage;
+
+    /**
+     * The expected percentage of hitting a single key in the hot set.
+     */
+    @Parameter(3)
+    public double expectedHotKeyHitPercentage;
+
+    /**
+     * The expected percentage of hitting a single key in the cold set.
+     */
+    @Parameter(4)
+    public double expectedColdKeyHitPercentage;
+
+    /**
+     * The epsilon defining the accepted interval around {@link #expectedHotKeyHitPercentage}.
+     */
+    @Parameter(5)
+    public double hotKeyPercentageEpsilon;
+
+    /**
+     * The epsilon defining the accepted interval around {@link #expectedColdKeyHitPercentage}.
+     */
+    @Parameter(6)
+    public double coldKeyPercentageEpsilon;
+
+    @Test
+    public void test() {
+        HotSetKeySelector keySelector = new HotSetKeySelector(0, keyDomain - 1, hotSetAccessPercentage, hotSetPercentage);
+        long[] dist = runSelections(keySelector);
+
+        verifyDistribution(dist, keySelector.getHotSetThreshold());
+    }
+
+    @NotNull
+    private long[] runSelections(HotSetKeySelector keySelector) {
+        long[] dist = new long[keyDomain];
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < SELECTIONS; i++) {
+            long x = keySelector.nextKey(random::nextLong);
+            dist[(int) x]++;
+        }
+        return dist;
+    }
+
+    private void verifyDistribution(long[] dist, int hotSetThreshold) {
+        long coldSetHits = 0;
+        long hotSetHits = 0;
+        for (int i = 0; i < dist.length; i++) {
+            long keyHits = dist[i];
+            double keyHitPercentage = ((double) keyHits) / SELECTIONS * 100;
+            if (i < hotSetThreshold) {
+                assertEquals("Unexpected hit count for key: " + i, expectedColdKeyHitPercentage, keyHitPercentage,
+                        coldKeyPercentageEpsilon);
+                coldSetHits += keyHits;
+            } else {
+                assertEquals(expectedHotKeyHitPercentage, keyHitPercentage, hotKeyPercentageEpsilon);
+                hotSetHits += keyHits;
+            }
+        }
+
+        double coldSetHitsPercentage = ((double) coldSetHits) / SELECTIONS * 100;
+        double hotSetHitsPercentage = ((double) hotSetHits) / SELECTIONS * 100;
+
+        assertEquals(100.0D - hotSetAccessPercentage, coldSetHitsPercentage, 10E-1);
+        assertEquals(hotSetAccessPercentage, hotSetHitsPercentage, 10E-1);
+    }
+}


### PR DESCRIPTION
Simulator currently supports only uniform distribution over all keys in its tests. 
This change adds support for defining a hot set for long key tests. This addition
classifies the keys as hot and cold keys and aims for uniform distribution _inside_ 
these key classes by accessing keys randomly within the classes, but selecting 
keys from the hot set class with the probability defined in the test configuration.
For example, a test can be configured to classify 10% of all keys as hot, and hit
them in 95% of all accesses.

The tests can define the percentage of the hot keys in the key domain as well as 
the probability of hitting the hot keys. This feature is added to 
`LongByteArrayMapTest` only. The "hotset" key selection can be activated by 
setting `selector: hotset` in the test configuration, otherwise the test still uses 
the random key selection algorithm without classification, as before.