### PR TITLE
Feat: Add support for running benchmarks against existing Hazelcast clusters

### DIFF
--- a/src/inventory_cli.py
+++ b/src/inventory_cli.py
@@ -6,6 +6,7 @@ from os import path
 
 from simulator.inventory_terraform import terraform_import, terraform_destroy, terraform_apply
 from simulator.inventory_lab import lab_apply, lab_destroy
+from simulator.inventory_existing_cluster import existing_cluster_apply, existing_cluster_destroy
 from simulator.util import load_yaml_file, exit_with_error, simulator_home, shell, now_seconds
 from simulator.log import info, log_header
 from simulator.ssh import new_key
@@ -320,6 +321,8 @@ class InventoryApplyCli:
                 terraform_apply(inventory_plan, force)
             case "lab":
                 lab_apply(inventory_plan)
+            case "existing-cluster":
+                existing_cluster_apply(inventory_plan)    
             case _:
                 exit_with_error(f"Unrecognized provisioner [{provisioner}]")
 
@@ -353,6 +356,8 @@ class InventoryDestroyCli:
                 terraform_destroy(inventory_plan, force=True)
             case "lab":
                 lab_destroy()
+            case "existing-cluster":
+                existing_cluster_destroy()                
             case _:
                 exit_with_error(f"Unrecognized provisioner [{provisioner}]")
 

--- a/src/simulator/inventory_existing_cluster.py
+++ b/src/simulator/inventory_existing_cluster.py
@@ -1,0 +1,83 @@
+import yaml
+import os
+import glob
+import re
+
+__INVENTORY_FILE = "inventory.yaml"
+__AGENT_START_PATH = os.path.join("..", "bin", "hidden", "agent_start")
+
+
+def existing_cluster_destroy():
+    try:
+        os.remove(__INVENTORY_FILE)
+    except OSError:
+        pass
+
+def existing_cluster_apply(inventory_plan):
+
+    cluster_name = inventory_plan.get("cluster_name", "default-cluster")
+
+    # Generate inventory.yaml
+    inventory = __generate_inventory_for_existing_cluster(inventory_plan)
+    __write_yaml(__INVENTORY_FILE, inventory)
+
+    # Replace placeholders in files
+    __substitute_cluster_name(cluster_name)
+
+    # Replace java kill block in script
+    __replace_java_kill_block(__AGENT_START_PATH)
+
+def __generate_inventory_for_existing_cluster(plan):
+    def format_hosts(entries):
+        return {
+            entry["public_ip"]: {
+                "ansible_ssh_private_key_file": "key",
+                "ansible_user": entry["user"],
+                "private_ip": entry["private_ip"]
+            }
+            for entry in entries
+        }
+
+    return {
+        "loadgenerators": {"hosts": format_hosts(plan.get("loadgenerators", []))},
+        "nodes": {"hosts": format_hosts(plan.get("nodes", []))}
+    }
+
+def __write_yaml(path, data):
+    with open(path, 'w') as f:
+        yaml.dump(data, f, default_flow_style=False)
+
+def __substitute_cluster_name(cluster_name, search_dir="."):
+    placeholder_start = "<cluster-name>"
+    placeholder_end = "</cluster-name>"
+    for filepath in glob.glob(os.path.join(search_dir, "**"), recursive=True):
+        if not os.path.isfile(filepath) or filepath.endswith(".yaml"):
+            continue
+        with open(filepath, "r") as file:
+            content = file.read()
+        if placeholder_start in content:
+            new_content = content.replace(
+                f"{placeholder_start}{cluster_name}{placeholder_end}", cluster_name
+            )
+            with open(filepath, "w") as file:
+                file.write(new_content)
+
+def __replace_java_kill_block(file_path):
+    with open(file_path, 'r') as file:
+        lines = file.readlines()
+
+    inside_block = False
+    new_lines = []
+    for line in lines:
+        if re.match(r'\s*if\s+hash\s+killall', line):
+            inside_block = True
+            new_lines.append("pkill -9 -f 'java.*hazelcast-simulator.*' || true\n")
+            continue
+        if inside_block and re.match(r'\s*fi\s*', line):
+            inside_block = False
+            continue
+        if not inside_block:
+            new_lines.append(line)
+
+    with open(file_path, 'w') as file:
+        file.writelines(new_lines)

--- a/src/simulator/inventory_lab.py
+++ b/src/simulator/inventory_lab.py
@@ -30,7 +30,6 @@ def lab_apply(inventory_plan):
     with open(__INVENTORY_FILE, 'w') as f:
         f.write(yaml.dump(output))
 
