### PR TITLE
Support adding extra tags to AWS resources [DEX-341]

### DIFF
--- a/templates/hazelcast5-cp-ec2/aws/main.tf
+++ b/templates/hazelcast5-cp-ec2/aws/main.tf
@@ -1,8 +1,12 @@
-
 locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -46,11 +50,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -60,11 +62,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -86,14 +86,11 @@ resource "aws_security_group" "node-sg" {
     name        = "simulator-security-group-node-${local.settings.basename}"
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -109,7 +106,7 @@ resource "aws_security_group" "node-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -144,15 +141,12 @@ resource "aws_instance" "nodes" {
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
-    
-    tags = {
+
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 output "nodes" {
@@ -165,14 +159,11 @@ resource "aws_security_group" "loadgenerator-sg" {
     name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -215,15 +206,12 @@ resource "aws_instance" "loadgenerators" {
     placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-} 
+    }, local.common_resource_tags)
+}
 
 output "loadgenerators" {
     value = [aws_instance.loadgenerators.*]
@@ -284,14 +272,11 @@ resource "aws_instance" "mc" {
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-cp-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-cp-ec2/inventory_plan.yaml
@@ -15,6 +15,8 @@ cidr_block: 10.0.20.0/24
 #Change team information
 team: Cloud
 type: Benchmarking
+# Any other tags to add to the created resources
+extraTags: {}
 
 keypair:
     public_key: key.pub

--- a/templates/hazelcast5-ec2/aws/main.tf
+++ b/templates/hazelcast5-ec2/aws/main.tf
@@ -1,8 +1,12 @@
-
 locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -46,11 +50,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -60,11 +62,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -86,14 +86,11 @@ resource "aws_security_group" "node-sg" {
     name        = "simulator-security-group-node-${local.settings.basename}"
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -161,15 +158,12 @@ resource "aws_instance" "nodes" {
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
-    
-    tags = {
+
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 output "nodes" {
@@ -182,14 +176,11 @@ resource "aws_security_group" "loadgenerator-sg" {
     name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -222,7 +213,7 @@ resource "aws_security_group" "loadgenerator-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -249,15 +240,12 @@ resource "aws_instance" "loadgenerators" {
     placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-} 
+    }, local.common_resource_tags)
+}
 
 output "loadgenerators" {
     value = [aws_instance.loadgenerators.*]
@@ -318,14 +306,11 @@ resource "aws_instance" "mc" {
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-ec2/inventory_plan.yaml
@@ -15,6 +15,8 @@ cidr_block: 10.0.20.0/24
 #Change team information
 team: Cloud
 type: Benchmarking
+# Any other tags to add to the created resources
+extraTags: {}
 
 keypair:
     public_key: key.pub

--- a/templates/hazelcast5-hd-ec2/aws/main.tf
+++ b/templates/hazelcast5-hd-ec2/aws/main.tf
@@ -3,6 +3,11 @@ locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -22,7 +27,7 @@ resource "aws_default_vpc" "vpc" {
 #    enable_dns_hostnames = "true" #gives you an internal host name
 #    enable_classiclink = "false"
 #    instance_tenancy = "default"
-#    
+#
 #    tags = {
 #        Name = "prod-vpc"
 #    }
@@ -46,11 +51,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -60,11 +63,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -86,14 +87,11 @@ resource "aws_security_group" "node-sg" {
     name        = "simulator-security-group-node-${local.settings.basename}"
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -126,7 +124,7 @@ resource "aws_security_group" "node-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -161,15 +159,12 @@ resource "aws_instance" "nodes" {
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
-    
-    tags = {
+
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 output "nodes" {
@@ -182,14 +177,11 @@ resource "aws_security_group" "loadgenerator-sg" {
     name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -222,7 +214,7 @@ resource "aws_security_group" "loadgenerator-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -249,15 +241,12 @@ resource "aws_instance" "loadgenerators" {
     #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-} 
+    }, local.common_resource_tags)
+}
 
 output "loadgenerators" {
     value = [aws_instance.loadgenerators.*]
@@ -317,14 +306,11 @@ resource "aws_instance" "mc" {
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
     tenancy                 = local.settings.mc.tenancy
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-hd-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-hd-ec2/inventory_plan.yaml
@@ -15,6 +15,8 @@ cidr_block: 10.0.20.0/24
 #Change team information
 team: Cloud
 type: Benchmarking
+# Any other tags to add to the created resources
+extraTags: {}
 
 keypair:
     public_key: key.pub

--- a/templates/hazelcast5-sql-ec2-tstore/aws/main.tf
+++ b/templates/hazelcast5-sql-ec2-tstore/aws/main.tf
@@ -3,6 +3,11 @@ locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -22,7 +27,7 @@ resource "aws_default_vpc" "vpc" {
 #    enable_dns_hostnames = "true" #gives you an internal host name
 #    enable_classiclink = "false"
 #    instance_tenancy = "default"
-#    
+#
 #    tags = {
 #        Name = "prod-vpc"
 #    }
@@ -46,11 +51,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -60,11 +63,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -87,12 +88,9 @@ resource "aws_security_group" "node-sg" {
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
 
-    tags = {
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     ingress {
         description = "SSH"
@@ -154,14 +152,11 @@ resource "aws_instance" "nodes" {
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
 
-    tags = {
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     # mount instance store to be used by Tiered Storage
     # install nocache tool to bypass OS page cache for benchmarking/testing TStore
@@ -187,12 +182,9 @@ resource "aws_security_group" "loadgenerator-sg" {
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
 
-    tags = {
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     ingress {
         description = "SSH"
@@ -253,14 +245,11 @@ resource "aws_instance" "loadgenerators" {
     #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 output "loadgenerators" {
@@ -321,14 +310,11 @@ resource "aws_instance" "mc" {
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
     tenancy                 = local.settings.mc.tenancy
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-sql-ec2/aws/main.tf
+++ b/templates/hazelcast5-sql-ec2/aws/main.tf
@@ -3,6 +3,11 @@ locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -22,7 +27,7 @@ resource "aws_default_vpc" "vpc" {
 #    enable_dns_hostnames = "true" #gives you an internal host name
 #    enable_classiclink = "false"
 #    instance_tenancy = "default"
-#    
+#
 #    tags = {
 #        Name = "prod-vpc"
 #    }
@@ -46,11 +51,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -60,11 +63,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -86,14 +87,11 @@ resource "aws_security_group" "node-sg" {
     name        = "simulator-security-group-node-${local.settings.basename}"
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -126,7 +124,7 @@ resource "aws_security_group" "node-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -153,15 +151,12 @@ resource "aws_instance" "nodes" {
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
-    
-    tags = {
+
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 output "nodes" {
@@ -174,14 +169,11 @@ resource "aws_security_group" "loadgenerator-sg" {
     name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -214,7 +206,7 @@ resource "aws_security_group" "loadgenerator-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -241,15 +233,12 @@ resource "aws_instance" "loadgenerators" {
     #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-} 
+    }, local.common_resource_tags)
+}
 
 output "loadgenerators" {
     value = [aws_instance.loadgenerators.*]
@@ -310,14 +299,11 @@ resource "aws_instance" "mc" {
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-storage-ec2/aws/main.tf
+++ b/templates/hazelcast5-storage-ec2/aws/main.tf
@@ -3,6 +3,11 @@ locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     private_key = file("../${local.settings.keypair.private_key}")
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -46,11 +51,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -60,11 +63,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -86,14 +87,11 @@ resource "aws_security_group" "node-sg" {
     name        = "simulator-security-group-node-${local.settings.basename}"
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -162,14 +160,11 @@ resource "aws_instance" "nodes" {
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
     
-    tags = {
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"
@@ -200,14 +195,11 @@ resource "aws_security_group" "loadgenerator-sg" {
     name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -267,15 +259,12 @@ resource "aws_instance" "loadgenerators" {
     #placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-} 
+    }, local.common_resource_tags)
+}
 
 output "loadgenerators" {
     value = [aws_instance.loadgenerators.*]
@@ -336,14 +325,11 @@ resource "aws_instance" "mc" {
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-tls-ec2/aws/main.tf
+++ b/templates/hazelcast5-tls-ec2/aws/main.tf
@@ -1,7 +1,11 @@
-
 locals {
     settings = yamldecode(file("../inventory_plan.yaml"))
     public_key = file("../${local.settings.keypair.public_key}")
+    common_resource_tags = merge({
+        team  = local.settings.team
+        type  = local.settings.type
+        Owner = local.settings.owner
+    }, try(local.settings.extraTags, {}))
 }
 
 provider "aws" {
@@ -19,11 +23,9 @@ resource "aws_subnet" "subnet" {
     cidr_block              = local.settings.cidr_block
     availability_zone       = local.settings.availability_zone
     map_public_ip_on_launch = true
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table" "route_table" {
@@ -33,11 +35,9 @@ resource "aws_route_table" "route_table" {
         gateway_id = local.settings.internet_gateway_id
     }
 
-    tags = {
+    tags = merge({
         Name = "Simulator Public Subnet Route Table ${local.settings.basename}"
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 resource "aws_route_table_association" "route_table_association" {
@@ -59,14 +59,11 @@ resource "aws_security_group" "node-sg" {
     name        = "simulator-security-group-node-${local.settings.basename}"
     description = "Security group for the node"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Node Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -134,15 +131,12 @@ resource "aws_instance" "nodes" {
     vpc_security_group_ids  = [ aws_security_group.node-sg.id ]
     subnet_id               = aws_subnet.subnet.id
     tenancy                 = local.settings.nodes.tenancy
-    
-    tags = {
+
+    tags = merge({
         Name  = "Simulator Node ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.nodes.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 }
 
 output "nodes" {
@@ -155,14 +149,11 @@ resource "aws_security_group" "loadgenerator-sg" {
     name        = "simulator-security-group-loadgenerator-${local.settings.basename}"
     description = "Security group for the loadgenerator"
     vpc_id      = local.settings.vpc_id
-    
-    tags = {
+
+    tags = merge({
         Name = "Simulator Load Balancer Security Group ${local.settings.basename}",
-        Owner = local.settings.owner
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-    
+    }, local.common_resource_tags)
+
     ingress {
         description = "SSH"
         from_port   = 22
@@ -195,7 +186,7 @@ resource "aws_security_group" "loadgenerator-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
     ingress {
         description = "Simulator"
         from_port   = 9000
@@ -222,15 +213,12 @@ resource "aws_instance" "loadgenerators" {
     placement_group         = aws_placement_group.cluster_placement_group.name
     vpc_security_group_ids  = [ aws_security_group.loadgenerator-sg.id ]
     tenancy                 = local.settings.loadgenerators.tenancy
-    tags = {
+    tags = merge({
         Name  = "Simulator Load Generator ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.loadgenerators.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
-} 
+    }, local.common_resource_tags)
+}
 
 output "loadgenerators" {
     value = [aws_instance.loadgenerators.*]
@@ -291,14 +279,11 @@ resource "aws_instance" "mc" {
     availability_zone       = local.settings.availability_zone
     vpc_security_group_ids  = [ aws_security_group.mc-sg.id ]
 
-    tags = {
+    tags = merge({
         Name  = "Simulator MC ${local.settings.basename}"
-        Owner = local.settings.owner
         "passthrough:ansible_ssh_private_key_file" = local.settings.keypair.private_key
         "passthrough:ansible_user" = local.settings.mc.user
-        team  = local.settings.team
-        type  = local.settings.type
-    }
+    }, local.common_resource_tags)
 
     connection {
         type        = "ssh"

--- a/templates/hazelcast5-tls-ec2/inventory_plan.yaml
+++ b/templates/hazelcast5-tls-ec2/inventory_plan.yaml
@@ -15,6 +15,8 @@ cidr_block: 10.0.20.0/24
 #Change team information
 team: Core
 type: Benchmarking
+# Any other tags to add to the created resources
+extraTags: {}
 
 keypair:
     public_key: key.pub


### PR DESCRIPTION
Added `extraTags` block to `inventory_plan.yaml` which allows adding additional tags to all aws resources created for a simulation.