### PR TITLE
Remove ec2-user  Example from EC2 Inventory Template

### DIFF
--- a/templates/hazelcast5-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-ec2/inventory_plan.yaml
@@ -18,10 +18,6 @@ keypair:
 nodes:
     count: 1
     instance_type: c5.9xlarge
-    # default AWS AMI
-    # ami: ami-05cafdf7c9f772ad2
-    # user: ec2-user
-    # ubuntu
     ami: ami-04e601abe3e1a910f
     user: ubuntu
     tenancy: null
@@ -29,10 +25,6 @@ nodes:
 loadgenerators:
     count: 1
     instance_type: c5.9xlarge
-    # default AWS AMI
-    # ami: ami-05cafdf7c9f772ad2
-    # user: ec2-user
-    # ubuntu
     ami: ami-04e601abe3e1a910f
     user: ubuntu
     tenancy: null
@@ -40,10 +32,6 @@ loadgenerators:
 mc:
     instance_type: c5.4xlarge
     count: 0
-    # default AWS AMI
-    # ami: ami-05cafdf7c9f772ad2
-    # user: ec2-user
-    # ubuntu
     ami: ami-04e601abe3e1a910f
     user: ubuntu
     tenancy: null


### PR DESCRIPTION
This may have worked correctly with report generation at some point, however it no longer works with report generation (and maybe other things). Therefore, for now, we only support the default generated inventory parameters which is what most (if not all) people are using.