### PR TITLE
Uses appropriate time unit in latency distribution per %

### DIFF
--- a/src/simulator/perftest_report_common.py
+++ b/src/simulator/perftest_report_common.py
@@ -40,7 +40,8 @@ class ReportConfig:
     preserve_time = False
     y_start_from_zero = False
     svg = False
-    #interactive = True
+
+    # interactive = True
 
     def __init__(self, report_dir):
         self.report_dir = report_dir
@@ -121,6 +122,7 @@ def df_trim_time(df: pd.DataFrame, start_time_seconds, end_time_seconds):
     df = df[df.index <= end]
     return df
 
+
 def extract_worker_id(path):
     if not os.path.isdir(path):
         return None
@@ -131,6 +133,19 @@ def extract_worker_id(path):
 
     index = basename.index("-")
     return basename[:index]
+
+
+def format_us_time_ticks(value_us, _):
+    if value_us >= 1e6:
+        unit = "s"
+        value = value_us / 1e6
+    elif value_us >= 1e3:
+        unit = "ms"
+        value = value_us / 1e3
+    else:
+        unit = "us"
+        value = value_us
+    return f"{value:.2f} {unit}"
 
 
 class Period:

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -8,6 +8,7 @@ from matplotlib.dates import DateFormatter
 import plotly.express as px
 import plotly.offline as pyo
 import plotly.tools as tls
+from matplotlib.ticker import FuncFormatter
 from pandas.errors import EmptyDataError
 
 from simulator.perftest_report_common import *
@@ -371,11 +372,12 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
         xlabels.loc[len(xlabels)] = ["99.99999%", 10_000_000.0]
         plt.xticks(xlabels['tick'], xlabels['label'])
 
-        plt.ylabel("latency (us)")
-        plt.xlabel("percentile")
+        plt.ylabel("Latency")
+        plt.xlabel("Percentile")
         plt.legend()
-        plt.title(f"latency distribution")
+        plt.title(f"Latency distribution")
         plt.grid()
+        plt.gca().yaxis.set_major_formatter(FuncFormatter(format_us_time_ticks))
 
         hgrm_file_path_no_ext = hgrm_file_name.rstrip(".hgrm")
         path = f"{config.report_dir}/latency/latency_distribution_{hgrm_file_path_no_ext}.png"


### PR DESCRIPTION
So instead of always using us, the time unit is picked based on the value.

Fixes https://github.com/hazelcast/hazelcast-simulator/issues/2151