### PR TITLE
Only use public enterprise repo

### DIFF
--- a/java/drivers/driver-hazelcast4plus/conf/install.py
+++ b/java/drivers/driver-hazelcast4plus/conf/install.py
@@ -71,7 +71,7 @@ def _get_remote_repo(is_enterprise:bool, version:str):
         if version.endswith("-SNAPSHOT"):
             # maven ignores settings.xml authentication unless forced with fully qualified remoteRepositories construct
             # https://maven.apache.org/plugins/maven-dependency-plugin/get-mojo.html
-            return "snapshot-internal::::https://repository.hazelcast.com/snapshot-internal"
+            return "snapshot::::https://repository.hazelcast.com/snapshot/"
         else:
             return "https://repository.hazelcast.com/release"
 

--- a/java/drivers/driver-hazelcast4plus/pom.xml
+++ b/java/drivers/driver-hazelcast4plus/pom.xml
@@ -67,12 +67,6 @@
 
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-enterprise</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,28 +27,6 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>snapshot-internal</id>
-            <name>Hazelcast Internal Snapshots</name>
-            <url>https://repository.hazelcast.com/snapshot-internal/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-          </repository>
-          <repository>
-            <id>release-internal</id>
-            <name>Hazelcast Internal</name>
-            <url>https://repository.hazelcast.com/release</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-          </repository>
     </repositories>
 
     <properties>

--- a/java/settings.xml
+++ b/java/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-    <servers>
-        <server>
-            <id>snapshot-internal</id>
-            <username>${env.HZ_SNAPSHOT_INTERNAL_USERNAME}</username>
-            <password>${env.HZ_SNAPSHOT_INTERNAL_PASSWORD}</password>
-        </server>
-    </servers>
-</settings>


### PR DESCRIPTION
Ensures that users without hazelcast credentials can use the simulator tooling. This is a temporary solution. The user must have an enterprise license and use   `driver: hazelcast-enterprise5`