### PR TITLE
Remove duplicated work processing hdr files in report [DEX-376]

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/ReportHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/ReportHistogramLogProcessor.java
@@ -13,12 +13,15 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.CompletableFuture.runAsync;
 
-public class BatchedHistogramLogProcessor {
+public class ReportHistogramLogProcessor {
     /**
      * Utility to process multiple {@link SimulatorHistogramLogProcessor} invocations
      * in parallel. A single path is expected as an arg which points to file where each
      * line is interpreted as an invocation of {@link SimulatorHistogramLogProcessor}
      * detailing the args to pass for that invocation.
+     *
+     * The latency history output will always be in csv format, the overall distribution
+     * format can be controlled with the -csv flag.
      */
     public static void main(String[] args)
             throws IOException, InterruptedException {
@@ -30,7 +33,7 @@ public class BatchedHistogramLogProcessor {
             List<CompletableFuture<Void>> tasks = new ArrayList<>();
             for (var processorInvocation : processorInvocations) {
                 tasks.add(runAsync(() -> {
-                    try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(processorInvocation)) {
+                    try (var processor = new SimulatorHistogramLogProcessor(processorInvocation, true)) {
                         processor.run();
                     } catch (FileNotFoundException e) {
                         throw new RuntimeException(e);

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/SimulatorHistogramLogProcessor.java
@@ -24,8 +24,11 @@ import java.io.FileNotFoundException;
 @SuppressWarnings({"checkstyle:methodlength", "checkstyle:magicnumber"})
 public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implements Closeable {
 
-    public SimulatorHistogramLogProcessor(String[] args) throws FileNotFoundException {
+    private final boolean areLatenciesFormattedAsCsv;
+
+    public SimulatorHistogramLogProcessor(String[] args, boolean forceLatencyFormatAsCsv) throws FileNotFoundException {
         super(args);
+        this.areLatenciesFormattedAsCsv = config.logFormatCsv || forceLatencyFormatAsCsv;
     }
 
     @Override
@@ -120,7 +123,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implem
 
     @Override
     protected String buildLegend(boolean cvs) {
-        if (cvs) {
+        if (cvs || areLatenciesFormattedAsCsv) {
             return "\"Timestamp\","
                     + "\"StartTime\","
                     + "\"Int_Count\","
@@ -162,7 +165,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implem
 
     @Override
     protected String buildLogFormat(boolean cvs) {
-        if (cvs) {
+        if (cvs || areLatenciesFormattedAsCsv) {
             return "%.3f," //timestamp
                     + "%.3f," //timestamp
                     + "%d," //int count
@@ -213,7 +216,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implem
                     + "%7.3f " //int mean
                     + "%7.3f " //int std deviation
                     + "%7.3f " //int throughput
-                    + "( "
+                    + ") "
                     + "T:%d " //total count
                     + "( "
                     + "%7.3f " //total 25%
@@ -239,7 +242,7 @@ public class SimulatorHistogramLogProcessor extends HistogramLogProcessor implem
     }
 
     public static void main(final String[] args) {
-        try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(args)) {
+        try (SimulatorHistogramLogProcessor processor = new SimulatorHistogramLogProcessor(args, false)) {
             processor.run();
         } catch (FileNotFoundException ex) {
             System.err.println("Failed to open input file: " + ex.getMessage());

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -76,16 +76,14 @@ def __process_hdr(config: ReportConfig, run_dir, run_label):
     
     info(f"Processing {len(prepared_hdr_files)} hdr files")
     hdr_processing_cmd = f"""java -cp "{simulator_home}/lib/*" \
-                    com.hazelcast.simulator.utils.BatchedHistogramLogProcessor {hdr_batch_process_details}"""
+                    com.hazelcast.simulator.utils.ReportHistogramLogProcessor {hdr_batch_process_details}"""
     status = shell(hdr_processing_cmd)
     if status != 0:
         raise Exception(
             f"hdr processing failed with status {status}, cmd executed: \"{hdr_processing_cmd}\"")
 
     for hdr_output_dir, hdr_file_name_no_ext in prepared_hdr_files:
-        os.remove(f"{hdr_output_dir}/{hdr_file_name_no_ext}")
-        os.remove(f"{hdr_output_dir}/{hdr_file_name_no_ext}-csv.hgrm")
-        os.rename(f"{hdr_output_dir}/{hdr_file_name_no_ext}-csv",
+        os.rename(f"{hdr_output_dir}/{hdr_file_name_no_ext}",
                   f"{hdr_output_dir}/{hdr_file_name_no_ext}.latency-history.csv")
     os.remove(hdr_batch_process_details)
 
@@ -117,7 +115,6 @@ def __prepare_hdr_file(config: ReportConfig, run_label, worker_id, hdr_file, bat
         start_end += f" -end {end} "
     
     batch_process_output.write(f"{start_end} -i {hdr_file} -o {target_dir}/{hdr_file_name_no_ext} -outputValueUnitRatio 1000\n")
-    batch_process_output.write(f"{start_end} -csv -i {hdr_file} -o {target_dir}/{hdr_file_name_no_ext}-csv -outputValueUnitRatio 1000\n")
     return target_dir, hdr_file_name_no_ext
 
 


### PR DESCRIPTION
Remove duplication of work when processing each hdr file by supporting more control over the output file formats. Now we allow the overall latency distribution to be output in .hgrm but the latency over time to be output in .csv instead of requiring both files to have the same format.