### PR TITLE
add boto3 to list of required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Also contains pointers where to go next.
 3. Install Python libraries:
 
     ```shell
-    pip3 install -U ansible pyyaml matplotlib signal-processing-algorithms pandas plotly
+    pip3 install -U ansible pyyaml matplotlib signal-processing-algorithms pandas plotly boto3
     ```
 
    `signal-processing-algorithms` is only needed when you are going to do performance regression testing. The library is


### PR DESCRIPTION
Not required by perftest directly but it is required to interact with the aws api.  The "setup" script in the performance test fails without it.