### PR TITLE
Minor performance output enhancement.

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollector.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollector.java
@@ -71,28 +71,46 @@ public class PerformanceStatsCollector {
             return "";
         }
 
-        String latencyUnit = "µs";
-        long latencyAvg = NANOSECONDS.toMicros(round(latest.getIntervalLatencyAvgNanos()));
-        long latency999Percentile = NANOSECONDS.toMicros(latest.getIntervalLatency999PercentileNanos());
-        long latencyMax = NANOSECONDS.toMicros(latest.getIntervalLatencyMaxNanos());
-
-        if (latencyAvg > DISPLAY_LATENCY_AS_MICROS_MAX_VALUE) {
-            latencyUnit = "ms";
-            latencyAvg = MICROSECONDS.toMillis(latencyAvg);
-            latency999Percentile = MICROSECONDS.toMillis(latency999Percentile);
-            latencyMax = MICROSECONDS.toMillis(latencyMax);
-        }
+        double latencyAvgNs = latest.getIntervalLatencyAvgNanos();
+        double latency999PercentileNs = latest.getIntervalLatency999PercentileNanos();
+        double latencyMaxNs = latest.getIntervalLatencyMaxNanos();
 
         return format("%s ops %s ops/s %s %s (avg) %s %s (%sth) %s %s (max)",
                 formatLong(latest.getOperationCount(), OPERATION_COUNT_FORMAT_LENGTH),
                 formatDouble(latest.getIntervalThroughput(), THROUGHPUT_FORMAT_LENGTH),
-                formatLong(latencyAvg, LATENCY_FORMAT_LENGTH),
-                latencyUnit,
-                formatLong(latency999Percentile, LATENCY_FORMAT_LENGTH),
-                latencyUnit,
+                formatLong(toPrettyValue(latencyAvgNs), LATENCY_FORMAT_LENGTH),
+                toPrettyUnit(latencyAvgNs),
+                formatLong(toPrettyValue(latency999PercentileNs), LATENCY_FORMAT_LENGTH),
+                toPrettyUnit(latency999PercentileNs),
                 INTERVAL_LATENCY_PERCENTILE,
-                formatLong(latencyMax, LATENCY_FORMAT_LENGTH),
-                latencyUnit);
+                formatLong(toPrettyValue(latencyMaxNs), LATENCY_FORMAT_LENGTH),
+                toPrettyUnit(latencyMaxNs));
+    }
+
+    /**
+     * If the valueNs is less than or equal to DISPLAY_LATENCY_AS_MICROS_MAX_VALUE,
+     * it will return the time in microseconds and otherwise in nanoseconds.
+     */
+    private static long toPrettyValue(double valueNs) {
+        long v = NANOSECONDS.toMicros(round(valueNs));
+        if (v > DISPLAY_LATENCY_AS_MICROS_MAX_VALUE) {
+            return MICROSECONDS.toMillis(v);
+        } else {
+            return v;
+        }
+    }
+
+    /**
+     * If the valueNs is less than or equal to DISPLAY_LATENCY_AS_MICROS_MAX_VALUE,
+     * it will return "µs" and otherwise "ms".
+     */
+    private static String toPrettyUnit(double valueNs) {
+        long value = NANOSECONDS.toMicros(round(valueNs));
+        if (value > DISPLAY_LATENCY_AS_MICROS_MAX_VALUE) {
+            return "ms";
+        } else {
+            return "µs";
+        }
     }
 
     PerformanceStats get(String testCaseId, boolean aggregated) {

--- a/java/simulator/src/test/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollectorTest.java
+++ b/java/simulator/src/test/java/com/hazelcast/simulator/coordinator/PerformanceStatsCollectorTest.java
@@ -69,7 +69,7 @@ public class PerformanceStatsCollectorTest {
     }
 
     @Test
-    public void testFormatPerformanceNumbers_avgLatencyOverMicrosThreshold() throws Exception {
+    public void testFormatPerformanceNumbers_avgLatencyOverMicrosThreshold() {
         SimulatorAddress worker = workerAddress(3, 1);
 
         Map<String, PerformanceStats> performanceStats = new HashMap<String, PerformanceStats>();
@@ -78,9 +78,8 @@ public class PerformanceStatsCollectorTest {
 
         performanceStatsCollector.update(worker, performanceStats);
 
-        String performance = performanceStatsCollector.formatIntervalPerformanceNumbers(TEST_CASE_ID_1);
-        assertTrue(performance.contains("ms"));
-        assertFalse(performance.contains("µs"));
+        String s = performanceStatsCollector.formatIntervalPerformanceNumbers(TEST_CASE_ID_1);
+        assertEquals("           800 ops       100.00 ops/s      3,000 ms (avg)      2,400 µs (99.9th)      2,500 µs (max)", s);
     }
 
     private void update(SimulatorAddress address, String testId, PerformanceStats performanceStats) {


### PR DESCRIPTION
3 columns are being printed: avg, p999 and the max.

```
FO  05:02:36 map Running 00d 00h 02m 39s ( 88.33%)    96,585,791 ops   610,472.29 ops/s         12 ms (avg)        595 ms (99.9th)        711 ms (max)
INFO  05:02:37 map Running 00d 00h 02m 40s ( 88.89%)    97,198,883 ops   613,037.38 ops/s      9,517 µs (avg)    529,006 µs (99.9th)    543,686 µs (max)
INFO  05:02:38 map Running 00d 00h 02m 41s ( 89.45%)    97,810,848 ops   611,899.57 ops/s         10 ms (avg)        739 ms (99.9th)        764 ms (max)
INFO  05:02:39 map Running 00d 00h 02m 42s ( 90.00%)    98,421,879 ops   610,993.83 ops/s      9,446 µs (avg)    537,919 µs (99.9th)    594,542 µs (max)
INFO  05:02:40 map Running 00d 00h 02m 43s ( 90.56%)    99,032,041 ops   610,127.92 ops/s      9,347 µs (avg)    886,571 µs (99.9th)    890,241 µs (max)
INFO  05:02:41 map Running 00d 00h 02m 44s ( 91.11%)    99,643,654 ops   611,576.28 ops/s         12 ms (avg)        645 ms (99.9th)        670 ms (max)
INFO  05:02:42 map Running 00d 00h 02m 45s ( 91.67%)   100,258,475 ops   614,765.89 ops/s         11 ms (avg)        880 ms (99.9th)        888 ms (max)
INFO  05:02:43 map Running 00d 00h 02m 46s ( 92.22%)   100,868,678 ops   610,152.71 ops/s         10 ms (avg)        633 ms (99.9th)        656 ms (max)
INFO  05:02:44 map Running 00d 00h 02m 47s ( 92.78%)   101,481,330 ops   612,591.18 ops/s         11 ms (avg)        724 ms (99.9th)        741 ms (max)
INFO  05:02:45 map Running 00d 00h 02m 48s ( 93.33%)   102,093,122 ops   611,749.60 ops/s         18 ms (avg)        802 ms (99.9th)        872 ms (max)
INFO  05:02:46 map Running 00d 00h 02m 49s ( 93.89%)   102,706,894 ops   613,731.67 ops/s         11 ms (avg)        720 ms (99.9th)        745 ms (max)
INFO  05:02:47 map Running 00d 00h 02m 50s ( 94.44%)   103,317,798 ops   610,866.29 ops/s      9,485 µs (avg)    551,550 µs (99.9th)    669,515 µs (max)
INFO  05:02:48 map Running 00d 00h 02m 51s ( 95.00%)   103,930,211 ops   612,343.10 ops/s         12 ms (avg)        709 ms (99.9th)        728 ms (max)
INFO  05:02:49 map Running 00d 00h 02m 52s ( 95.56%)   104,537,059 ops   606,827.22 ops/s         16 ms (avg)        859 ms (99.9th)        861 ms (max)
INFO  05:02:50 map Running 00d 00h 02m 53s ( 96.11%)   105,146,317 ops   609,212.03 ops/s      9,831 µs (avg)    655,884 µs (99.9th)    668,991 µs (max)
INFO  05:02:51 map Running 00d 00h 02m 54s ( 96.67%)   105,759,452 ops   613,075.40 ops/s         11 ms (avg)        646 ms (99.9th)        649 ms (max)
INFO  05:02:52 map Running 00d 00h 02m 55s ( 97.22%)   106,371,667 ops   612,159.40 ops/s      9,919 µs (avg)    641,204 µs (99.9th)    657,981 µs (max)
INFO  05:02:53 map Running 00d 00h 02m 56s ( 97.78%)   106,985,569 ops   613,887.80 ops/s         13 ms (avg)        696 ms (99.9th)        698 ms (max)
INFO  05:02:54 map Running 00d 00h 02m 57s ( 98.33%)   107,595,269 ops   609,650.31 ops/s         10 ms (avg)        570 ms (99.9th)        648 ms (max)
INFO  05:02:55 map Running 00d 00h 02m 58s ( 98.89%)   108,208,544 ops   613,225.98 ops/s      9,588 µs (avg)    789,577 µs (99.9th)    802,160 µs (max)
INFO  05:02:56 map Running 00d 00h 02m 59s ( 99.44%)   108,821,069 ops   612,473.23 ops/s         10 ms (avg)        687 ms (99.9th)        713 ms (max)
INFO  05:02:57 map Running 00d 00h 03m 00s (100.00%)   109,434,657 ops   613,495.46 ops/s         16 ms (avg)        758 ms (99.9th)        804 ms (max)
INFO  05:02:58 map Test finished run
```

If the first one is less than 10ms, it will revert to us which is good.

But it will also cause the p999 and max to revert to us which becomes noisy because often they are a lot higher.

So with this fix, the unit of each column is determined separately instead of all based on the first column.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2138