### PR TITLE
Add simulator template with TLS enabled [DEX-338]

### DIFF
--- a/java/drivers/driver-hazelcast4plus/pom.xml
+++ b/java/drivers/driver-hazelcast4plus/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <hazelcast.version>6.0.0-SNAPSHOT</hazelcast.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <netty.version>4.1.94.Final</netty.version>
-        <netty-tcnative.version>2.0.34.Final</netty-tcnative.version>
+        <netty.version>4.1.119.Final</netty.version>
+        <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>
         <netty-tcnative.artifactId>netty-tcnative-boringssl-static</netty-tcnative.artifactId>
         <netty-tcnative.classifier />
     </properties>

--- a/playbooks/install_tls_keystores.yaml
+++ b/playbooks/install_tls_keystores.yaml
@@ -33,26 +33,68 @@
 
     - name: Finalise keystore
       copy:
-        force: true
         src: /tmp/simulator-keystore-rsa{{ rsa_key_size }}.jks
         dest: /tmp/simulator-keystore.jks
+        force: true
 
     - name: Finalise truststore
       copy:
-        force: true
         src: /tmp/simulator-truststore-rsa{{ rsa_key_size }}.jks
         dest: /tmp/simulator-truststore.jks
+        force: true
+
+    - name: Create openssl private key
+      community.crypto.openssl_privatekey:
+        path: /tmp/simulator-cert.key
+        size: "{{ rsa_key_size }}"
+
+    - name: Create certificate signing request (CSR) for self-signed certificate
+      community.crypto.openssl_csr_pipe:
+        privatekey_path: /tmp/simulator-cert.key
+        common_name: simulator
+        organization_name: Hazelcast
+      register: csr
+
+    - name: Create self-signed certificate from CSR
+      community.crypto.x509_certificate:
+        path: /tmp/simulator-cert.pem
+        csr_content: "{{ csr.csr }}"
+        privatekey_path: /tmp/simulator-cert.key
+        provider: selfsigned
+
+    - name: Convert private key to PKCS8 format
+      community.crypto.openssl_privatekey_convert:
+        src_path: /tmp/simulator-cert.key
+        dest_path: /tmp/simulator-key.pem
+        format: pkcs8
 
 - name: Copy Keystore and Truststore to remote servers
   hosts: all
   tasks:
-    - name: Copy keystore to remote server
+    - name: Copy jks keystore to remote server
       copy:
         src: /tmp/simulator-keystore.jks
         dest: /tmp/keystore.jks
+        force: true
         mode: '0444'
-    - name: Copy truststore to remote server
+
+    - name: Copy jks truststore to remote server
       copy:
         src: /tmp/simulator-truststore.jks
         dest: /tmp/truststore.jks
+        force: true
+        mode: '0444'
+
+    - name: Copy openssl key to remote server
+      copy:
+        src: /tmp/simulator-key.pem
+        dest: /tmp/key.pem
+        force: true
+        mode: '0444'
+
+    - name: Copy openssl cert to remote server
+      copy:
+        src: /tmp/simulator-cert.pem
+        dest: /tmp/cert.pem
+        force: true
         mode: '0444'

