### PR TITLE
Add native ping failure detector support for simulator runs [DEX-360]

### DIFF
--- a/playbooks/install_java.yaml
+++ b/playbooks/install_java.yaml
@@ -6,7 +6,6 @@
     tar_gz_filename: "{{ jdk_url | basename }}"
 
   tasks:
-
   - name: Downloads the tar.gz
     get_url:
       url: "{{ jdk_url }}"
@@ -39,3 +38,24 @@
       regexp: '^export JAVA_HOME'
       line: "export JAVA_HOME=~{{ console_user | default(ansible_user) }}/{{ archive_contents.files[0].split('/')[0] }}"
       insertbefore: BOF
+
+  - name: Add Ping Failure Detector support
+    when: ansible_system == "Linux"
+    block:
+      - name: Set raw socket capability on java binary
+        become: yes
+        command:
+          cmd: "setcap cap_net_raw=+ep /home/{{ console_user | default(ansible_user) }}/{{ archive_contents.files[0].split('/')[0] }}/bin/java"
+
+      - name: Trust jdk libs
+        become: yes
+        copy:
+          dest: /etc/ld.so.conf.d/java.conf
+          content: |
+            /home/{{ console_user | default(ansible_user) }}/{{ archive_contents.files[0].split('/')[0] }}/lib
+            /home/{{ console_user | default(ansible_user) }}/{{ archive_contents.files[0].split('/')[0] }}/jre/lib/amd64/jli
+
+      - name: Reload trusted libs
+        become: yes
+        command:
+          cmd: ldconfig

--- a/templates/hazelcast5-cp-ec2/aws/main.tf
+++ b/templates/hazelcast5-cp-ec2/aws/main.tf
@@ -123,6 +123,14 @@ resource "aws_security_group" "node-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -186,6 +194,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         to_port     = 9001
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {
@@ -253,6 +269,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-ec2/aws/main.tf
+++ b/templates/hazelcast5-ec2/aws/main.tf
@@ -140,6 +140,14 @@ resource "aws_security_group" "node-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -222,6 +230,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -287,6 +303,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-hd-ec2/aws/main.tf
+++ b/templates/hazelcast5-hd-ec2/aws/main.tf
@@ -141,6 +141,14 @@ resource "aws_security_group" "node-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -223,6 +231,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -286,6 +302,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-sql-ec2-tstore/aws/main.tf
+++ b/templates/hazelcast5-sql-ec2-tstore/aws/main.tf
@@ -133,6 +133,14 @@ resource "aws_security_group" "node-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -227,6 +235,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -290,6 +306,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-sql-ec2/aws/main.tf
+++ b/templates/hazelcast5-sql-ec2/aws/main.tf
@@ -132,7 +132,15 @@ resource "aws_security_group" "node-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -215,6 +223,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -280,6 +296,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-sql-prunability-ec2/aws/main.tf
+++ b/templates/hazelcast5-sql-prunability-ec2/aws/main.tf
@@ -130,7 +130,15 @@ resource "aws_security_group" "node-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -213,6 +221,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -276,6 +292,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-storage-ec2/aws/main.tf
+++ b/templates/hazelcast5-storage-ec2/aws/main.tf
@@ -140,7 +140,15 @@ resource "aws_security_group" "node-sg" {
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
     }
-  
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -241,6 +249,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -306,6 +322,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {

--- a/templates/hazelcast5-tls-ec2/aws/main.tf
+++ b/templates/hazelcast5-tls-ec2/aws/main.tf
@@ -113,6 +113,14 @@ resource "aws_security_group" "node-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -195,6 +203,14 @@ resource "aws_security_group" "loadgenerator-sg" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
+    }
+
     egress {
         from_port   = 0
         to_port     = 0
@@ -260,6 +276,14 @@ resource "aws_security_group" "mc-sg" {
         to_port     = 8443
         protocol    = "tcp"
         cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        description = "ICMP"
+        from_port   = -1
+        to_port     = -1
+        protocol    = "icmp"
+        cidr_blocks = [local.settings.cidr_block]
     }
 
     egress {


### PR DESCRIPTION
Configures the simulator hosts to allow the java processes to create raw sockets, adds ingress rule allowing instances to connect with the icmp protocol.