### PR TITLE
Use released Hazelcast `5.4.0` instead of `SNAPSHOT`

### DIFF
--- a/java/drivers/driver-hazelcast4plus/pom.xml
+++ b/java/drivers/driver-hazelcast4plus/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <hazelcast.version>5.4.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.4.0</hazelcast.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <netty.version>4.1.94.Final</netty.version>
         <netty-tcnative.version>2.0.34.Final</netty-tcnative.version>

--- a/templates/hazelcast5-sql-ec2-tstore/tests.yaml
+++ b/templates/hazelcast5-sql-ec2-tstore/tests.yaml
@@ -8,7 +8,7 @@
   loadgenerator_hosts: &loadgenerator_hosts loadgenerators
   node_hosts: &node_hosts nodes
   driver: &driver hazelcast-enterprise5
-  version: &version maven=5.4.0-SNAPSHOT
+  version: &version maven=5.4.0
   client_args: &client_args >
     -Xms10G
     -Xmx10G

--- a/templates/hazelcast5-sql-prunability-ec2/tests.yaml
+++ b/templates/hazelcast5-sql-prunability-ec2/tests.yaml
@@ -9,7 +9,7 @@
   node_hosts: &node_hosts nodes
   driver: &driver hazelcast5
   version: &version maven=5.3.2
-#  version: &version maven=5.4.0-SNAPSHOT # Tested functionality works since version 5.4
+#  version: &version maven=5.4.0 # Tested functionality works since version 5.4
   client_args: &client_args >
     -Xms8G
     -Xmx8G


### PR DESCRIPTION
Now `5.4.0` is released, the released version should be used in preferences to a pre-release `SNAPSHOT`.