-
 def __configure_group_inventory(group_plan, lab_addresses, bandwidth):
     output = {}
     group_size = group_plan["count"]

--- a/templates/hazelcast5-existing-cluster/.gitignore
+++ b/templates/hazelcast5-existing-cluster/.gitignore
@@ -1,0 +1,14 @@
+*/terraform.tfstate
+*/terraform.tfstate.backup
+*/.terraform
+*/.terraform.lock.hcl
+*/.terraform.tfstate.lock.info
+key.pub
+key
+*.kate-swp
+*.jfr
+venv/
+/.idea/
+/runs/
+/logs/
+inventory.yaml

--- a/templates/hazelcast5-existing-cluster/README.md
+++ b/templates/hazelcast5-existing-cluster/README.md
@@ -1,0 +1,86 @@
+# Hazelcast Simulator – Existing Cluster Template
+
+This template is designed to run Hazelcast Simulator on an existing cluster. It allows you to define node and load generator IPs and user credentials, and run performance tests without provisioning new infrastructure.
+
+## 🔐 SSH Access Requirement
+
+Ensure that your SSH public key (`key.pub`) is added to the `~/.ssh/authorized_keys` file on **all nodes and load generators**. This is required for passwordless SSH access.
+
+## Modify the Environment
+
+Edit the `inventory_plan.yaml` file to specify your cluster setup:
+- `cluster_name`
+- IP addresses and SSH users for `nodes` and `loadgenerators`
+
+## Apply the Inventory
+
+To generate the environment configuration:
+```bash
+inventory apply
+```
+
+## View the Environment
+To review the generated inventory and verify the available instances:
+
+```bash
+cat inventory.yaml
+```
+
+## Install Dependencies
+Install Java and the Hazelcast Simulator on the configured instances:
+
+```bash
+inventory install java
+inventory install simulator
+```
+
+## Tune the Environment
+To optimize the environment for performance:
+
+```bash
+inventory tune
+```
+## Configure and Run Tests
+Modify the tests by editing the tests.yaml file.
+
+To run the performance tests:
+
+```bash
+perftest run
+```
+
+## To clean up the inventory:
+
+```bash
+inventory destroy
+```
+
+## Example inventory_plan.yaml
+
+```yaml
+provisioner: existing-cluster
+
+cluster_name: test-cluster
+
+nodes:
+  - private_ip: 10.0.0.10
+    public_ip: 10.0.0.10
+    user: root
+
+  - private_ip: 10.0.0.11
+    public_ip: 10.0.0.11
+    user: root
+
+  - private_ip: 10.0.0.12
+    public_ip: 10.0.0.12
+    user: root
+
+loadgenerators:
+  - private_ip: 10.0.0.21
+    public_ip: 10.0.0.21
+    user: root
+
+  - private_ip: 10.0.0.22
+    public_ip: 10.0.0.22
+    user: root
+```

--- a/templates/hazelcast5-existing-cluster/ansible.cfg
+++ b/templates/hazelcast5-existing-cluster/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+host_key_checking = False
+inventory = inventory.yaml
+
+
+# For nice formatted output
+stdout_callback = yaml
+bin_ansible_callbacks = True
+
+interpreter_python=auto_silent

--- a/templates/hazelcast5-existing-cluster/async-tests.yaml
+++ b/templates/hazelcast5-existing-cluster/async-tests.yaml
@@ -1,0 +1,41 @@
+# Using asynchronous load generation.
+#
+# So instead of having thread per request, a concurrency level is specified. And the load
+# generator will keep that number of concurrent request using the IMap async methods.
+# With synchronous load generation, the clients can quickly become a bottleneck, especially
+# when testing high throughput due to context switching. With async load generation this is much less
+# if a problem since there are fewer threads involved. So they are a much better alternative to do
+# throughput testing.
+
+- name: read_only
+  duration: 300s
+  repetitions: 1
+  clients: 1
+  members: 0
+  driver: hazelcast5
+  version: maven=5.3.0
+  client_args: >
+    -Xms3g
+    -Xmx3g
+    --add-modules java.se 
+    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED 
+    --add-opens java.base/java.lang=ALL-UNNAMED 
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED 
+    --add-opens java.management/sun.management=ALL-UNNAMED 
+    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+  loadgenerator_hosts: loadgenerators
+  node_hosts: nodes
+  verify_enabled: False
+  performance_monitor_interval_seconds: 1
+  warmup_seconds: 0
+  cooldown_seconds: 0
+    - class: com.hazelcast.simulator.hz.map.AsyncLongStringMapTest
+      name: map
+      getProb: 1
+      putProb: 0
+      setProb: 0
+      concurrency: 100
+      keyDomain: 1_000_000
+      valueCount: 100
+      minValueLength: 100
+      maxValueLength: 100

