### PR TITLE
Fix merge hdr step during report processing [DEX-375]

### DIFF
--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
@@ -103,9 +103,7 @@ public final class HistogramLogMerger {
             }
 
             writer.outputIntervalHistogram(merged);
-            if (++numberOfMergedHistograms % 1000 == 0) {
-                System.out.println("[HistogramLogMerger] Added merged histogram " + numberOfMergedHistograms + " to " + outputFile);
-            }
+            System.out.println("[HistogramLogMerger] Added merged histogram " + ++numberOfMergedHistograms + " to " + outputFile);
 
         }
     }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
@@ -53,7 +53,7 @@ public final class HistogramLogMerger {
 
         File inputFilesListFile = new File(args[1]);
         if (!inputFilesListFile.exists()) {
-            throw new IllegalArgumentException("inputFilesListingFile File [" + inputFilesListFile + "] doesn't exist");
+            throw new IllegalArgumentException("inputFilesListingFile [" + inputFilesListFile + "] doesn't exist");
         }
 
         System.out.println("[HistogramLogMerger] Reading input files list from " + inputFilesListFile);

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
@@ -96,9 +96,6 @@ public final class HistogramLogMerger {
                             histogram.getNumberOfSignificantValueDigits());
                 }
                 merged.add(histogram);
-                if (++numberOfMergedHistograms % 100 == 0) {
-                    System.out.println("[HistogramLogMerger] Merged " + numberOfMergedHistograms + " histograms");
-                }
             }
 
             if (merged == null) {
@@ -106,6 +103,10 @@ public final class HistogramLogMerger {
             }
 
             writer.outputIntervalHistogram(merged);
+            if (++numberOfMergedHistograms % 1000 == 0) {
+                System.out.println("[HistogramLogMerger] Added merged histogram " + numberOfMergedHistograms + " to " + outputFile);
+            }
+
         }
     }
 

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
@@ -57,7 +57,7 @@ public final class HistogramLogMerger {
             throw new IllegalArgumentException("hdr_files_list_file [" + inputFilesListFile + "] doesn't exist");
         }
 
-        System.out.println("[HistogramLogMerger] Using input files list from " + inputFilesListFile);
+        log("Using input files list from " + inputFilesListFile);
 
         List<String> inputFiles = Files.readAllLines(inputFilesListFile.toPath());
         ArrayList<HistogramLogReader> readers = new ArrayList<>(inputFiles.size());
@@ -75,7 +75,7 @@ public final class HistogramLogMerger {
 
         HistogramLogWriter writer = new HistogramLogWriter(outputFile);
         String comment = "[Latency histograms for " + getBaseName(outputFile) + ']';
-        System.out.println(comment);
+        log(comment);
         writer.outputComment(comment);
         writer.outputLogFormatVersion();
         writer.outputLegend();
@@ -103,9 +103,12 @@ public final class HistogramLogMerger {
             }
 
             writer.outputIntervalHistogram(merged);
-            System.out.println("[HistogramLogMerger] Added merged histogram " + ++numberOfMergedHistograms + " to " + outputFile);
-
+            log("Added merged histogram " + ++numberOfMergedHistograms + " to " + outputFile);
         }