--- a/playbooks/install_tls_keystores.yaml
+++ b/playbooks/install_tls_keystores.yaml
@@ -1,0 +1,58 @@
+---
+- name: Generate Keystore and Truststore
+  hosts: localhost
+
+  vars:
+    rsa_key_size: 2048
+
+  tasks:
+    - name: Generate keystore
+      command:
+        chdir: /tmp
+        creates: /tmp/simulator-keystore-rsa{{ rsa_key_size }}.jks
+        cmd: > 
+          keytool -genkeypair -alias member -keyalg RSA -keysize {{ rsa_key_size }} -validity 365 
+            -keystore simulator-keystore-rsa{{ rsa_key_size }}.jks -storepass changeit
+            -dname "CN=simulator, OU=IT, O=Hazelcast, L=City, C=GB"
+
+    - name: Export cert
+      command:
+        chdir: /tmp
+        creates: /tmp/simulator-member-rsa{{ rsa_key_size }}.crt
+        cmd: >
+          keytool -export -alias member -keystore simulator-keystore-rsa{{ rsa_key_size }}.jks 
+            -file simulator-member-rsa{{ rsa_key_size }}.crt -storepass changeit -rfc
+
+    - name: Generate truststore
+      command:
+        chdir: /tmp
+        creates: /tmp/simulator-truststore-rsa{{ rsa_key_size }}.jks
+        cmd: >
+          keytool -import -noprompt -alias member -file simulator-member-rsa{{ rsa_key_size }}.crt 
+            -keystore simulator-truststore-rsa{{ rsa_key_size }}.jks -storepass changeit
+
+    - name: Finalise keystore
+      copy:
+        force: true
+        src: /tmp/simulator-keystore-rsa{{ rsa_key_size }}.jks
+        dest: /tmp/simulator-keystore.jks
+
+    - name: Finalise truststore
+      copy:
+        force: true
+        src: /tmp/simulator-truststore-rsa{{ rsa_key_size }}.jks
+        dest: /tmp/simulator-truststore.jks
+
+- name: Copy Keystore and Truststore to remote servers
+  hosts: all
+  tasks:
+    - name: Copy keystore to remote server
+      copy:
+        src: /tmp/simulator-keystore.jks
+        dest: /tmp/keystore.jks
+        mode: '0444'
+    - name: Copy truststore to remote server
+      copy:
+        src: /tmp/simulator-truststore.jks
+        dest: /tmp/truststore.jks
+        mode: '0444'

--- a/src/inventory_cli.py
+++ b/src/inventory_cli.py
@@ -253,15 +253,11 @@ class InventoryInstallCli:
     def tls_keystores(self, argv):
         parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                          description='Install TLS keystore and truststore')
-        parser.add_argument("--hosts", help="The target hosts.", default="all:!mc:!load_balancers")
         parser.add_argument("--rsa-key-size", help="The key size to use when generating the key pair", default = "2048")
         args = parser.parse_args(argv)
-
-        hosts = args.hosts
         rsa_key_size = args.rsa_key_size
 
         log_header("Generating and installing TLS keystore and truststores")
-        info(f"hosts={hosts}")
         cmd = f"ansible-playbook --inventory inventory.yaml {simulator_home}/playbooks/install_tls_keystores.yaml -e rsa_key_size='{rsa_key_size}'"
         self._run_installation(cmd)
 

--- a/src/inventory_cli.py
+++ b/src/inventory_cli.py
@@ -262,7 +262,7 @@ class InventoryInstallCli:
 
         log_header("Generating and installing TLS keystore and truststores")
         info(f"hosts={hosts}")
-        cmd = f"ansible-playbook --limit {hosts} --inventory inventory.yaml {simulator_home}/playbooks/install_tls_keystores.yaml -e rsa_key_size='{rsa_key_size}'"
+        cmd = f"ansible-playbook --inventory inventory.yaml {simulator_home}/playbooks/install_tls_keystores.yaml -e rsa_key_size='{rsa_key_size}'"
         self._run_installation(cmd)
 
     def _run_installation(self, cmd):

--- a/src/inventory_cli.py
+++ b/src/inventory_cli.py
@@ -136,6 +136,7 @@ class InventoryInstallCli:
             perf            Installs Linux Perf
             async_profiler  Installs Async Profiler
             iperf3          Installs iperf3 Profiler
