### PR TITLE
Improve dataframe concatenation speed by using more memory [DEX-385]

### DIFF
--- a/src/simulator/perftest_report_common.py
+++ b/src/simulator/perftest_report_common.py
@@ -83,16 +83,11 @@ class ColumnDesc:
         return ColumnDesc(group, metric, attributes)
 
 
-def merge_dataframes(*dfs):
-    result = None
-    for df in dfs:
-        if df is None:
-            continue
-        elif result is None:
-            result = df
-        else:
-            result = pd.concat([result, df], axis=1, join="outer")
-    return result
+def concat_dataframe_columns(dataframes):
+    if len(dataframes) == 0:
+        return None
+    else:
+        return pd.concat(dataframes, axis=1, join='outer')
 
 
 # Shifts the vales in the time index to the beginning (epoch). This is needed

--- a/src/simulator/perftest_report_dstat.py
+++ b/src/simulator/perftest_report_dstat.py
@@ -7,15 +7,12 @@ from matplotlib.dates import DateFormatter
 
 from simulator.perftest_report_common import *
 import matplotlib.pyplot as plt
-import plotly.express as px
-import plotly.offline as pyo
-import plotly.tools as tls
 
 def analyze_dstat(run_dir, attributes):
     log_section("Loading dstat data: Start")
     start_sec = time.time()
 
-    result = None
+    all_dstat_data = []
     for csv_filename in os.listdir(run_dir):
         if not csv_filename.endswith("_dstat.csv"):
             continue
@@ -40,8 +37,9 @@ def analyze_dstat(run_dir, attributes):
             column_desc = ColumnDesc("dstat", column_name, new_attributes)
             df.rename(columns={column_name: column_desc.to_string()}, inplace=True)
 
-        result = merge_dataframes(result, df)
+        all_dstat_data.append(df)
 
+    result = concat_dataframe_columns(all_dstat_data)
     duration_sec = time.time() - start_sec
     log_section(f"Loading dstat data: Done (duration {duration_sec:.2f} seconds)")
     return result

--- a/src/simulator/perftest_report_operations.py
+++ b/src/simulator/perftest_report_operations.py
@@ -27,9 +27,7 @@ def analyze_operations(run_dir, attributes):
     df_list += __load_aggregated_operations_csv(run_dir, attributes)
     df_list += __load_worker_operations_csv(run_dir, attributes)
 
-    result = None
-    for df in df_list:
-        result = merge_dataframes(result, df)
+    result = concat_dataframe_columns(df_list)
 
     duration_sec = time.time() - start_sec
     log_section(f"Loading operations data: Done (duration {duration_sec:.2f} seconds)")


### PR DESCRIPTION
When aggregating all run data the dataframe concatenation is currently very slow for a run with many workers. The current implementation is repeatedly copying the same data. This change increases the memory used by less than the size of the final dataframe but the time taken to run the operation is greatly improved. For example on my machine the analyze step takes roughly 2 hours with 6k workers before this change, with this change it takes less than a minute.