### PR TITLE
Remove redundant checkstyle `enableRSS` parameter

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -270,7 +270,6 @@
                             <configLocation>${main.basedir}/checkstyle/checkstyle.xml</configLocation>
                             <suppressionsLocation>${main.basedir}/checkstyle/suppressions.xml</suppressionsLocation>
                             <headerLocation>${main.basedir}/checkstyle/ClassHeader.txt</headerLocation>
-                            <enableRSS>false</enableRSS>
                             <linkXRef>true</linkXRef>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>


### PR DESCRIPTION
`enableRSS` was removed in [checkstyle 3.3.0](https://issues.apache.org/jira/browse/MCHECKSTYLE-435)