### PR TITLE
Support CP Priority assignment [HZG-205]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,7 +1742,7 @@ Here is an example of usage in the `tests.yaml` file:
       priority: 1
     - address: 10.0.55.179
       priority: 2
-      test:
+  test:
     - class: com.hazelcast.simulator.tests.cp.IAtomicLongTest
       threadCount: 135
       getProb: .8

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ should be conducted in.
 
 | Property                               | Example value    | Description                                                                                                                                 |
 |----------------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`                                 | `read_only`      | The name of the test suite (overriden by test-specific values)                                                                               |
+| `name`                                 | `read_only`      | The name of the test suite (overriden by test-specific values)                                                                              |
 | `repititions`                          | `1`              | The number of times this test suite should run (1 or more)                                                                                  |
 | `duration`                             | `300s`           | The amount of time this test suite should run for (45m, 1h, 2d, etc.)                                                                       |
 | `clients`                              | `1`              | The number of Hazelcast Clients to use in this test suite (hosted on `loadgenerator_hosts`                                                  |
@@ -425,7 +425,7 @@ should be conducted in.
 | `cooldown_seconds`                     | `0`              | The number of seconds before the end of the test to exclude in reporting (only used for report generation)                                  |
 | `license_key`                          | `your_ee_key`    | The Hazelcast Enterprise Edition license to use in your test, if using `hazelcast-enterprise5` drivers                                      |
 | `parallel`                             | `True`           | Defines whether tests should be run in parallel when multiple tests are defined within 1 suite (default false)                              |
-| `cp_priorities` | <pre>- address: internalIp<br> &nbsp;priority: 1</pre> | Defines the priority of the CP Subsystem members in the cluster. The priority is used to determine the order of the members in the CP Subsystem. |
+| `cp_priorities` | <pre>- address: internalIp<br> &nbsp;priority: 1</pre> | Defines the leadership priority of the CP Subsystem members in the cluster. Use the internal IP address of the agent you wish to configure. |
 
 ### Specify test class(es) and number of threads per worker
 

--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ should be conducted in.
 | `cooldown_seconds`                     | `0`              | The number of seconds before the end of the test to exclude in reporting (only used for report generation)                                  |
 | `license_key`                          | `your_ee_key`    | The Hazelcast Enterprise Edition license to use in your test, if using `hazelcast-enterprise5` drivers                                      |
 | `parallel`                             | `True`           | Defines whether tests should be run in parallel when multiple tests are defined within 1 suite (default false)                              |
+| `cp_priorities` | <pre>- address: internalIp<br> &nbsp;priority: 1</pre> | Defines the priority of the CP Subsystem members in the cluster. The priority is used to determine the order of the members in the CP Subsystem. |
 
 ### Specify test class(es) and number of threads per worker
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ should be conducted in.
 | `cooldown_seconds`                     | `0`              | The number of seconds before the end of the test to exclude in reporting (only used for report generation)                                  |
 | `license_key`                          | `your_ee_key`    | The Hazelcast Enterprise Edition license to use in your test, if using `hazelcast-enterprise5` drivers                                      |
 | `parallel`                             | `True`           | Defines whether tests should be run in parallel when multiple tests are defined within 1 suite (default false)                              |
-| `cp_priorities` | <pre>- address: internalIp<br> &nbsp;priority: 1</pre> | Defines the leadership priority of the CP Subsystem members in the cluster. Use the internal IP address of the agent you wish to configure. |
+| `cp_priorities` | <pre>- address: internalIp<br> &nbsp;priority: 1</pre> | Defines the leadership priority of the CP Subsystem members in the cluster. Use the internal IP address of the agent(s) you wish to configure. |
 
 ### Specify test class(es) and number of threads per worker
 
@@ -1726,6 +1726,30 @@ but on the server side `pps_allowance_exceeded` might show 0 events/s.
 For any pair of instances A and B, it is advised to run the PPS test for both A and B as the server.
 This ensure a clear picture of all the PPS limits across instances.
 
+### CP subsystem leader priority
+
+It is possible to assign leadership priority to a member or list of members in a CP group(s). This is useful when 
+you want to attribute certain behaviours to an agent in the cluster. For example, you may wish to inject a latency 
+on the leader of a CP group. Ensure the internal IP of the agent(s) are used. 
+
+Here is an example of usage in the `tests.yaml` file:
+
+```yaml
+- name: my-test
+  <<: *defaults
+  cp_priorities:
+    - address: 10.0.55.178
+      priority: 1
+    - address: 10.0.55.179
+      priority: 2
+      test:
+    - class: com.hazelcast.simulator.tests.cp.IAtomicLongTest
+      threadCount: 135
+      getProb: .8
+```
+
+Consult [Configuring Leadership Priority](https://docs.hazelcast.com/hazelcast/5.5/cp-subsystem/configuration#configuring-leadership-priority
+) for more information about the CP subsystem priority.
 
 # Get Help
 

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/Hazelcast4PlusDriver.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/Hazelcast4PlusDriver.java
@@ -27,6 +27,7 @@ import com.hazelcast.partition.Partition;
 import com.hazelcast.partition.PartitionService;
 import com.hazelcast.simulator.coordinator.registry.AgentData;
 import com.hazelcast.simulator.drivers.Driver;
+import com.hazelcast.simulator.utils.HazelcastUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -90,6 +91,7 @@ public class Hazelcast4PlusDriver extends Driver<HazelcastInstance> {
                 // this way of loading is preferred so that env-variables and sys properties are picked up
                 System.setProperty("hazelcast.config", configFile.getAbsolutePath());
                 Config config = Config.load();
+                HazelcastUtils.handlePerAgentConfig(properties, config);
                 hazelcastInstance = Hazelcast.newHazelcastInstance(config);
             } catch (NoSuchMethodError e) {
                 // Fall back in case Config.load doesn't exist (pre 4.2)

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/HazelcastUtils.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/HazelcastUtils.java
@@ -63,7 +63,7 @@ public final class HazelcastUtils {
     /**
      * Handles configuration settings for a member, based on properties bound to an agent's internal IP address.
      * <p>
-     * This method should is designed to be extendable for future configuration
+     * This method is designed to be extendable for future configuration
      * properties that may be applied on exclusive agents.
      * </p>
      *

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/HazelcastUtils.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/HazelcastUtils.java
@@ -61,14 +61,24 @@ public final class HazelcastUtils {
     }
 
     /**
-     * Handler to set the member configuration with specific properties which
-     * are bound to an agent by internal IP.
+     * Handles configuration settings for a member, based on properties bound to an agent's internal IP address.
      * <p>
-     *     Sets CP priority for member based on the agent's private address
-     *     if provided.
+     * This method should is designed to be extendable for future configuration
+     * properties that may be applied on exclusive agents.
      * </p>
-     * @param properties
-     * @param config
+     *
+     * <p>
+     * Currently, the method supports the following configuration:
+     * </p>
+     * <ul>
+     *   <li><b>CP Member Priority:</b> If the "cp_priority" property is provided,
+     *   the method will set the CP member priority for the agent based on the agent's private IP address.</li>
+     * </ul>
+     *
+     * <p>
+     * Future configurations may extend the use of additional properties in a similar manner.
+     * </p>
+     *
      */
     public static void handlePerAgentConfig(Map<String, String> properties, Config config) {
         String cpPriorities = properties.get("cp_priority");
@@ -85,7 +95,7 @@ public final class HazelcastUtils {
             int priority = jsonObject.getInt("priority");
             if (address.equals(agentPrivateAddress)) {
                 LOGGER.info("Setting CP member priority to " + priority + " for agent " + agentPrivateAddress);
-                config.getCPSubsystemConfig().setCPMemberCount(priority);
+                config.getCPSubsystemConfig().setCPMemberPriority(priority);
             }
         });
     }


### PR DESCRIPTION
Introduces ability to assign cp-priority to members.

Simply use the the internal ip of an agent and assign the priority in the test.yaml file.

Example usage : 

```yaml
cp_priorities:
  - address: 10.0.55.178
    priority: 1
  - address: 10.0.55.179
    priority: 2
