### PR TITLE
Cache DatasetReader in vector collection tests

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/vector/DatasetReader.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/vector/DatasetReader.java
@@ -22,6 +22,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class DatasetReader {
 
@@ -128,8 +130,12 @@ public abstract class DatasetReader {
             }
         }
 
+    private record DatasetKey(String url, boolean normalize) {}
+    private final static Map<DatasetKey, DatasetReader> DATASET_CACHE = new ConcurrentHashMap<>();
+
     public static DatasetReader create(String url, String directory, boolean normalizeVector) {
-        return create(url, directory, normalizeVector, false);
+        return DATASET_CACHE.computeIfAbsent(new DatasetKey(url, normalizeVector),
+                __ -> create(url, directory, normalizeVector, false));
     }
 
     public static DatasetReader create(String url, String directory, boolean normalizeVector, boolean testOnly) {


### PR DESCRIPTION
Loading test dataset in `DatasetReader` takes some time and happens for each step in multi-step tests. Caching should make the test preparation faster and reduce memory footprint on the load generator.