### PR TITLE
Resolve 'var list' ansible deprecation warnings.

### DIFF
--- a/playbooks/install_async_profiler.yaml
+++ b/playbooks/install_async_profiler.yaml
@@ -1,9 +1,9 @@
 ---
 - hosts: all
   vars:
-  - version: 2.9
-  - url: "https://github.com/jvm-profiling-tools/async-profiler/releases/download/v{{ version }}/async-profiler-{{ version }}-linux-x64.tar.gz"
-  - tar_gz_filename: "{{ url | basename }}"
+    version: 2.9
+    url: "https://github.com/jvm-profiling-tools/async-profiler/releases/download/v{{ version }}/async-profiler-{{ version }}-linux-x64.tar.gz"
+    tar_gz_filename: "{{ url | basename }}"
 
   tasks:
   - name: Downloads the Async Profiler tar.gz

--- a/playbooks/install_iperf3.yaml
+++ b/playbooks/install_iperf3.yaml
@@ -7,7 +7,6 @@
         apt-get update || true
       become: yes
 
-    # needed for pcp dstat.
     - name: Install iperf3
       ansible.builtin.package:
         name: iperf3

--- a/playbooks/install_java.yaml
+++ b/playbooks/install_java.yaml
@@ -2,8 +2,8 @@
 - hosts: all
 
   vars:
-    - jdk_url:
-    - tar_gz_filename: "{{ jdk_url | basename }}"
+    jdk_url: null
+    tar_gz_filename: "{{ jdk_url | basename }}"
 
   tasks:
 

--- a/playbooks/install_simulator.yaml
+++ b/playbooks/install_simulator.yaml
@@ -2,8 +2,8 @@
 - hosts: all
 
   vars:
-    - simulator_home:
-    - simulator_dir: ~{{ console_user | default(ansible_user) }}/hazelcast-simulator
+    simulator_home: null
+    simulator_dir: ~{{ console_user | default(ansible_user) }}/hazelcast-simulator
   tasks:
 
   - name: yum update/apt-get update
@@ -29,7 +29,7 @@
     become: yes
     ignore_errors: yes
 
-  # check if pcp managed to instal dstat.
+  # check if pcp managed to install dstat.
   - name: Check if dstat already exists
     stat:
       path: /usr/bin/dstat


### PR DESCRIPTION
The variables should be declared as a dictionary and not as a list.

Fixes partially https://github.com/hazelcast/hazelcast-simulator/issues/2044

It doesn't resolve all deprecation warnings. There are some that are caused by some obscure python problem.