### PR TITLE
Added setup/teardown scripts

### DIFF
--- a/templates/cp-ec2/setup
+++ b/templates/cp-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/cp-ec2/teardown
+++ b/templates/cp-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/elasticache-cluster/setup
+++ b/templates/elasticache-cluster/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/elasticache-cluster/teardown
+++ b/templates/elasticache-cluster/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/hazelcast5-ec2/setup
+++ b/templates/hazelcast5-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/hazelcast5-ec2/teardown
+++ b/templates/hazelcast5-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/hazelcast5-hd-ec2/setup
+++ b/templates/hazelcast5-hd-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/hazelcast5-hd-ec2/teardown
+++ b/templates/hazelcast5-hd-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/sql-ec2-tstore/setup
+++ b/templates/sql-ec2-tstore/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/sql-ec2-tstore/teardown
+++ b/templates/sql-ec2-tstore/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/sql-ec2/setup
+++ b/templates/sql-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/sql-ec2/teardown
+++ b/templates/sql-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/sql-prunability-ec2/setup
+++ b/templates/sql-prunability-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/sql-prunability-ec2/teardown
+++ b/templates/sql-prunability-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/storage-ec2/setup
+++ b/templates/storage-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/storage-ec2/teardown
+++ b/templates/storage-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy


### PR DESCRIPTION
Each template has a setup/teardown script to make setting up the environment easier and less error prone.

Also the Java version is explicit instead of relying on whatever default is provided by some snapshot version of the Simulator.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2115