### PR TITLE
Adjust LongByteArrayMapTest to support multiple maps [DEX-340]

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -55,12 +55,13 @@ public class LongByteArrayMapTest extends HazelcastTest {
     private List<IMap<Long, byte[]>> maps = new ArrayList<>();
     private byte[][] values;
     private final Executor callerRuns = Runnable::run;
-    Random random = new Random();
+    private final Random random = new Random();
 
     @Setup
     public void setUp() {
         for (int i = 0; i < mapCount; i++) {
-            maps.add(targetInstance.getMap(name + "_" + i));
+            String mapName = (mapCount == 1) ? name : name + "_" + i;
+            maps.add(targetInstance.getMap(mapName));
         }
         values = generateByteArrays(valueCount, minValueLength, maxValueLength);
     }


### PR DESCRIPTION
**NOTES:**
- Extend `LongByteArrayMapTest` to support multiple maps
- `LongByteArrayMapTest` has been chosen for a specific customer [benchmark](https://hazelcast.atlassian.net/wiki/spaces/TES/pages/5847285775/Visa+Workload+Validation+-+Approach+Roles+Responsibilities+Client+Count+Thresholds) 

![image](https://github.com/user-attachments/assets/013f0a6d-8d2c-4fe6-861b-cacdb84cbb56)
