### PR TITLE
Upgrade to Java 17

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/BuildInfoUtils.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/BuildInfoUtils.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
 public final class BuildInfoUtils {
 
     static final int DEFAULT_MAJOR_VERSION = 5;
-    static final int DEFAULT_MINOR_VERSION = 3;
+    static final int DEFAULT_MINOR_VERSION = 4;
 
     static final int DEFAULT_FALLBACK_MAJOR_VERSION = 5;
     static final int DEFAULT_FALLBACK_MINOR_VERSION = 3;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <java.version>1.8</java.version>
+        <jdk.version>17</jdk.version>
 
         <jsr107.api.version>1.0.0</jsr107.api.version>
 
@@ -62,7 +62,7 @@
 
         <disruptor.version>3.4.3</disruptor.version>
 
-        <maven.compiler.plugin.version>3.11.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.6.0</maven.javadoc.plugin.version>
         <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
@@ -156,8 +156,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${jdk.version}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/java/simulator/pom.xml
+++ b/java/simulator/pom.xml
@@ -121,6 +121,12 @@
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/ScriptExecutor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/ScriptExecutor.java
@@ -62,7 +62,7 @@ public class ScriptExecutor {
                 String result = task.call();
                 promise.answer(result);
             } catch (Exception e) {
-                LOGGER.warn("Failed to execute script: " + command, e);
+                LOGGER.warn("Failed to execute script: {}", command, e);
                 promise.answer(e);
             }
         }).start();


### PR DESCRIPTION
In 47d54e8a13b4242cee8bc60a84f84141f9be2034, the `hazelcast.version` was upgraded to `5.4`, which requires Java 17

Changes:
- code level `hazelcast-simulator` upgraded to Java 17
- added `nashorn` dependency to support Javascript evaluation as [no longer bundled with JDK](https://github.com/szegedi/nashorn/wiki/Using-Nashorn-with-different-Java-versions)
- upgrading the build jobs to JDK 17 (outside of this PR)

[Slack discussion](https://hazelcast.slack.com/archives/C034XSXE6/p1705424515952179).