### PR TITLE
Update BatchedHistogramLogProcessor to improve hdr files processing [DEX-353][DEX-377]

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
@@ -1,5 +1,6 @@
 package com.hazelcast.simulator.utils;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +32,7 @@ public class BatchedHistogramLogProcessor {
                 tasks.add(runAsync(() -> {
                     try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(processorInvocation)) {
                         processor.run();
-                    } catch (IOException e) {
+                    } catch (FileNotFoundException e) {
                         throw new RuntimeException(e);
                     }
                 }, executor));

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.CompletableFuture.runAsync;
@@ -29,16 +28,12 @@ public class BatchedHistogramLogProcessor {
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         try {
             List<CompletableFuture<Void>> tasks = new ArrayList<>();
-            Semaphore gate = new Semaphore(1000);
             for (var processorInvocation : processorInvocations) {
                 tasks.add(runAsync(() -> {
-                    gate.acquireUninterruptibly();
                     try {
                         new SimulatorHistogramLogProcessor(processorInvocation).run();
                     } catch (FileNotFoundException e) {
                         throw new RuntimeException(e);
-                    } finally {
-                        gate.release();
                     }
                 }, executor));
             }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
@@ -1,6 +1,5 @@
 package com.hazelcast.simulator.utils;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
@@ -30,9 +30,9 @@ public class BatchedHistogramLogProcessor {
             List<CompletableFuture<Void>> tasks = new ArrayList<>();
             for (var processorInvocation : processorInvocations) {
                 tasks.add(runAsync(() -> {
-                    try {
-                        new SimulatorHistogramLogProcessor(processorInvocation).run();
-                    } catch (FileNotFoundException e) {
+                    try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(processorInvocation)) {
+                        processor.run();
+                    } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
                 }, executor));

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/BatchedHistogramLogProcessor.java
@@ -35,11 +35,9 @@ public class BatchedHistogramLogProcessor {
                     gate.acquireUninterruptibly();
                     try {
                         new SimulatorHistogramLogProcessor(processorInvocation).run();
-                    }
-                    catch (FileNotFoundException e) {
+                    } catch (FileNotFoundException e) {
                         throw new RuntimeException(e);
-                    }
-                    finally {
+                    } finally {
                         gate.release();
                     }
                 }, executor));

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogProcessor.java
@@ -147,7 +147,7 @@ public class HistogramLogProcessor implements Runnable {
             histogram = logReader.nextIntervalHistogram(config.rangeStartTimeSec, config.rangeEndTimeSec);
         } catch (RuntimeException ex) {
             System.err.println("Log file parsing error at line number " + lineNumber +
-                    ": line appears to be malformed.");
+                    ": line appears to be malformed. " + "Log file: " + config.inputFileName);
             if (config.verbose) {
                 throw ex;
             } else {

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
@@ -19,12 +19,12 @@ import org.HdrHistogram.DoubleHistogram;
 import org.HdrHistogram.Histogram;
 
 import java.io.Closeable;
-import java.io.IOException;
+import java.io.FileNotFoundException;
 
 @SuppressWarnings({"checkstyle:methodlength", "checkstyle:magicnumber"})
 public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implements Closeable {
 
-    public SimulatorHistogramLogProcessor(String[] args) throws IOException {
+    public SimulatorHistogramLogProcessor(String[] args) throws FileNotFoundException {
         super(args);
     }
 
@@ -234,14 +234,14 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implem
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         logReader.close();
     }
 
     public static void main(final String[] args) {
         try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(args)) {
             processor.run();
-        } catch (IOException ex) {
+        } catch (FileNotFoundException ex) {
             System.err.println("Failed to open input file: " + ex.getMessage());
         }
     }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
@@ -18,12 +18,13 @@ package com.hazelcast.simulator.utils;
 import org.HdrHistogram.DoubleHistogram;
 import org.HdrHistogram.Histogram;
 
-import java.io.FileNotFoundException;
+import java.io.Closeable;
+import java.io.IOException;
 
 @SuppressWarnings({"checkstyle:methodlength", "checkstyle:magicnumber"})
-public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
+public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implements Closeable {
 
-    public SimulatorHistogramLogProcessor(String[] args) throws FileNotFoundException {
+    public SimulatorHistogramLogProcessor(String[] args) throws IOException {
         super(args);
     }
 
@@ -232,11 +233,16 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor {
         }
     }
 
+    @Override
+    public void close() throws IOException {
+        logReader.close();
+    }
+
     public static void main(final String[] args) {
-        try {
-            new SimulatorHistogramLogProcessor(args).run();
-        } catch (FileNotFoundException ex) {
-            System.err.println("failed to open input file.");
+        try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(args)) {
+            processor.run();
+        } catch (IOException ex) {
+            System.err.println("Failed to open input file: " + ex.getMessage());
         }
     }
 }


### PR DESCRIPTION
```
INFO  12:06:49 Processing 6002 hdr files
WARN  12:06:49 Log file parsing error at line number 85: line appears to be malformed.
Traceback (most recent call last):
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/bin/../src/perftest_cli.py", line 63, in <module>
    PerftestCli()
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/bin/../src/perftest_cli.py", line 37, in __init__
    getattr(self, args.command)()
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/bin/../src/perftest_cli.py", line 58, in report
    PerfTestReportCli(sys.argv[2:])
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/src/simulator/perftest_report.py", line 262, in __init__
    prepare(config)
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/src/simulator/perftest_report.py", line 28, in prepare
    prepare_hdr(config)
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/src/simulator/perftest_report_hdr.py", line 23, in prepare_hdr
    __process_hdr(config, run_dir, run_label)
  File "/Users/alaktionov/IdeaProjects/hazelcast-simulator/src/simulator/perftest_report_hdr.py", line 82, in __process_hdr
    raise Exception(
Exception: hdr processing failed with status 1, cmd executed: "java -cp "/Users/alaktionov/IdeaProjects/hazelcast-simulator/lib/*"                     com.hazelcast.simulator.utils.BatchedHistogramLogProcessor runs/3k_clients_test_near_cache_disabled/test/hdr_batch_process_details"
```
fixes #2265 