### PR TITLE
Incorrect value size generation

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/cp/IAtomicReferenceTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/cp/IAtomicReferenceTest.java
@@ -39,8 +39,7 @@ public class IAtomicReferenceTest extends HazelcastTest {
 
     String createString(int kb) {
         int bytes = kb * 1024;
-        int charsRequired = bytes / 2;
-        return GeneratorUtils.generateAsciiString(charsRequired);
+        return GeneratorUtils.generateAsciiString(bytes);
     }
 
     @TimeStep(prob = 1)


### PR DESCRIPTION
Typo: as it's ASCII it should always render 1-byte per character.