+    }
+
+    private static void log(String log) {
+        System.out.println("[HistogramLogMerger] " + log);
     }
 
     private static String getBaseName(File file) {

--- a/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/utils/HistogramLogMerger.java
@@ -48,12 +48,12 @@ public final class HistogramLogMerger {
         ensureExistingFile(outputFile);
 
         if (args.length < 2) {
-            throw new IllegalArgumentException("Usage: HistogramLogMerger <outputFile> <inputFilesListingFile>");
+            throw new IllegalArgumentException("Usage: HistogramLogMerger <outputFile> <hdr_files_list_file>");
         }
 
         File inputFilesListFile = new File(args[1]);
         if (!inputFilesListFile.exists()) {
-            throw new IllegalArgumentException("inputFilesListingFile [" + inputFilesListFile + "] doesn't exist");
+            throw new IllegalArgumentException("hdr_files_list_file [" + inputFilesListFile + "] doesn't exist");
         }
 
         System.out.println("[HistogramLogMerger] Reading input files list from " + inputFilesListFile);

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -39,10 +39,21 @@ def __merge_worker_hdr(run_dir):
                 dic[file_name] = files
             files.append(hdr_file)
 
+
     for file_name, hdr_files in dic.items():
-        shell(f"""java -cp "{simulator_home}/lib/*" \
+        # write the list of files into a file named inputFilesListingFile.txt
+        file_name = file_name + "._merge_worker_hdr_input_files_list"
+        hdr_list_file = os.path.join(run_dir, file_name)
+        print(f"Writing file list for {file_name} into file {hdr_list_file}")
+        with open(hdr_list_file, 'w') as listing_file:
+            listing_file.writelines(hdr_files)
+
+        command = f"""java -cp "{simulator_home}/lib/*" \
                          com.hazelcast.simulator.utils.HistogramLogMerger \
-                         {run_dir}/{file_name} {" ".join(hdr_files)} 2>/dev/null""")
+                         {run_dir}/{file_name} {hdr_list_file} 2>/dev/null"""
+
+        print(f"Executing process for {command}")
+        shell(command)
 
 
 def __process_hdr(config: ReportConfig, run_dir, run_label):

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -41,9 +41,9 @@ def __merge_worker_hdr(run_dir):
 
 
     for file_name, hdr_files in dic.items():
-        # write the list of files into a file named inputFilesListingFile.txt
-        file_name = file_name + "._merge_worker_hdr_input_files_list"
-        hdr_list_file = os.path.join(run_dir, file_name)
+        # write the list of files into a file and let Java processor read from it
+        hdr_list_file_name = file_name + "._merge_worker_hdr_input_files_list"
+        hdr_list_file = os.path.join(run_dir, hdr_list_file_name)
         print(f"Writing file list for {file_name} into file {hdr_list_file}")
         with open(hdr_list_file, 'w') as listing_file:
             for hdr_file_path in hdr_files:

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -46,7 +46,8 @@ def __merge_worker_hdr(run_dir):
         hdr_list_file = os.path.join(run_dir, file_name)
         print(f"Writing file list for {file_name} into file {hdr_list_file}")
         with open(hdr_list_file, 'w') as listing_file:
-            listing_file.writelines(hdr_files)
+            for hdr_file_path in hdr_files:
+                listing_file.write(hdr_file_path + '\n')
 
         command = f"""java -cp "{simulator_home}/lib/*" \
                          com.hazelcast.simulator.utils.HistogramLogMerger \


### PR DESCRIPTION
Fix to __merge_worker_hdr step: Write all files list into a file and read from that file while processing in Java.

I also added some extra logs during hdr merge step to understand the progress since this step lasts too long. I write the log after each merged hdr like this: 
```
INFO  23:20:01 [2025-04-18 23:20:01] [HistogramLogMerger] Added merged histogram 1082 to run_dir/map.get.hdr
```

With this fix, the report generation can be run on lab servers. I ran it on lab server 1. I was able to generate the 12k report on lab server 101 in 1.5 hours.
```
47413.55user 4561.21system 1:30:34elapsed 956%CPU
```

Out of this 1/5 hours, 
- 30 mins is hdr_merge step. 
- 20 mins: Processing hdr files: Done 1219.31 seconds
- 6 mins: Loading csv files.
- 26 mins: Writing combined run data to: /home/ihsan/hazelcast-simulator/tmp/my_report/data.csv
- 7 min : Generating png files.

Given these times. The next improvement for further speedup would be to focus on the highest ones and see if we can speed them up. For example, the step `Writing combined run data to: /home/ihsan/hazelcast-simulator/tmp/my_report/data.csv` taking 26 mins seems like a candidate for improvement.

The problem without the fix was:

```
INFO  11:28:25 Using the following run:
INFO  11:28:25        09-04-2025_12-47-55 runs/3k_clients_test_near_cache_disabled/09-04-2025_12-47-55
INFO  11:28:27  Merging operations dataframes
INFO  11:28:30 Completed merging operations dataframes
INFO  11:28:30  Finished merging dataframes in 2.5143046379089355 seconds.
INFO  11:28:30 Starting worker hdr file merge
Traceback (most recent call last):
  File "/home/ihsan/hazelcast-simulator/bin/../src/perftest_cli.py", line 63, in <module>
    PerftestCli()
  File "/home/ihsan/hazelcast-simulator/bin/../src/perftest_cli.py", line 37, in __init__
    getattr(self, args.command)()
  File "/home/ihsan/hazelcast-simulator/bin/../src/perftest_cli.py", line 58, in report
    PerfTestReportCli(sys.argv[2:])
  File "/home/ihsan/hazelcast-simulator/src/simulator/perftest_report.py", line 262, in __init__
    prepare(config)
  File "/home/ihsan/hazelcast-simulator/src/simulator/perftest_report.py", line 28, in prepare
    prepare_hdr(config)
  File "/home/ihsan/hazelcast-simulator/src/simulator/perftest_report_hdr.py", line 22, in prepare_hdr
    __merge_worker_hdr(run_dir)
  File "/home/ihsan/hazelcast-simulator/src/simulator/perftest_report_hdr.py", line 47, in __merge_worker_hdr
    shell(f"""java -cp "{simulator_home}/lib/*" \
  File "/home/ihsan/hazelcast-simulator/src/simulator/util.py", line 163, in shell
    process = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=shell)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1022, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1899, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 7] Argument list too long: '/bin/sh'
```
