### PR TITLE
Support Hazelcast versions 5+ [HZG-197] 

### DIFF
--- a/java/drivers/driver-hazelcast4plus/conf/install.py
+++ b/java/drivers/driver-hazelcast4plus/conf/install.py
@@ -52,7 +52,7 @@ def _get_artifact_ids(enterprise:bool, version:str):
             return ['hazelcast-enterprise-all']
         else:
             return ['hazelcast-all']
-    elif version.startswith("5"):
+    elif int(version.split('.')[0]) >= 5:
         if enterprise:
             return ['hazelcast-enterprise', 'hazelcast-sql', 'hazelcast-spring']
         else:


### PR DESCRIPTION
Currently simulator will throw an error if one tries to use a version >5. This change permits the use of the new 6.0 HZ version. 