### PR TITLE
Add easy way to generate test comparison reports with readable labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,8 +849,33 @@ By default the `perftest run` creates a directory for each run inside
 you can simply run the `perftest report` with `-l` flag (or `--last`):
 
 ```shell
-perftest report -o my-comparison-report runs/MyTestA runs/MyTestB
+perftest report -l -o my-comparison-report runs/MyTestA runs/MyTestB
 ```
+
+In order to have readable labels in comparison reports you can run the benchmark with `--runLabel <your label>` option
+(note that it will overwrite any previous benchmark results with given label):
+
+```
+perftest run --runLabel ver1
+# do some changes
+perftest run --runLabel ver2
+
+perftest report -o my-comparison-report ver1 ver2
+```
+
+When comparing different benchmarks in the same report you can add `--longLabel` in generate report command to include
+test name in run labels in tables and graphs. This option cannot be used with `--last`.
+
+`--longLabel` also works nicely with `--runLabel` for comparing combinations. 
+For example, if the test suite contains `test1` and `test2` tests, and you issue the following commands:
+
+```
+perftest run --runLabel ver1
+perftest run --runLabel ver2
+perftest report --longLabel -o my-comparison-report runs/*/*
+```
+
+then the report will contain the following run labels: `test1@ver1`, `test1@ver2`, `test2@ver1`, `test2@ver2`.
 
 ## Extensive reports
 

--- a/src/simulator/perftest.py
+++ b/src/simulator/perftest.py
@@ -202,7 +202,7 @@ class PerfTest:
                 exit_with_error(f"Failed run coordinator, exitcode={self.exitcode}")
             return self.exitcode
 
-    def run(self, tests, tags, skip_report, test_commit, test_pattern):
+    def run(self, tests, tags, skip_report, test_commit, test_pattern, run_label):
         if test_commit:
             info("Automatic test commit enabled.")
             if not is_git_installed():
@@ -234,7 +234,7 @@ class PerfTest:
                 repetitions = 1
 
             for i in range(0, repetitions):
-                exitcode, run_path = self.run_test(test)
+                exitcode, run_path = self.run_test(test, run_label=run_label)
                 if exitcode == 0 and not skip_report:
                     self.collect(run_path,
                                  tags,
@@ -242,11 +242,15 @@ class PerfTest:
                                  cooldown_seconds=test.get('cooldown_seconds'))
         return
 
-    def run_test(self, test, run_path=None):
+    def run_test(self, test, *, run_path=None, run_label=None):
         if not run_path:
-            dt = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
             name = test['name']
-            run_path = f"runs/{name}/{dt}"
+            if not run_label:
+                dt = datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+                run_path = f"runs/{name}/{dt}"
+            else:
+                run_path = f"runs/{name}/{run_label}"
+                shutil.rmtree(run_path)
 
         exitcode = self.exec(
             test['test'],
@@ -492,6 +496,11 @@ class PerftestRunCli:
         #                     nargs=1,
         #                     help="The path where the result of the run need to be stored.")
 
+        parser.add_argument('-rl', '--runLabel',
+                            nargs=1,
+                            default=[None],
+                            help="The label of the run to use as run results directory name instead of timestamp.")
+
         parser.add_argument('-agr', '--skipReport',
                             action='store_true', dest='skip_report', default=False,
                             help="When set, this flag stops the automatic generation of reports after test completion.")
@@ -501,11 +510,12 @@ class PerftestRunCli:
         pattern = args.pattern[0]
         # kill_java = args.kill_java
         # run_path = args.runPath
+        run_label = args.runLabel[0]
 
         tests = load_yaml_file(args.file)
         perftest = PerfTest()
 
-        perftest.run(tests, tags, args.skip_report, args.commit, pattern)
+        perftest.run(tests, tags, args.skip_report, args.commit, pattern, run_label)
 
 
 class PerftestExecCli:

--- a/src/simulator/perftest.py
+++ b/src/simulator/perftest.py
@@ -250,7 +250,7 @@ class PerfTest:
                 run_path = f"runs/{name}/{dt}"
             else:
                 run_path = f"runs/{name}/{run_label}"
-                shutil.rmtree(run_path)
+                remove(run_path)
 
         exitcode = self.exec(
             test['test'],

--- a/src/simulator/perftest_report_common.py
+++ b/src/simulator/perftest_report_common.py
@@ -37,6 +37,7 @@ class ReportConfig:
     cooldown_seconds = 0
     worker_reporting = True
     compare_last = False
+    long_label = False
     preserve_time = False
     y_start_from_zero = False
     svg = False


### PR DESCRIPTION
This PR makes it easier to run and compare a set of tests across multiple named test configurations/versions and avoids necessity to manually rename directories for each run. Long labels make it easy to do matrix comparisons (test name + label).

Example how this can be used: https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4766597215/Jet+Light+Jobs+Performance#Appendix (commands) and the same document contains generated tables (slightly modified) and graphs.