### PR TITLE
Add driver support for multiple clients per worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Please refer to the [Quickstart](#quickstart) to start your Simulator journey.
     * [Network constraints](#network-constraints)
     * [CP subsystem leader priority](#cp-subsystem-leader-priority)
     * [Persistence](#persistence)
-    * [Client count scaling](#client-count-scaling)
+    * [Running multiple clients per loadgenerator](#running-multiple-clients-per-loadgenerator-worker)
 - [Get Help](#get-help)
 
 # Quickstart
@@ -1892,7 +1892,7 @@ Parameters:
 
 `mount_path:` Defines the directory where the device will be mounted (e.g., /dir/to/persistence).
 
-## Client count scaling
+## Running multiple clients per loadgenerator worker
 By default, each simulator worker uses a single Hazelcast instance. For workers using the Hazelcast Java client the number of 
 clients is configurable and can be increased. This can be useful when benchmarking how a Hazelcast cluster behaves with a high 
 number of client connections as having a single client per worker process is expensive with thousands of clients. To configure this
@@ -1924,6 +1924,26 @@ fashion. For example the following config will assign each simulator test thread
 
 With `threadCount: 20` each client would have 2 threads assigned to it. If `threadCount < clients_per_loadgenerator` then the 
 extra clients will simply be ignored.
+
+### Using the clients in a test
+
+When implementing your own test it is recommended to extend `HazelcastTest`, this provides a method available to subclasses:
+
+```java
+protected final List<HazelcastInstance> getTargetInstances() {
+    // ...
+}
+```
+
+which allows access to the client instances. If you don't want to subclass this class then you can use the `@InjectDriver` 
+annotation on your own class with the `HazelcastInstances` type, like:
+
+```java
+class MySimulatorTest {
+    @InjectDriver
+    HazelcastInstances instances;
+}
+```
 
 # Get Help
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Please refer to the [Quickstart](#quickstart) to start your Simulator journey.
     * [Logging](#logging)
     * [Running multiple tests in parallel](#running-multiple-tests-in-parallel)
     * [Various forms of testing](#various-forms-of-testing)
+    * [Network constraints](#network-constraints)
+    * [CP subsystem leader priority](#cp-subsystem-leader-priority)
+    * [Persistence](#persistence)
+    * [Client count scaling](#client-count-scaling)
 - [Get Help](#get-help)
 
 # Quickstart
@@ -418,9 +422,9 @@ should be conducted in.
 | Property                               | Example value    | Description                                                                                                                                 |
 |----------------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`                                 | `read_only`      | The name of the test suite (overriden by test-specific values)                                                                              |
-| `repititions`                          | `1`              | The number of times this test suite should run (1 or more)                                                                                  |
+| `repetitions`                          | `1`              | The number of times this test suite should run (1 or more)                                                                                  |
 | `duration`                             | `300s`           | The amount of time this test suite should run for (45m, 1h, 2d, etc.)                                                                       |
-| `clients`                              | `1`              | The number of Hazelcast Clients to use in this test suite (hosted on `loadgenerator_hosts`                                                  |
+| `clients`                              | `1`              | The number of loadgenerator workers to use in this test suite (hosted on `loadgenerator_hosts`                                              |
 | `members`                              | `1`              | The number of Hazelcast Members to use in this test suite (hosted on `node_hosts`)                                                          |
 | `loadgenerator_hosts`                  | `loadgenerators` | Defines the host for Clients, based on either `loadgenerators` or `nodes`, allowing both separate and mixed client/member setups            |
 | `node_hosts`                           | `nodes`          | Defines the host for Members - this should generally always be `nodes`, and only `loadgenerator_hosts` should be changed for mixed testing. |
@@ -435,6 +439,7 @@ should be conducted in.
 | `license_key`                          | `your_ee_key`    | The Hazelcast Enterprise Edition license to use in your test, if using `hazelcast-enterprise5` drivers                                      |
 | `parallel`                             | `True`           | Defines whether tests should be run in parallel when multiple tests are defined within 1 suite (default false)                              |
 | `cp_priorities` | <pre>- address: internalIp<br> &nbsp;priority: 1</pre> | Defines the leadership priority of the CP Subsystem members in the cluster. Use the internal IP address of the agent(s) you wish to configure. |
+| `clients_per_loadgenerator`            | `1`              | The number of Hazelcast client instances per loadgenerator worker (default 1)                                                               |
 
 ### Specify test class(es) and number of threads per worker
 
@@ -1887,6 +1892,38 @@ Parameters:
 
 `mount_path:` Defines the directory where the device will be mounted (e.g., /dir/to/persistence).
 
+## Client count scaling
+By default, each simulator worker uses a single Hazelcast instance. For workers using the Hazelcast Java client the number of 
+clients is configurable and can be increased. This can be useful when benchmarking how a Hazelcast cluster behaves with a high 
+number of client connections as having a single client per worker process is expensive with thousands of clients. To configure this
+value you can set the `clients_per_loadgenerator` value in the `tests.yaml` file. For example the following snippet will configure
+600 loadgenerator processes each with 10 Hazelcast client instances
+
+```yaml
+- name: many_clients_test
+  duration: 5m
+  repetitions: 1
+  node_count: 10
+  loadgenerator_count: 600
+  clients_per_loadgenerator: 10
+  driver: hazelcast-enterprise5
+  # ...
+```
+
+How the clients are used is **test specific** and most current test implementations simply ignore all but one of the clients. One
+test which works with multiple clients is `LongByteArrayMapTest` which evenly assigns simulator threads to clients in a many to 1 
+fashion. For example the following config will assign each simulator test thread a single client.
+
+```yaml
+    - class: com.hazelcast.simulator.tests.map.LongByteArrayMapTest
+      name: map
+      threadCount: 10
+      getProb: 0.9
+      putProb: 0.1
+```
+
+With `threadCount: 20` each client would have 2 threads assigned to it. If `threadCount < clients_per_loadgenerator` then the 
+extra clients will simply be ignored.
 
 # Get Help
 

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/Hazelcast4PlusMultiDriver.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/Hazelcast4PlusMultiDriver.java
@@ -1,0 +1,56 @@
+package com.hazelcast.simulator.hazelcast4plus;
+
+import com.hazelcast.simulator.drivers.Driver;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Hazelcast4PlusMultiDriver
+        extends Driver<HazelcastInstances> {
+
+    private static final String CLIENT_COUNT_PROPERTY = "clients_per_loadgenerator";
+    private static final String WORKER_TYPE_PROPERTY = "WORKER_TYPE";
+    private static final String CLIENT_TYPE = "javaclient";
+
+    private final List<Hazelcast4PlusDriver> delegates = new ArrayList<>();
+    private HazelcastInstances instances;
+
+    @Override
+    public HazelcastInstances getDriverInstance() {
+        return instances;
+    }
+
+    @Override
+    public void startDriverInstance()
+            throws Exception {
+        String workerType = get(WORKER_TYPE_PROPERTY);
+        int clientsPerLoadGenerator = Integer.parseInt(get(CLIENT_COUNT_PROPERTY, "1"));
+        int instancesCount = CLIENT_TYPE.equals(workerType) ? clientsPerLoadGenerator : 1;
+        for (int i = 0; i < instancesCount; i++) {
+            Hazelcast4PlusDriver delegate = new Hazelcast4PlusDriver();
+            delegate.setAll(properties);
+            delegate.startDriverInstance();
+            delegates.add(delegate);
+        }
+        instances = new HazelcastInstances(delegates.stream().map(Hazelcast4PlusDriver::getDriverInstance).toList());
+    }
+
+    @Override
+    public void close()
+            throws IOException {
+        IOException err = null;
+        for (var delegate : delegates) {
+            try {
+                delegate.close();
+            } catch (IOException e) {
+                if (err == null) {
+                    err = e;
+                } else {
+                    err.addSuppressed(e);
+                }
+            }
+        }
+        if (err != null) throw err;
+    }
+}

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/Hazelcast4PlusMultiDriver.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/Hazelcast4PlusMultiDriver.java
@@ -40,7 +40,7 @@ public class Hazelcast4PlusMultiDriver
     public void close()
             throws IOException {
         IOException err = null;
-        for (var delegate : delegates) {
+        for (Hazelcast4PlusDriver delegate : delegates) {
             try {
                 delegate.close();
             } catch (IOException e) {

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/HazelcastInstances.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hazelcast4plus/HazelcastInstances.java
@@ -1,0 +1,30 @@
+package com.hazelcast.simulator.hazelcast4plus;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.simulator.drivers.Convertible;
+
+import java.util.List;
+
+public class HazelcastInstances implements Convertible {
+
+    private final List<HazelcastInstance> values;
+
+    public HazelcastInstances(List<HazelcastInstance> values) {
+        this.values = List.copyOf(values);
+    }
+
+    public List<HazelcastInstance> values() {
+        return values;
+    }
+
+    @Override
+    public Object convertTo(Class<?> target) {
+        if (HazelcastInstances.class.equals(target)) {
+            return this;
+        } else if (HazelcastInstance.class.equals(target)) {
+            return values.isEmpty() ? null : values.get(0);
+        } else {
+            return null;
+        }
+    }
+}

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hz/HazelcastTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hz/HazelcastTest.java
@@ -17,12 +17,14 @@ package com.hazelcast.simulator.hz;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
+import com.hazelcast.simulator.hazelcast4plus.HazelcastInstances;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.InjectTestContext;
 import com.hazelcast.simulator.test.annotations.InjectDriver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 
 /**
  * An Abstract Hazelcast Test that provides basic behavior so it doesn't need to be repeated for every test.
@@ -46,6 +48,13 @@ public abstract class HazelcastTest {
 
     @InjectDriver
     protected HazelcastInstance targetInstance;
+
+    @InjectDriver
+    private HazelcastInstances targetInstances;
+
+    protected final List<HazelcastInstance> getAllInstances() {
+        return targetInstances == null ? null : targetInstances.values();
+    }
 
     public IAtomicLong getAtomicLong(String name) {
         return targetInstance.getDistributedObject("hz:impl:atomicLongService", name);

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hz/HazelcastTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/hz/HazelcastTest.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An Abstract Hazelcast Test that provides basic behavior so it doesn't need to be repeated for every test.
@@ -52,8 +53,11 @@ public abstract class HazelcastTest {
     @InjectDriver
     private HazelcastInstances targetInstances;
 
-    protected final List<HazelcastInstance> getAllInstances() {
-        return targetInstances == null ? null : targetInstances.values();
+    protected final List<HazelcastInstance> getTargetInstances() {
+        if (targetInstances == null) {
+            throw new IllegalStateException("Cannot access injected field until it has been initialised");
+        }
+        return targetInstances.values();
     }
 
     public IAtomicLong getAtomicLong(String name) {

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -37,9 +37,14 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.stream.IntStream;
 
+import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.assignKeyToIndex;
 import static com.hazelcast.simulator.utils.GeneratorUtils.generateByteArrays;
+import static java.lang.Thread.currentThread;
+import static java.util.Comparator.comparingInt;
 
 public class LongByteArrayMapTest extends HazelcastTest {
 
@@ -69,6 +74,9 @@ public class LongByteArrayMapTest extends HazelcastTest {
     private final Executor callerRuns = Runnable::run;
     private final Random random = new Random();
 
+    // Tracks which thread is assigned which client by its index
+    private final Map<Thread, Integer> clientIndexForThread = new ConcurrentHashMap<>();
+
     @Setup
     public void setUp() {
         for (var instance : getTargetInstances()) {
@@ -96,7 +104,18 @@ public class LongByteArrayMapTest extends HazelcastTest {
     }
 
     private IMap<Long, byte[]> getRandomMap() {
-        return maps.get(random.nextInt(maps.size())).get(random.nextInt(mapCount));
+        List<IMap<Long, byte[]>> mapsToSelectFrom;
+        if (maps.size() == 1) {
+            mapsToSelectFrom = maps.get(0);
+        } else {
+            Integer clientIndex = clientIndexForThread.get(currentThread());
+            mapsToSelectFrom = maps.get(clientIndex == null ? putClientForCurrentThread() : clientIndex);
+        }
+        return mapsToSelectFrom.get(random.nextInt(mapCount));
+    }
+
+    private synchronized int putClientForCurrentThread() {
+        return assignKeyToIndex(getTargetInstances().size(), currentThread(), clientIndexForThread);
     }
 
     @TimeStep(prob = -1)

--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/tests/map/LongByteArrayMapTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.simulator.tests.map;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Pipelining;
 import com.hazelcast.map.IMap;
 import com.hazelcast.simulator.hz.HazelcastTest;
@@ -79,7 +80,7 @@ public class LongByteArrayMapTest extends HazelcastTest {
 
     @Setup
     public void setUp() {
-        for (var instance : getTargetInstances()) {
+        for (HazelcastInstance instance : getTargetInstances()) {
             List<IMap<Long, byte[]>> mapsForInstance = new ArrayList<>();
             maps.add(mapsForInstance);
             for (int i = 0; i < mapCount; i++) {

--- a/java/drivers/driver-hazelcast4plus/src/test/java/com/hazelcast/simulator/tests/map/helpers/AssignKeyToIndexTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/test/java/com/hazelcast/simulator/tests/map/helpers/AssignKeyToIndexTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.simulator.tests.map.helpers;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.hazelcast.simulator.tests.helpers.HazelcastTestUtils.assignKeyToIndex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AssignKeyToIndexTest {
+
+    @Test
+    public void test() {
+        int indexUpperBound = 5;
+        Map<String, Integer> indexMap = new HashMap<>();
+        assertThat(assignKeyToIndex(indexUpperBound, "a", indexMap), equalTo(0));
+        assertThat(assignKeyToIndex(indexUpperBound, "b", indexMap), equalTo(1));
+        assertThat(assignKeyToIndex(indexUpperBound, "c", indexMap), equalTo(2));
+        assertThat(assignKeyToIndex(indexUpperBound, "d", indexMap), equalTo(3));
+        assertThat(assignKeyToIndex(indexUpperBound, "e", indexMap), equalTo(4));
+        assertThat(assignKeyToIndex(indexUpperBound, "f", indexMap), equalTo(0));
+
+        assertThat(indexMap, equalTo(Map.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 0)));
+    }
+}

--- a/java/drivers/driver-hazelcast4plus/src/test/java/com/hazelcast/simulator/tests/map/helpers/AssignKeyToIndexTest.java
+++ b/java/drivers/driver-hazelcast4plus/src/test/java/com/hazelcast/simulator/tests/map/helpers/AssignKeyToIndexTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class AssignKeyToIndexTest {
 
     @Test
-    public void test() {
+    public void testSequentialAssignment() {
         int indexUpperBound = 5;
         Map<String, Integer> indexMap = new HashMap<>();
         assertThat(assignKeyToIndex(indexUpperBound, "a", indexMap), equalTo(0));
@@ -23,5 +23,25 @@ public class AssignKeyToIndexTest {
         assertThat(assignKeyToIndex(indexUpperBound, "f", indexMap), equalTo(0));
 
         assertThat(indexMap, equalTo(Map.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 0)));
+    }
+
+    @Test
+    public void testAssignmentToUnbalancedMap() {
+        int indexUpperBound = 3;
+        Map<String, Integer> initialMap = Map.of("a", 2, "b", 2, "c", 2, "d", 0, "e", 0, "f", 0);
+        Map<String, Integer> underTest = new HashMap<>(initialMap);
+        assertThat(assignKeyToIndex(indexUpperBound, "g", underTest), equalTo(1));
+        Map<String, Integer> expected = new HashMap<>(initialMap);
+        expected.put("g", 1);
+        assertThat(underTest, equalTo(expected));
+    }
+
+    @Test
+    public void testDuplicateAssignment() {
+        int indexUpperBound = 3;
+        Map<String, Integer> initialMap = Map.of("a", 1, "b", 2, "c", 0);
+        Map<String, Integer> underTest = new HashMap<>(initialMap);
+        assertThat(assignKeyToIndex(indexUpperBound, "a", underTest), equalTo(1));
+        assertThat(underTest, equalTo(initialMap));
     }
 }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
@@ -60,7 +60,8 @@ public class WorkerParameters {
             case "hazelcast-enterprise4", "hazelcast4", "hazelcast-enterprise5", "hazelcast5" ->
                     "com.hazelcast.simulator.hazelcast4plus.Hazelcast4PlusMultiDriver";
             default -> throw new IllegalStateException(
-                    "No default \"driver_class\" found for \"" + driver + "\" please specify it explicitly");
+                    "No default driver class found for driver \"" + driver + "\". Specify it explicitly using the "
+                            + "parameter \"driver_class\" alongside the \"driver\" parameter in tests.yaml");
         };
     }
 

--- a/java/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
@@ -58,7 +58,7 @@ public class WorkerParameters {
         return driverClassOverride != null ? driverClassOverride : switch (driver) {
             case "hazelcast-enterprise3" -> "com.hazelcast.simulator.hazelcast3.Hazelcast3Driver";
             case "hazelcast-enterprise4", "hazelcast4", "hazelcast-enterprise5", "hazelcast5" ->
-                    "com.hazelcast.simulator.hazelcast4plus.Hazelcast4PlusDriver";
+                    "com.hazelcast.simulator.hazelcast4plus.Hazelcast4PlusMultiDriver";
             default -> throw new IllegalStateException(
                     "No default \"driver_class\" found for \"" + driver + "\" please specify it explicitly");
         };

--- a/java/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/agent/workerprocess/WorkerParameters.java
@@ -52,6 +52,31 @@ public class WorkerParameters {
         }
     }
 
+    public String findDriverClass() {
+        String driverClassOverride = findDriverClassOverride();
+        String driver = findDriver();
+        return driverClassOverride != null ? driverClassOverride : switch (driver) {
+            case "hazelcast-enterprise3" -> "com.hazelcast.simulator.hazelcast3.Hazelcast3Driver";
+            case "hazelcast-enterprise4", "hazelcast4", "hazelcast-enterprise5", "hazelcast5" ->
+                    "com.hazelcast.simulator.hazelcast4plus.Hazelcast4PlusDriver";
+            default -> throw new IllegalStateException(
+                    "No default \"driver_class\" found for \"" + driver + "\" please specify it explicitly");
+        };
+    }
+
+    private String findDriverClassOverride() {
+        String driverClassOverride = map.get("driver_class");
+        if (driverClassOverride != null) {
+            return driverClassOverride;
+        }
+
+        if (getWorkerType().equals("member")) {
+            return map.get("node_driver_class");
+        } else {
+            return map.get("loadgenerator_driver_class");
+        }
+    }
+
     public Map<String, String> asMap() {
         return map;
     }

--- a/java/simulator/src/main/java/com/hazelcast/simulator/drivers/Convertible.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/drivers/Convertible.java
@@ -1,0 +1,18 @@
+package com.hazelcast.simulator.drivers;
+
+/**
+ * Used for converting driver instances into other types when binding
+ * the instance to fields via the {@link com.hazelcast.simulator.test.annotations.InjectDriver}
+ * annotation.
+ */
+public interface Convertible {
+    /**
+     * Converts this object into the target type. Note any class which
+     * implements this interface <b>must</b> support the identity conversion,
+     * i.e. converting to its own class by returning itself (or a copy).
+     *
+     * @param target The type to convert the instance to
+     * @return The converted instance if the type is supported, null otherwise
+     */
+    Object convertTo(Class<?> target);
+}

--- a/java/simulator/src/main/java/com/hazelcast/simulator/drivers/Driver.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/drivers/Driver.java
@@ -15,23 +15,17 @@
  */
 package com.hazelcast.simulator.drivers;
 
-import com.hazelcast.simulator.agent.workerprocess.WorkerParameters;
 import com.hazelcast.simulator.coordinator.registry.AgentData;
 import com.hazelcast.simulator.utils.CommandLineExitException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.simulator.utils.FileUtils.fileAsText;
-import static com.hazelcast.simulator.utils.FileUtils.getConfigurationFile;
-import static com.hazelcast.simulator.utils.FileUtils.getSimulatorHome;
 import static java.lang.String.format;
 
 public abstract class Driver<V> implements Closeable {
@@ -41,36 +35,23 @@ public abstract class Driver<V> implements Closeable {
     protected Map<String, String> properties = new HashMap<>();
     private final Map<String, String> configCache = new HashMap<>();
 
-    public static Driver loadDriver(String driver) {
-        LOGGER.info(format("Loading driver [%s]", driver));
-
-        if ("hazelcast-enterprise4".equals(driver)
-                || "hazelcast4".equals(driver)
-                || "hazelcast-enterprise5".equals(driver)
-                || "hazelcast5".equals(driver)) {
-            // The 'P' is intentionally uppercase to match the driver name
-            return loadInstance("hazelcast4Plus");
-        } else if ("hazelcast-enterprise3".equals(driver)) {
-            return loadInstance("hazelcast3");
-        } else {
-            return loadInstance(driver);
-        }
+    public static Driver loadDriver(String driverClass) {
+        LOGGER.info("Loading driver [{}]", driverClass);
+        return loadInstance(driverClass);
     }
 
-    private static Driver loadInstance(String driver) {
-        String driverName = "com.hazelcast.simulator." + driver.toLowerCase() + "."
-                + driver.substring(0, 1).toUpperCase() + driver.substring(1) + "Driver";
+    private static Driver loadInstance(String driverClassName) {
         Class driverClass;
         try {
-            driverClass = Driver.class.getClassLoader().loadClass(driverName);
+            driverClass = Driver.class.getClassLoader().loadClass(driverClassName);
         } catch (ClassNotFoundException e) {
-            throw new CommandLineExitException(format("Could not locate driver class [%s]", driverName));
+            throw new CommandLineExitException(format("Could not locate driver class [%s]", driverClassName));
         }
 
         try {
             return (Driver) driverClass.newInstance();
         } catch (Exception e) {
-            throw new CommandLineExitException(format("Failed to create an instance of driver [%s]", driverName), e);
+            throw new CommandLineExitException(format("Failed to create an instance of driver [%s]", driverClassName), e);
         }
     }
 

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/Worker.java
@@ -68,9 +68,7 @@ public class Worker {
         this.publicAddress = parameters.get("PUBLIC_ADDRESS");
         this.workerAddress = SimulatorAddress.fromString(parameters.get("WORKER_ADDRESS"));
 
-        String driverString = parameters.findDriver();
-        this.driver = loadDriver(driverString)
-                .setAll(parameters.asMap());
+        this.driver = loadDriver(parameters.findDriverClass()).setAll(parameters.asMap());
         this.server = new Server("workers")
                 .setBrokerURL(localIp(), parseInt(parameters.get("AGENT_PORT")))
                 .setSelfAddress(workerAddress);

--- a/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
+++ b/java/simulator/src/main/java/com/hazelcast/simulator/worker/testcontainer/PropertyBinding.java
@@ -18,6 +18,7 @@ package com.hazelcast.simulator.worker.testcontainer;
 import com.hazelcast.simulator.common.TestCase;
 import com.hazelcast.simulator.probes.LatencyProbe;
 import com.hazelcast.simulator.probes.impl.HdrLatencyProbe;
+import com.hazelcast.simulator.drivers.Convertible;
 import com.hazelcast.simulator.test.TestContext;
 import com.hazelcast.simulator.test.annotations.InjectTestContext;
 import com.hazelcast.simulator.test.annotations.InjectDriver;
@@ -211,10 +212,16 @@ public class PropertyBinding {
             if (driverInstance == null) {
                 throw new IllegalTestException("No driver found");
             }
-
-            Class driverType = driverInstance.getClass();
+            Object valueToSet = driverInstance;
+            if (valueToSet instanceof Convertible c) {
+                Object converted = c.convertTo(fieldType);
+                if (converted != null) {
+                    valueToSet = converted;
+                }
+            }
+            Class<?> driverType = valueToSet.getClass();
             assertFieldType(driverType, fieldType, InjectDriver.class);
-            setFieldValue(object, field, driverInstance);
+            setFieldValue(object, field, valueToSet);
         }
     }
 


### PR DESCRIPTION
Currently the simulator only supports one hazelcast client per loadgenerator worker process. This means if you want to run experiments to see the behaviour of a cluster with many client connections you need to create many processes and this means larger test setup times, more expensive tests and slower report generation. 

This PR adds a new driver and configuration parameter to the tests.yaml "clients_per_loadgenerator" which allow you to create multiple clients for each loadgenerator while retaining backwards compatibility with existing tests.

It also adds the ability to change the driver class used with configuration making it easier to add new driver implementations in future.