### PR TITLE
Resolved 'perftest report -t' problem.

### DIFF
--- a/src/simulator/perftest_report.py
+++ b/src/simulator/perftest_report.py
@@ -90,9 +90,6 @@ def report(config: ReportConfig, df: pd.DataFrame):
 
 
 def lookup_periods(config):
-    if config.preserve_time:
-        return
-
     for run_label, run_dir in config.runs.items():
         for worker_name in os.listdir(run_dir):
             worker_dir = f"{run_dir}/{worker_name}"
@@ -130,7 +127,6 @@ def lookup_periods(config):
                     # at the end of the throughput charts
                     period = Period(min(period.start_time, start_time), max(period.end_time, end_time))
                 config.periods[run_label] = period
-
 
 def collect_runs(benchmarks, config: ReportConfig):
     benchmark_dirs = []


### PR DESCRIPTION
The problem was that if the preserve time flag was set, the periods were not loaded and this leads to problems further down the line.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2157