### PR TITLE
Fix BuildInfoUtilsTest after change to 5.6 [CTT-504]

### DIFF
--- a/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/BuildInfoUtils.java
+++ b/java/drivers/driver-hazelcast4plus/src/main/java/com/hazelcast/simulator/utils/BuildInfoUtils.java
@@ -35,8 +35,8 @@ import static java.lang.String.format;
 
 public final class BuildInfoUtils {
 
-    static final int DEFAULT_MAJOR_VERSION = 6;
-    static final int DEFAULT_MINOR_VERSION = 0;
+    static final int DEFAULT_MAJOR_VERSION = 5;
+    static final int DEFAULT_MINOR_VERSION = 6;
 
     static final int DEFAULT_FALLBACK_MAJOR_VERSION = 5;
     static final int DEFAULT_FALLBACK_MINOR_VERSION = 3;


### PR DESCRIPTION
The test was not updated in https://github.com/hazelcast/hazelcast-simulator/pull/2285