+            tls_keystores   Installs TLS keystore and truststores for secure connections
         '''
 
         parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -248,6 +249,28 @@ class InventoryInstallCli:
         if exitcode != 0:
             exit_with_error(f'Failed to install iperf3, exitcode={exitcode} command=[{cmd}])')
         log_header("Installing iperf3: Done")
+
+    def tls_keystores(self, argv):
+        parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                         description='Install TLS keystore and truststore')
+        parser.add_argument("--hosts", help="The target hosts.", default="all:!mc:!load_balancers")
+        parser.add_argument("--rsa-key-size", help="The key size to use when generating the key pair", default = "2048")
+        args = parser.parse_args(argv)
+
+        hosts = args.hosts
+        rsa_key_size = args.rsa_key_size
+
+        log_header("Generating and installing TLS keystore and truststores")
+        info(f"hosts={hosts}")
+        cmd = f"ansible-playbook --limit {hosts} --inventory inventory.yaml {simulator_home}/playbooks/install_tls_keystores.yaml -e rsa_key_size='{rsa_key_size}'"
+        self._run_installation(cmd)
+
+    def _run_installation(self, cmd):
+        info(cmd)
+        exitcode = shell(cmd)
+        if exitcode != 0:
+            exit_with_error(f'Installation failed, exitcode={exitcode} command=[{cmd}])')
+        log_header("Installation complete")
 
 class InventoryImportCli:
 

--- a/templates/hazelcast5-tls-ec2/.gitignore
+++ b/templates/hazelcast5-tls-ec2/.gitignore
@@ -1,0 +1,14 @@
+*/terraform.tfstate
+*/terraform.tfstate.backup
+*/.terraform
+*/.terraform.lock.hcl
+*/.terraform.tfstate.lock.info
+key.pub
+key
+*.kate-swp
+*.jfr
+venv/
+/.idea/
+/runs/
+/logs/
+inventory.yaml

--- a/templates/hazelcast5-tls-ec2/README.md
+++ b/templates/hazelcast5-tls-ec2/README.md
@@ -1,0 +1,35 @@
+To modify the environment, edit the `inventory_plan.yaml`.
+
+To create the environment.
+```shell
+inventory apply
+```
+
+To get an overview of the available instances:
+```shell
+cat inventory.yaml
+```
+
+Install the simulator and Java on the environment
+```shell
+inventory install java
+inventory install simulator
+```
+
+If you want to get the best performance for your environment
+```shell
+inventory tune
+```
+
+
+Modify the tests by editing the `tests.yaml` file.
+
+To run the tests
+```shell
+perftest run
+```
+
+To destroy the environment.
+```shell
+inventory destroy
+```

--- a/templates/hazelcast5-tls-ec2/README.md
+++ b/templates/hazelcast5-tls-ec2/README.md
@@ -21,7 +21,6 @@ If you want to get the best performance for your environment
 inventory tune
 ```
 
-
 Modify the tests by editing the `tests.yaml` file.
 
 To run the tests

--- a/templates/hazelcast5-tls-ec2/ansible.cfg
+++ b/templates/hazelcast5-tls-ec2/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+host_key_checking = False
+inventory = inventory.yaml
+
+
+# For nice formatted output
+stdout_callback = yaml
+bin_ansible_callbacks = True
+
+interpreter_python=auto_silent

--- a/templates/hazelcast5-tls-ec2/ansible.cfg
+++ b/templates/hazelcast5-tls-ec2/ansible.cfg
@@ -2,7 +2,6 @@
 host_key_checking = False
 inventory = inventory.yaml
 
-
 # For nice formatted output
 stdout_callback = yaml
 bin_ansible_callbacks = True

--- a/templates/hazelcast5-tls-ec2/aws/main.tf
+++ b/templates/hazelcast5-tls-ec2/aws/main.tf
@@ -1,0 +1,358 @@
+
+locals {
+    settings = yamldecode(file("../inventory_plan.yaml"))
+    private_key = file("../${local.settings.keypair.private_key}")
+    public_key = file("../${local.settings.keypair.public_key}")
+}
+
+provider "aws" {
+    profile = "default"
+    region = local.settings.region
+}
+
+resource "aws_default_vpc" "vpc" {
+  tags = {
+    Name = "Default VPC"
+  }
+}
+
+#resource "aws_vpc" "prod-vpc" {
+#    cidr_block = "10.0.0.0/16"
+#    enable_dns_support = "true" #gives you an internal domain name
+#    enable_dns_hostnames = "true" #gives you an internal host name
+#    enable_classiclink = "false"
+#    instance_tenancy = "default"
+#    
+#    tags = {
+#        Name = "prod-vpc"
+#    }
+#}
+
+#resource "aws_internet_gateway" "my_vpc_igw" {
+#  vpc_id = local.settings.vpc_id
+#
+#  tags = {
+#    Name = "My VPC - Internet Gateway"
+#  }
+#}
+
+resource "aws_key_pair" "keypair" {
+    key_name   = "simulator-keypair-${local.settings.basename}"
+    public_key = local.public_key
+}
+
+resource "aws_subnet" "subnet" {
+    vpc_id                  = local.settings.vpc_id
+    cidr_block              = local.settings.cidr_block
+    availability_zone       = local.settings.availability_zone
+    map_public_ip_on_launch = true
+    tags = {
+        Name = "Simulator Public Subnet ${local.settings.basename}"
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+}
+
+resource "aws_route_table" "route_table" {
+    vpc_id = local.settings.vpc_id
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = local.settings.internet_gateway_id
+    }
+
+    tags = {
+        Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+}
+
+resource "aws_route_table_association" "route_table_association" {
+    subnet_id       = aws_subnet.subnet.id
+    route_table_id  = aws_route_table.route_table.id
+}
+
+# ========== nodes ==========================
+
+# Currently there is a single placement group defined for all nodes/load generators.
+# If you want to use placement_group, uncomment the commented out 'placementgroup'
+# configuration in the nodes and loadgenerators sections.
+resource "aws_placement_group" "cluster_placement_group" {
+    name     = "simulator-placement-group-${local.settings.basename}"
+    strategy = "cluster"
+}
+
+resource "aws_security_group" "node-sg" {
+    name        = "simulator-security-group-node-${local.settings.basename}"
+    description = "Security group for the node"
+    vpc_id      = local.settings.vpc_id
+    
+    tags = {
+        Name = "Simulator Node Security Group ${local.settings.basename}",
+        Owner = local.settings.owner
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+    
+    ingress {
+        description = "SSH"
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+
+    ingress {
+        description = "iperf3_udp"
+        from_port   = 3000
+        to_port     = 3000
+        protocol    = "udp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "iperf3_tcp"
+        from_port   = 3000
+        to_port     = 3000
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "Hazelcast"
+        from_port   = 5701
+        to_port     = 5801
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+  
+    ingress {
+        description = "Simulator"
+        from_port   = 9000
+        to_port     = 9001
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "Hazelcast-tpc"
+        from_port   = 11000
+        to_port     = 12000
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_instance" "nodes" {
+    key_name                = aws_key_pair.keypair.key_name
+    ami                     = local.settings.nodes.ami
+    instance_type           = local.settings.nodes.instance_type
+    count                   = local.settings.nodes.count
+    availability_zone       = local.settings.availability_zone
+    placement_group         = aws_placement_group.cluster_placement_group.name
+    vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
+    subnet_id               = aws_subnet.subnet.id
+    tenancy                 = local.settings.nodes.tenancy
+    
+    tags = {
+        Name  = "Simulator Node ${local.settings.basename}"
+        Owner = local.settings.owner
+        "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
+        "passthrough:ansible_user" = local.settings.nodes.user
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+}
+
+output "nodes" {
+    value = [aws_instance.nodes.*]
+}
+
+# ========== load generators ==========================
+
+resource "aws_security_group" "loadgenerator-sg" {
+    name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
+    description = "Security group for the loadgenerator"
+    vpc_id      = local.settings.vpc_id
+    
+    tags = {
+        Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
+        Owner = local.settings.owner
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+    
+    ingress {
+        description = "SSH"
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+
+    ingress {
+        description = "iperf3_udp"
+        from_port   = 3000
+        to_port     = 3000
+        protocol    = "udp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "iperf3_tcp"
+        from_port   = 3000
+        to_port     = 3000
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "Hazelcast"
+        from_port   = 5701
+        to_port     = 5801
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+  
+    ingress {
+        description = "Simulator"
+        from_port   = 9000
+        to_port     = 9001
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_instance" "loadgenerators" {
+    key_name                = aws_key_pair.keypair.key_name
+    ami                     = local.settings.loadgenerators.ami
+    instance_type           = local.settings.loadgenerators.instance_type
+    count                   = local.settings.loadgenerators.count
+    subnet_id               = aws_subnet.subnet.id
+    availability_zone       = local.settings.availability_zone
+    placement_group         = aws_placement_group.cluster_placement_group.name
+    vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
+    tenancy                 = local.settings.loadgenerators.tenancy
+    tags = {
+        Name  = "Simulator Load Generator ${local.settings.basename}"
+        Owner = local.settings.owner
+        "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
+        "passthrough:ansible_user" = local.settings.loadgenerators.user
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+} 
+
+output "loadgenerators" {
+    value = [aws_instance.loadgenerators.*]
+}
+
+# ========== management center ==========================
+
+resource "aws_security_group" "mc-sg" {
+    name        = "simulator-security-group-mc-${local.settings.basename}"
+    description = "Security group for the Management Center"
+    vpc_id      = local.settings.vpc_id
+
+    tags = {
+        Name = "Simulator MC Security Group ${local.settings.basename}",
+        Owner = local.settings.owner
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+
+    ingress {
+        description = "SSH"
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "Hazelcast"
+        from_port   = 8080
+        to_port     = 8080
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "Simulator"
+        from_port   = 8443
+        to_port     = 8443
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_instance" "mc" {
+    key_name                = aws_key_pair.keypair.key_name
+    ami                     = local.settings.mc.ami
+    instance_type           = local.settings.mc.instance_type
+    count                   = local.settings.mc.count
+    subnet_id               = aws_subnet.subnet.id
+    availability_zone       = local.settings.availability_zone
+    vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
+
+    tags = {
+        Name  = "Simulator MC ${local.settings.basename}"
+        Owner = local.settings.owner
+        "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
+        "passthrough:ansible_user" = local.settings.mc.user
+        team  = local.settings.team
+        type  = local.settings.type
+    }
+
+    connection {
+        type        = "ssh"
+        user        = local.settings.mc.user
+        private_key = file("../${local.settings.keypair.private_key}")
+        host        = self.public_ip
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "wget -q https://repository.hazelcast.com/download/management-center/hazelcast-management-center-5.0.tar.gz",
+            "tar -xzvf hazelcast-management-center-5.0.tar.gz",
+            "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+            "sudo apt-get -y update",
+            "sudo apt-get -y install openjdk-11-jdk",
+            "nohup hazelcast-management-center-5.0/bin/start.sh  > mc.out 2>&1 &",
+            "sleep 2"
+        ]
+    }
+}
+
+output "mc" {
+    value = [aws_instance.mc.*]
+}
+
+
+
+
+
+

--- a/templates/hazelcast5-tls-ec2/aws/main.tf
+++ b/templates/hazelcast5-tls-ec2/aws/main.tf
@@ -1,7 +1,6 @@
 
 locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
-    private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
 }
 
@@ -9,32 +8,6 @@ provider "aws" {
     profile = "default"
     region = local.settings.region
 }
-
-resource "aws_default_vpc" "vpc" {
-  tags = {
-    Name = "Default VPC"
-  }
-}
-
-#resource "aws_vpc" "prod-vpc" {
-#    cidr_block = "10.0.0.0/16"
-#    enable_dns_support = "true" #gives you an internal domain name
-#    enable_dns_hostnames = "true" #gives you an internal host name
-#    enable_classiclink = "false"
-#    instance_tenancy = "default"
-#    
-#    tags = {
-#        Name = "prod-vpc"
-#    }
-#}
-
-#resource "aws_internet_gateway" "my_vpc_igw" {
-#  vpc_id = local.settings.vpc_id
-#
-#  tags = {
-#    Name = "My VPC - Internet Gateway"
-#  }
-#}
 
 resource "aws_key_pair" "keypair" {
     key_name   = "simulator-keypair-${local.settings.basename}"

--- a/templates/hazelcast5-tls-ec2/aws/main.tf
+++ b/templates/hazelcast5-tls-ec2/aws/main.tf
@@ -350,9 +350,3 @@ resource "aws_instance" "mc" {
 output "mc" {
     value = [aws_instance.mc.*]
 }
-
-
-
-
-
-

--- a/templates/hazelcast5-tls-ec2/client-hazelcast.xml
+++ b/templates/hazelcast5-tls-ec2/client-hazelcast.xml
@@ -12,21 +12,21 @@
             <!--MEMBERS-->
         </cluster-members>
 
-        <ssl enabled="true">
-            <properties>
-                <property name="protocol">TLSv1.2</property>
-                <property name="trustStore">/tmp/truststore.jks</property>
-                <property name="trustStorePassword">changeit</property>
-            </properties>
-        </ssl>
-
         <!--        <ssl enabled="true">-->
-        <!--            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>-->
         <!--            <properties>-->
         <!--                <property name="protocol">TLSv1.2</property>-->
-        <!--                <property name="trustCertCollectionFile">/tmp/cert.pem</property>-->
+        <!--                <property name="trustStore">/tmp/truststore.jks</property>-->
+        <!--                <property name="trustStorePassword">changeit</property>-->
         <!--            </properties>-->
         <!--        </ssl>-->
+
+        <ssl enabled="true">
+            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>
+            <properties>
+                <property name="protocol">TLSv1.2</property>
+                <property name="trustCertCollectionFile">/tmp/cert.pem</property>
+            </properties>
+        </ssl>
     </network>
 
     <properties>

--- a/templates/hazelcast5-tls-ec2/client-hazelcast.xml
+++ b/templates/hazelcast5-tls-ec2/client-hazelcast.xml
@@ -15,13 +15,18 @@
         <ssl enabled="true">
             <properties>
                 <property name="protocol">TLSv1.2</property>
-                <!--                <property name="mutualAuthentication">REQUIRED</property>-->
-                <!--                <property name="keyStore">/tmp/keystore.jks</property>-->
-                <!--                <property name="keyStorePassword">changeit</property>-->
                 <property name="trustStore">/tmp/truststore.jks</property>
                 <property name="trustStorePassword">changeit</property>
             </properties>
         </ssl>
+
+        <!--        <ssl enabled="true">-->
+        <!--            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>-->
+        <!--            <properties>-->
+        <!--                <property name="protocol">TLSv1.2</property>-->
+        <!--                <property name="trustCertCollectionFile">/tmp/cert.pem</property>-->
+        <!--            </properties>-->
+        <!--        </ssl>-->
     </network>
 
     <properties>

--- a/templates/hazelcast5-tls-ec2/client-hazelcast.xml
+++ b/templates/hazelcast5-tls-ec2/client-hazelcast.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client
+        xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+            http://www.hazelcast.com/schema/config/hazelcast-client-config-5.0.xsd"
+        xmlns="http://www.hazelcast.com/schema/client-config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <cluster-name>workers</cluster-name>
+
+    <network>
+        <cluster-members>
+            <!--MEMBERS-->
+        </cluster-members>
+
+        <ssl enabled="true">
+            <properties>
+                <property name="protocol">TLSv1.2</property>
+                <!--                <property name="mutualAuthentication">REQUIRED</property>-->
+                <!--                <property name="keyStore">/tmp/keystore.jks</property>-->
+                <!--                <property name="keyStorePassword">changeit</property>-->
+                <property name="trustStore">/tmp/truststore.jks</property>
+                <property name="trustStorePassword">changeit</property>
+            </properties>
+        </ssl>
+    </network>
+
+    <properties>
+        <property name="hazelcast.logging.type">log4j2</property>
+    </properties>
+
+</hazelcast-client>

--- a/templates/hazelcast5-tls-ec2/hazelcast.xml
+++ b/templates/hazelcast5-tls-ec2/hazelcast.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
+
+    <cluster-name>workers</cluster-name>
+
+    <!--LITE_MEMBER_CONFIG-->
+
+    <network>
+        <port port-count="200">5701</port>
+
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <!--MEMBERS-->
+            </tcp-ip>
+        </join>
+
+        <ssl enabled="true">
+            <properties>
+                <property name="protocol">TLSv1.2</property>
+                <!--                <property name="mutualAuthentication">REQUIRED</property>-->
+                <property name="keyStore">/tmp/keystore.jks</property>
+                <property name="keyStorePassword">changeit</property>
+                <property name="trustStore">/tmp/truststore.jks</property>
+                <property name="trustStorePassword">changeit</property>
+            </properties>
+        </ssl>
+    </network>
+
+    <properties>
+        <property name="hazelcast.phone.home.enabled">false</property>
+        <property name="hazelcast.logging.type">log4j2</property>
+    </properties>
+
+    <!--LICENSE-KEY-->
+
+</hazelcast>
+

--- a/templates/hazelcast5-tls-ec2/hazelcast.xml
+++ b/templates/hazelcast5-tls-ec2/hazelcast.xml
@@ -21,13 +21,22 @@
         <ssl enabled="true">
             <properties>
                 <property name="protocol">TLSv1.2</property>
-                <!--                <property name="mutualAuthentication">REQUIRED</property>-->
                 <property name="keyStore">/tmp/keystore.jks</property>
                 <property name="keyStorePassword">changeit</property>
                 <property name="trustStore">/tmp/truststore.jks</property>
                 <property name="trustStorePassword">changeit</property>
             </properties>
         </ssl>
+
+<!--        <ssl enabled="true">-->
+<!--            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>-->
+<!--            <properties>-->
+<!--                <property name="protocol">TLSv1.2</property>-->
+<!--                <property name="trustCertCollectionFile">/tmp/cert.pem</property>-->
+<!--                <property name="keyFile">/tmp/key.pem</property>-->
+<!--                <property name="keyCertChainFile">/tmp/cert.pem</property>-->
+<!--            </properties>-->
+<!--        </ssl>-->
     </network>
 
     <properties>

--- a/templates/hazelcast5-tls-ec2/hazelcast.xml
+++ b/templates/hazelcast5-tls-ec2/hazelcast.xml
@@ -18,25 +18,25 @@
             </tcp-ip>
         </join>
 
+        <!--        <ssl enabled="true">-->
+        <!--            <properties>-->
+        <!--                <property name="protocol">TLSv1.2</property>-->
+        <!--                <property name="keyStore">/tmp/keystore.jks</property>-->
+        <!--                <property name="keyStorePassword">changeit</property>-->
+        <!--                <property name="trustStore">/tmp/truststore.jks</property>-->
+        <!--                <property name="trustStorePassword">changeit</property>-->
+        <!--            </properties>-->
+        <!--        </ssl>-->
+
         <ssl enabled="true">
+            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>
             <properties>
                 <property name="protocol">TLSv1.2</property>
-                <property name="keyStore">/tmp/keystore.jks</property>
-                <property name="keyStorePassword">changeit</property>
-                <property name="trustStore">/tmp/truststore.jks</property>
-                <property name="trustStorePassword">changeit</property>
+                <property name="trustCertCollectionFile">/tmp/cert.pem</property>
+                <property name="keyFile">/tmp/key.pem</property>
+                <property name="keyCertChainFile">/tmp/cert.pem</property>
             </properties>
         </ssl>
-
-<!--        <ssl enabled="true">-->
-<!--            <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>-->
-<!--            <properties>-->
-<!--                <property name="protocol">TLSv1.2</property>-->
-<!--                <property name="trustCertCollectionFile">/tmp/cert.pem</property>-->
-<!--                <property name="keyFile">/tmp/key.pem</property>-->
-<!--                <property name="keyCertChainFile">/tmp/cert.pem</property>-->
-<!--            </properties>-->
-<!--        </ssl>-->
     </network>
 
     <properties>

--- a/templates/hazelcast5-tls-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-tls-ec2/inventory_plan.yaml
@@ -4,16 +4,16 @@ terraform_plan: aws
 basename: <id>-<rnd:5>
 # Enter something here that identifies you.
 owner: <id>
-region: eu-central-1
-availability_zone: eu-central-1a
+region: us-east-1
+availability_zone: us-east-1b
 #Engineering account VPC
-vpc_id: vpc-094e507d79a701227 
+vpc_id: vpc-02e85223e6d75fedd
 #Engineering account igw
-internet_gateway_id: igw-03696757cca398137
+internet_gateway_id: igw-04124f82713efd431
 #Change the '20' to a different octet to prevent running into conflicts.
 cidr_block: 10.0.20.0/24
 #Change team information
-team: Cloud
+team: Core
 type: Benchmarking
 
 keypair:
@@ -23,20 +23,20 @@ keypair:
 nodes:
     count: 1
     instance_type: c5.9xlarge
-    ami: ami-04e601abe3e1a910f
+    ami: ami-0f9de6e2d2f067fca
     user: ubuntu
     tenancy: null
     
 loadgenerators:
     count: 1
     instance_type: c5.9xlarge
-    ami: ami-04e601abe3e1a910f
+    ami: ami-0f9de6e2d2f067fca
     user: ubuntu
     tenancy: null
 
 mc:
     instance_type: c5.4xlarge
     count: 0
-    ami: ami-04e601abe3e1a910f
+    ami: ami-0f9de6e2d2f067fca
     user: ubuntu
     tenancy: null

--- a/templates/hazelcast5-tls-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-tls-ec2/inventory_plan.yaml
@@ -1,0 +1,42 @@
+provisioner: terraform
+terraform_plan: aws
+# Used for naming resources; give it some unique name specific to a set of benchmarks
+basename: <id>-<rnd:5>
+# Enter something here that identifies you.
+owner: <id>
+region: eu-central-1
+availability_zone: eu-central-1a
+#Engineering account VPC
+vpc_id: vpc-094e507d79a701227 
+#Engineering account igw
+internet_gateway_id: igw-03696757cca398137
+#Change the '20' to a different octet to prevent running into conflicts.
+cidr_block: 10.0.20.0/24
+#Change team information
+team: Cloud
+type: Benchmarking
+
+keypair:
+    public_key: key.pub
+    private_key: key
+
+nodes:
+    count: 1
+    instance_type: c5.9xlarge
+    ami: ami-04e601abe3e1a910f
+    user: ubuntu
+    tenancy: null
+    
+loadgenerators:
+    count: 1
+    instance_type: c5.9xlarge
+    ami: ami-04e601abe3e1a910f
+    user: ubuntu
+    tenancy: null
+
+mc:
+    instance_type: c5.4xlarge
+    count: 0
+    ami: ami-04e601abe3e1a910f
+    user: ubuntu
+    tenancy: null

--- a/templates/hazelcast5-tls-ec2/setup
+++ b/templates/hazelcast5-tls-ec2/setup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+echo "Waiting for instances to start"
+sleep 60
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/hazelcast5-tls-ec2/setup
+++ b/templates/hazelcast5-tls-ec2/setup
@@ -12,3 +12,5 @@ sleep 60
 inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
 
 inventory install simulator
+
+inventory install tls_keystores

--- a/templates/hazelcast5-tls-ec2/teardown
+++ b/templates/hazelcast5-tls-ec2/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/hazelcast5-tls-ec2/tests.yaml
+++ b/templates/hazelcast5-tls-ec2/tests.yaml
@@ -1,0 +1,43 @@
+- name: read_only
+  duration: 300s
+  repetitions: 1
+  clients: 1
+  members: 1
+  driver: hazelcast-enterprise5
+  license_key: key
+  version: maven=5.3.8
+  client_args: >
+    -Xms3g
+    -Xmx3g
+    --add-modules java.se 
+    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED 
+    --add-opens java.base/java.lang=ALL-UNNAMED 
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED 
+    --add-opens java.management/sun.management=ALL-UNNAMED 
+    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+  member_args: >
+    -Xms3g
+    -Xmx3g
+    --add-modules java.se 
+    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED 
+    --add-opens java.base/java.lang=ALL-UNNAMED 
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED 
+    --add-opens java.management/sun.management=ALL-UNNAMED 
+    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+  loadgenerator_hosts: loadgenerators
+  node_hosts: nodes
+  verify_enabled: False
+  performance_monitor_interval_seconds: 1
+  warmup_seconds: 0
+  cooldown_seconds: 0
+  test:
+    - class: com.hazelcast.simulator.tests.map.LongByteArrayMapTest
+      name: map
+      threadCount: 40
+      getProb: 1
+      putProb: 0
+      keyDomain: 1_000_000
+      valueCount: 100
+      minValueLength: 1_000
+      maxValueLength: 1_000
+


### PR DESCRIPTION
Add ansible playbook for reproducible TLS keystore + truststore generation and distribution which can be called via `inventory`. Added a template which sets everything up for the user. Both jdk and openssl TLS supported. Netty dependency versions have been bumped to their latest hazelcast platform versions to support this.