--- a/templates/hazelcast5-existing-cluster/client-hazelcast.xml
+++ b/templates/hazelcast5-existing-cluster/client-hazelcast.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client
+        xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+            http://www.hazelcast.com/schema/config/hazelcast-client-config-5.0.xsd"
+        xmlns="http://www.hazelcast.com/schema/client-config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <cluster-name>default-cluster</cluster-name>
+
+    <network>
+        <cluster-members>
+            <!--MEMBERS-->
+        </cluster-members>
+    </network>
+
+    <properties>
+        <property name="hazelcast.logging.type">log4j2</property>
+    </properties>
+
+</hazelcast-client>

--- a/templates/hazelcast5-existing-cluster/hazelcast.xml
+++ b/templates/hazelcast5-existing-cluster/hazelcast.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
+
+    <cluster-name>default-cluster</cluster-name>
+
+    <!--LITE_MEMBER_CONFIG-->
+
+    <network>
+        <port port-count="200">5701</port>
+
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <!--MEMBERS-->
+            </tcp-ip>
+        </join>
+    </network>
+
+    <properties>
+        <property name="hazelcast.phone.home.enabled">false</property>
+        <property name="hazelcast.logging.type">log4j2</property>
+    </properties>
+
+    <!--LICENSE-KEY-->
+
+</hazelcast>
+

--- a/templates/hazelcast5-existing-cluster/inventory_plan.yaml
+++ b/templates/hazelcast5-existing-cluster/inventory_plan.yaml
@@ -1,0 +1,13 @@
+provisioner: existing-cluster
+
+cluster_name: <cluster_name>
+
+nodes:
+    private_ip: <private_ip>
+    public_ip: <public_ip>
+    user: <ssh_username>
+
+loadgenerators:
+    private_ip: <private_ip>
+    public_ip: <public_ip>
+    user: <ssh_username>

--- a/templates/hazelcast5-existing-cluster/setup
+++ b/templates/hazelcast5-existing-cluster/setup
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script will setup the environment
+
+set -e
+
+inventory apply
+
+inventory install java --url https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz
+
+inventory install simulator

--- a/templates/hazelcast5-existing-cluster/teardown
+++ b/templates/hazelcast5-existing-cluster/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script will teardown the environment
+
+set -e
+
+inventory destroy

--- a/templates/hazelcast5-existing-cluster/tests.yaml
+++ b/templates/hazelcast5-existing-cluster/tests.yaml
@@ -1,0 +1,33 @@
+- name: read_only
+  duration: 300s
+  repetitions: 1
+  clients: 1
+  members: 0
+  driver: hazelcast5
+  version: maven=5.3.0
+  client_args: >
+    -Xms3g
+    -Xmx3g
+    --add-modules java.se 
+    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED 
+    --add-opens java.base/java.lang=ALL-UNNAMED 
+    --add-opens java.base/sun.nio.ch=ALL-UNNAMED 
+    --add-opens java.management/sun.management=ALL-UNNAMED 
+    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+  loadgenerator_hosts: loadgenerators
+  node_hosts: nodes
+  verify_enabled: False
+  performance_monitor_interval_seconds: 1
+  warmup_seconds: 0
+  cooldown_seconds: 0
+  test:
+    - class: com.hazelcast.simulator.tests.map.LongByteArrayMapTest
+      name: map
+      threadCount: 40
+      getProb: 1
+      putProb: 0
+      keyDomain: 1_000_000
+      valueCount: 100
+      minValueLength: 1_000
+      maxValueLength: 1_000
+


### PR DESCRIPTION
Currently, the Hazelcast Simulator assumes full control over the lifecycle of Hazelcast members by starting its own cluster during test execution. However, there are valid use cases, such as pre-provisioned or managed environments (IBM LinuxONE), where users need to run benchmarks against an existing Hazelcast cluster.

This pull request introduces functionality and new template that allows the simulator to connect to and execute benchmarks against a pre-existing Hazelcast cluster without launching its own members. This improves the flexibility and applicability of the simulator in more complex or enterprise-grade environments.
