### PR TITLE
Relabel `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT` [CTT-504]

### DIFF
--- a/java/drivers/driver-hazelcast4plus/pom.xml
+++ b/java/drivers/driver-hazelcast4plus/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <hazelcast.version>6.0.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.6.0-SNAPSHOT</hazelcast.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
         <netty.version>4.1.119.Final</netty.version>
         <netty-tcnative.version>2.0.70.Final</netty-tcnative.version>


### PR DESCRIPTION
Renames the version on `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT`.

Supports https://github.com/hazelcast/hazelcast-mono/pull/4852

Fixes: [CTT-504](https://hazelcast.atlassian.net/browse/CTT-504)

[CTT-504]: https://hazelcast.atlassian.net/browse/CTT-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