### PR TITLE
Remove Maven `prerequisites` - address warnings

### DIFF
--- a/java/archetype/pom.xml
+++ b/java/archetype/pom.xml
@@ -12,10 +12,6 @@
         <version>2.0-SNAPSHOT</version>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>

--- a/java/drivers/driver-couchbase/pom.xml
+++ b/java/drivers/driver-couchbase/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <couchbase-javaclient.version>2.4.3</couchbase-javaclient.version>

--- a/java/drivers/driver-hazelcast3/pom.xml
+++ b/java/drivers/driver-hazelcast3/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <hazelcast.version>3.12.6</hazelcast.version>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/java/drivers/driver-hazelcast4plus/pom.xml
+++ b/java/drivers/driver-hazelcast4plus/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <hazelcast.version>5.3.2</hazelcast.version>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/java/drivers/driver-ignite2/pom.xml
+++ b/java/drivers/driver-ignite2/pom.xml
@@ -13,10 +13,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <ignite.version>2.15.0</ignite.version>

--- a/java/drivers/driver-infinispan11/pom.xml
+++ b/java/drivers/driver-infinispan11/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <infinispan.version>11.0.3.Final</infinispan.version>

--- a/java/drivers/driver-jedis3/pom.xml
+++ b/java/drivers/driver-jedis3/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <jedis.version>3.2.0</jedis.version>

--- a/java/drivers/driver-lettuce6/pom.xml
+++ b/java/drivers/driver-lettuce6/pom.xml
@@ -14,10 +14,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
        <lettuce.version>6.2.6.RELEASE</lettuce.version>

--- a/java/drivers/driver-lettucecluster6/pom.xml
+++ b/java/drivers/driver-lettucecluster6/pom.xml
@@ -14,10 +14,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <lettuce.version>6.2.6.RELEASE</lettuce.version>

--- a/java/drivers/driver-memcached/pom.xml
+++ b/java/drivers/driver-memcached/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <memcached-javaclient.version>2.12.3</memcached-javaclient.version>

--- a/java/drivers/driver-mongodb/pom.xml
+++ b/java/drivers/driver-mongodb/pom.xml
@@ -12,10 +12,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <mongodb-javaclient.version>3.12.14</mongodb-javaclient.version>

--- a/java/drivers/pom.xml
+++ b/java/drivers/pom.xml
@@ -16,10 +16,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>

--- a/java/integration-tests/pom.xml
+++ b/java/integration-tests/pom.xml
@@ -13,10 +13,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,7 +34,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <java.version>1.8</java.version>
-        <maven.version>3.0.1</maven.version>
 
         <jsr107.api.version>1.0.0</jsr107.api.version>
 
@@ -216,26 +215,6 @@
                         <version>${maven.scm.provider.gitexe.version}</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce-maven</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>${maven.version}</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,10 +10,6 @@
     <url>http://github.com/hazelcast/hazelcast-simulator</url>
     <packaging>pom</packaging>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <repositories>
         <repository>
             <id>main-repo</id>
@@ -220,6 +216,26 @@
                         <version>${maven.scm.provider.gitexe.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.version}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/java/simulator/pom.xml
+++ b/java/simulator/pom.xml
@@ -11,10 +11,6 @@
         <version>2.0-SNAPSHOT</version>
     </parent>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>


### PR DESCRIPTION
The minimum version required (3.0.1) was [released in 2010](https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.0.1/), so it's unlikely anyone would be using an older version, and this [requirement was added in 2015](https://github.com/hazelcast/hazelcast-simulator/commit/7310feeffd1103450e8fdb87c9ddbb9bc77f7ccc).

Fixes: https://github.com/hazelcast/hazelcast-simulator/issues/2172