### PR TITLE
Modified CPMapTest to allow preloading

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/cp/CPMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/cp/CPMapTest.java
@@ -20,15 +20,20 @@ import com.hazelcast.cp.CPMap;
 import com.hazelcast.simulator.hz.HazelcastTest;
 import com.hazelcast.simulator.test.BaseThreadState;
 import com.hazelcast.simulator.test.annotations.AfterRun;
+import com.hazelcast.simulator.test.annotations.Prepare;
 import com.hazelcast.simulator.test.annotations.Setup;
 import com.hazelcast.simulator.test.annotations.TimeStep;
 import com.hazelcast.simulator.test.annotations.Verify;
 import com.hazelcast.simulator.tests.cp.helpers.CpMapOperationCounter;
-import com.hazelcast.simulator.utils.GeneratorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.simulator.utils.CommonUtils.sleepSeconds;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -48,16 +53,31 @@ public class CPMapTest extends HazelcastTest {
     public int valuesCount = 100;
     // size in bytes for each key's associated value
     public int valueSizeBytes = 100;
+    public int keySizeBytes = 100;
+    private byte[] val;
 
-    private List<CPMap<Integer, byte[]>> mapReferences;
+    private List<CPMap<String,  byte[]>> mapReferences;
 
     private byte[][] values;
+    private List<String> keyPool;
 
     private IList<CpMapOperationCounter> operationCounterList;
+    public boolean preload = false;
 
     @Setup
     public void setup() {
-        values = createValues();
+        val = new byte[valueSizeBytes];
+        keyPool = new ArrayList<>();
+
+        logger.info("Generating " + keys + " keys");
+        for (int i = 0; i < keys; i++) {
+            keyPool.add(generateString(i));
+        }
+        logger.info("Generated " + keys + " keys");
+        // print all keys
+        for (int i = 0; i < keys; i++) {
+            logger.info("Key: " + keyPool.get(i));
+        }
 
         // (1) create the cp group names that will host the maps
         String[] cpGroupNames = createCpGroupNames();
@@ -66,20 +86,90 @@ public class CPMapTest extends HazelcastTest {
         for (int i = 0; i < maps; i++) {
             String cpGroup = cpGroupNames[i % cpGroupNames.length];
             String mapName = "map" + i + "@" + cpGroup;
+            logger.info("Creating CPMap: " + mapName);
             mapReferences.add(targetInstance.getCPSubsystem().getMap(mapName));
         }
 
         operationCounterList = targetInstance.getList(name + "Report");
+        logger.info("Sleeping for 60s to allow CP Subsystem to stabilize");
+        sleepSeconds(60);
     }
 
-    private byte[][] createValues() {
-        byte[][] valuesArray = new byte[valuesCount][valueSizeBytes];
-        Random random = new Random(0);
-        for (int i = 0; i < valuesArray.length; i++) {
-            valuesArray[i] = GeneratorUtils.generateByteArray(random, valueSizeBytes);
+    @Prepare(global = true)
+    public void prepare() {
+        if (!preload) {
+            logger.info("Checking map already contains keys");
+            for (CPMap<String, byte[]> mapReference : mapReferences) {
+                // just check for first, middle and last key
+                for (int key : new int[]{0, keys / 2, keys - 1}) {
+                    byte[] get = mapReference.get(keyPool.get(key));
+                    if (get != null) {
+                        logger.info("Map " + mapReference.getName() + " already contains key: " + keyPool.get(key));
+                    } else {
+                        logger.info("Map " + mapReference.getName() + " doesn't contain key: " + keyPool.get(key));
+                        throw new IllegalStateException("Map " + mapReference.getName() + " doesn't contain key: " + keyPool.get(key));
+                    }
+                }
+            }
+            logger.info("Waiting for latencies to be applied ... ");
+            sleepSeconds(60);
+
+            return;
         }
-        return valuesArray;
+        // Determine the number of threads based on available processors
+        int threadCount = Runtime.getRuntime().availableProcessors();
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        // Atomic counter to track the total number of keys set
+        AtomicInteger totalKeysSet = new AtomicInteger(0);
+
+        // Calculate batch size based on the total number of keys and the number of threads
+        int batchSize = (int) Math.ceil((double) keyPool.size() / threadCount);
+
+        // Ensure each thread gets a unique portion of the keyPool
+        for (int t = 0; t < threadCount; t++) {
+            // Define the range of keys for this thread
+            int start = t * batchSize;
+            int end = Math.min(start + batchSize, keyPool.size());
+
+            // Create a sublist of keys for this thread, ensuring unique keys per thread
+            List<String> keyBatch = new ArrayList<>(keyPool.subList(start, end));
+
+            // Submit the batch processing task to the executor
+            executor.submit(() -> {
+                int i = 0;
+                for (String key : keyBatch) {
+                    // Add each key-value pair to the map
+                    mapReferences.get(0).set(key, val);
+
+                    // Increment the atomic counter
+                    totalKeysSet.incrementAndGet();
+
+                    // Log progress every 10,000 keys
+                    if (i++ % 10000 == 0) {
+                        logger.info("Preloaded " + i + " keys in this batch.");
+                    }
+                }
+            });
+        }
+
+        executor.shutdown();
+
+        try {
+            // Wait until all tasks are finished, effectively waiting indefinitely
+            while (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+                // Optional: log or monitor progress every minute while waiting
+                logger.info("Waiting for all threads to complete...");
+            }
+        } catch (InterruptedException e) {
+            // Handle interruptions properly; this will rarely happen
+            Thread.currentThread().interrupt();
+        }
+
+        // Log the final count of keys set
+        logger.info("Total number of keys set: " + totalKeysSet.get());
     }
+
 
     private String[] createCpGroupNames() {
         if (cpGroups == 0) {
@@ -93,27 +183,27 @@ public class CPMapTest extends HazelcastTest {
         return cpGroupNames;
     }
 
-    @TimeStep(prob = 1)
+    @TimeStep(prob = 0)
     public void set(ThreadState state) {
-        state.getNextMap().set(state.randomKey(), state.randomValue());
+        state.getNextMap().set(keyPool.get(state.randomKey()), state.randomValue());
         state.operationCounter.setCount++;
     }
 
     @TimeStep(prob = 0)
     public void put(ThreadState state) {
-        state.getNextMap().put(state.randomKey(), state.randomValue());
+        state.getNextMap().put(keyPool.get(state.randomKey()), state.randomValue());
         state.operationCounter.putCount++;
     }
 
     @TimeStep(prob = 0)
     public void putIfAbsent(ThreadState state) {
-        state.getNextMap().putIfAbsent(state.randomKey(), state.randomValue());
+        state.getNextMap().putIfAbsent(keyPool.get(state.randomKey()), val);
         state.operationCounter.putIfAbsentCount++;
     }
 
     @TimeStep(prob = 0)
     public void get(ThreadState state) {
-        state.getNextMap().get(state.randomKey());
+        state.getNextMap().get(keyPool.get(state.randomKey()));
         state.operationCounter.getCount++;
     }
 
@@ -122,20 +212,20 @@ public class CPMapTest extends HazelcastTest {
 
     @TimeStep(prob = 0)
     public void remove(ThreadState state) {
-        state.getNextMap().remove(state.randomKey());
+        state.getNextMap().remove(keyPool.get(state.randomKey()));
         state.operationCounter.removeCount++;
     }
 
     @TimeStep(prob = 0)
     public void delete(ThreadState state) {
-        state.getNextMap().delete(state.randomKey());
+        state.getNextMap().delete(keyPool.get(state.randomKey()));
         state.operationCounter.deleteCount++;
     }
 
     @TimeStep(prob = 0)
     public void cas(ThreadState state) {
-        CPMap<Integer, byte[]> randomMap = state.getNextMap();
-        Integer key = state.randomKey();
+        CPMap<String,  byte[]> randomMap = state.getNextMap();
+        String key = keyPool.get(state.randomKey());
         byte[] expectedValue = randomMap.get(key);
         if (expectedValue != null) {
             randomMap.compareAndSet(key, expectedValue, state.randomValue());
@@ -145,8 +235,8 @@ public class CPMapTest extends HazelcastTest {
 
     @TimeStep(prob = 0)
     public void setThenDelete(ThreadState state) {
-        CPMap<Integer, byte[]> map = state.getNextMap();
-        int key = state.randomKey();
+        CPMap<String, byte[]> map = state.getNextMap();
+        String key = keyPool.get(state.randomKey());
         map.set(key, state.randomValue());
         map.delete(key);
     }
@@ -166,10 +256,10 @@ public class CPMapTest extends HazelcastTest {
         logger.info(name + ": " + total + " from " + operationCounterList.size() + " worker threads");
 
         // basic verification
-        for (CPMap<Integer, byte[]> mapReference : mapReferences) {
+        for (CPMap<String, byte[]> mapReference : mapReferences) {
             int entriesCount = 0;
             for (int key = 0; key < keys; key++) {
-                byte[] get = mapReference.get(key);
+                byte[] get = mapReference.get(keyPool.get(key));
                 if (get != null) {
                     entriesCount++;
                 }
@@ -194,11 +284,39 @@ public class CPMapTest extends HazelcastTest {
             return values[randomInt(valuesCount)]; // [0, values)
         }
 
-        public CPMap<Integer, byte[]> getNextMap() {
+        public CPMap<String, byte[]> getNextMap() {
             if (currentMapIndex == maps) {
                 currentMapIndex = 0;
             }
             return mapReferences.get(currentMapIndex++);
         }
+    }
+
+    private String generateString(int number) {
+        String prefix = "PREFIX_";
+
+        String numberStr = Integer.toString(number);
+
+        // Calculate the number of characters needed to fill up the string
+        int totalCharacters = keySizeBytes / 2;
+        int remainingLength = totalCharacters - (prefix.length() + numberStr.length());
+
+        // Deterministic fixed string for each input number
+        StringBuilder fixedDigits = new StringBuilder(remainingLength);
+
+        // Use a fixed pattern
+        String pattern = Integer.toString(number).repeat((remainingLength / numberStr.length()) + 1);
+
+        // Append up to remainingLength characters from the pattern
+        fixedDigits.append(pattern.substring(0, remainingLength));
+
+        String result = prefix + numberStr + fixedDigits;
+
+        // Ensure the result is exactly the desired number of characters
+        if (result.length() != totalCharacters) {
+            throw new IllegalStateException("Generated string is not exactly the correct length.");
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
Adds ability for fast preload of the CPMap with data and keep that persisted for subsequent test runs. 

For usage, add a testphase with `preload : true`

Example: 

```
- name: load-data
  <<: *defaults
  duration: 2s
  repetitions: 1
  test:
    class: com.hazelcast.simulator.tests.cp.CPMapTest
    name: putIfAbsent
    threadCount: 1
    putIfAbsentProb: 1
    preload: true
    keys: 7000000
    keySizeBytes: 100
    valueSizeBytes: 100
    ratePerSecond: 0
```
    
The next test phases should have `preload: false`. Ensure that the same variables are used, i.e.   
```
    keys: 7000000
    keySizeBytes: 100
    valueSizeBytes: 100
```
a validation step will occur to ensure that the expected keys exist. 

If mounting a filesystem, ensure that these properties are included in the top level of the `test.yaml`

```
    mount_volume: /dev/nvme1n1
    mount_path: /cp-data
```
/cp-data must map to the hazelcast.xml cp-persistence config and the map name must be consistent. The following config can serve as a reliable example 

```
    <cp-subsystem>
        <cp-member-count>3</cp-member-count>
        <persistence-enabled>true</persistence-enabled>
        <base-dir>/cp-data</base-dir>
        <maps>
            <map>
                <name>map0</name>
                <max-size-mb>2000</max-size-mb>
            </map >
        </maps >
        <raft-algorithm>
            <commit-index-advance-count-to-snapshot>1000000</commit-index-advance-count-to-snapshot>
        </raft-algorithm>
    </cp-subsystem>
```

