### PR TITLE
fix: Replace invalid failure() and cancelled() functions with job.status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
 
       - name: Setup Java
         uses: actions/setup-java@v4
+        env: 
+          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -74,9 +78,6 @@ jobs:
 
       - name: Build Java artifacts (required for Docker build)
         id: java-build
-        env: 
-          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
         run: |
           echo "Building Java components..."
           ./build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: master
 
 env:
-  IMAGE_NAME: ${{ vars.IMAGE_NAME }}  # hazelcast/simulator
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }} # hazelcast/simulator
   PYTHON_VERSION: "3.11"
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
   LOCAL_REGISTRY_IMAGE: localhost:5000/${{ vars.IMAGE_NAME }}:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,9 @@ jobs:
           
           # Determine overall workflow status
           OVERALL_STATUS="Success"
-          if [ "${{ failure() }}" = "true" ]; then
+          if [ "${{ job.status }}" = "failure" ]; then
             OVERALL_STATUS="Failed"
-          elif [ "${{ cancelled() }}" = "true" ]; then
+          elif [ "${{ job.status }}" = "cancelled" ]; then
             OVERALL_STATUS="Cancelled"
           fi
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ on:
     branches: master
 
 env:
-  IMAGE_NAME: ${{ vars.IMAGE_NAME }} # hazelcast/simulator
+  IMAGE_NAME: hazelcast/simulator
   PYTHON_VERSION: "3.11"
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
-  LOCAL_REGISTRY_IMAGE: localhost:5000/${{ vars.IMAGE_NAME }}:test
+  LOCAL_REGISTRY_IMAGE: localhost:5000/hazelcast/simulator:test
 
 jobs:
   docker-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,10 @@ on:
     branches: master
 
 env:
-  IMAGE_NAME: hazelcast/simulator
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
   PYTHON_VERSION: "3.11"
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
-  LOCAL_REGISTRY_IMAGE: localhost:5000/hazelcast/simulator:test
-  HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-  HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+  LOCAL_REGISTRY_IMAGE: localhost:5000/${{ vars.IMAGE_NAME }}:test
 
 
 jobs:
@@ -76,6 +74,9 @@ jobs:
 
       - name: Build Java artifacts (required for Docker build)
         id: java-build
+        env: 
+          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
         run: |
           echo "Building Java components..."
           ./build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ env:
   PYTHON_VERSION: "3.11"
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
   LOCAL_REGISTRY_IMAGE: localhost:5000/hazelcast/simulator:test
+  HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
+  HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+
 
 jobs:
   docker-ci:
@@ -58,9 +61,6 @@ jobs:
 
       - name: Setup Java
         uses: actions/setup-java@v4
-        env:
-          HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
-          HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
         with:
           java-version: '17'
-          distribution: 'termurin'
+          distribution: 'temurin'
           cache: 'maven'
           server-id: snapshot-internal
           server-username: HZ_SNAPSHOT_INTERNAL_USERNAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: master
 
 env:
-  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}  # hazelcast/simulator
   PYTHON_VERSION: "3.11"
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
   LOCAL_REGISTRY_IMAGE: localhost:5000/${{ vars.IMAGE_NAME }}:test
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup Java
         uses: actions/setup-java@v4
-        env: 
+        env:
           HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
           HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
         env:
           HZ_SNAPSHOT_INTERNAL_USERNAME: ${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }}
           HZ_SNAPSHOT_INTERNAL_PASSWORD: ${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
-
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
   LOCAL_REGISTRY_IMAGE: localhost:5000/${{ vars.IMAGE_NAME }}:test
 
-
 jobs:
   docker-ci:
     name: Docker Build, Test, and Push

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,7 +12,7 @@ on:
         default: 'latest'
 
 env:
-  IMAGE_NAME: ${{ vars.IMAGE_NAME }} # hazelcast/simulator
+  IMAGE_NAME: hazelcast/simulator
 
 jobs:
   security-scan:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,7 +12,7 @@ on:
         default: 'latest'
 
 env:
-  IMAGE_NAME: hazelcast/simulator
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }} # hazelcast/simulator
 
 jobs:
   security-scan:


### PR DESCRIPTION
Fixed invalid GitHub Actions syntax in the CI workflow where non-existent `failure()` and `cancelled()` functions were being used instead of the correct `${{ job.status }}` context variable. This change ensures the build summary step can properly determine and display the overall workflow status.