### PR TITLE
Improve hdr file processing performance [DEX-353]

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
@@ -1,0 +1,39 @@
+package com.hazelcast.simulator.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+
+public class BatchedHistogramLogProcessor {
+    /**
+     * Utility to process multiple {@link SimulatorHistogramLogProcessor} invocations
+     * in parallel. A single path is expected as an arg which points to file where each
+     * line is interpreted as an invocation of {@link SimulatorHistogramLogProcessor}
+     * detailing the args to pass for that invocation.
+     */
+    public static void main(String[] args)
+            throws IOException, InterruptedException {
+        Path input = Path.of(args[0]);
+        List<String[]> processorInvocations = Files.readAllLines(input).stream().map(line -> line.trim().split("\\s+")).toList();
+        int threadCount = Math.max(2, Runtime.getRuntime().availableProcessors() - 1);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            List<CompletableFuture<Void>> tasks = new ArrayList<>();
+            for (var processorInvocation : processorInvocations) {
+                tasks.add(runAsync(new SimulatorHistogramLogProcessor(processorInvocation), executor));
+            }
+            CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogProcessor.java
@@ -27,7 +27,7 @@ import static com.hazelcast.simulator.utils.CommonUtils.exitWithError;
  *
  * @author Gil Tene
  */
-public class HistogramLogProcessor extends Thread {
+public class HistogramLogProcessor implements Runnable {
 
     public static final String versionString = "Histogram Log Processor version ---SIMULATOR--";
 
@@ -375,7 +375,6 @@ public class HistogramLogProcessor extends Thread {
      * @throws FileNotFoundException if specified input file is not found
      */
     public HistogramLogProcessor(final String[] args) throws FileNotFoundException {
-        this.setName("HistogramLogProcessor");
         config = new HistogramLogProcessorConfiguration(args);
         if (config.inputFileName != null) {
             logReader = new HistogramLogReader(config.inputFileName);
@@ -390,10 +389,8 @@ public class HistogramLogProcessor extends Thread {
      * @param args command line arguments
      */
     public static void main(final String[] args) {
-        final HistogramLogProcessor processor;
         try {
-            processor = new HistogramLogProcessor(args);
-            processor.start();
+           new HistogramLogProcessor(args).run();
         } catch (FileNotFoundException ex) {
             System.err.println("failed to open input file.");
         }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
@@ -27,6 +27,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
         super(args);
     }
 
+    @Override
     protected Object[] buildRegularHistogramStatistics(Histogram intervalHistogram, Histogram accumulatedHistogram) {
         double intervalThroughput = ((double) (intervalHistogram.getTotalCount())
                 / (intervalHistogram.getEndTimeStamp() - intervalHistogram.getStartTimeStamp()));
@@ -71,6 +72,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
         };
     }
 
+    @Override
     protected Object[] buildDoubleHistogramStatistics(DoubleHistogram intervalHistogram, DoubleHistogram accumulatedHistogram) {
         double intervalThroughput = ((double) (intervalHistogram.getTotalCount())
                 / (intervalHistogram.getEndTimeStamp() - intervalHistogram.getStartTimeStamp()));
@@ -115,6 +117,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
         };
     }
 
+    @Override
     protected String buildLegend(boolean cvs) {
         if (cvs) {
             return "\"Timestamp\","
@@ -156,6 +159,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
         }
     }
 
+    @Override
     protected String buildLogFormat(boolean cvs) {
         if (cvs) {
             return "%.3f," //timestamp
@@ -229,10 +233,8 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
     }
 
     public static void main(final String[] args) {
-        final SimulatorHistogramLogProcessor processor;
         try {
-            processor = new SimulatorHistogramLogProcessor(args);
-            processor.start();
+            new SimulatorHistogramLogProcessor(args).run();
         } catch (FileNotFoundException ex) {
             System.err.println("failed to open input file.");
         }


### PR DESCRIPTION
For a large number of workers it currently takes a long time to process all hdr files, e.g. for 1025 workers it took over 1 hour. This change improves the speed by 10x, the same run took 6mins to process them all. The improvements come from running all processing in parallel in a single jvm instance instead of sequentially processing each file in separate jvm processes.