### PR TITLE
Remove `awscli` from Docker image to fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,6 @@ jobs:
           echo "Testing Terraform installation..."
           docker exec "${CONTAINER_ID}" terraform version
           
-          echo "Testing AWS CLI installation..."
-          docker exec "${CONTAINER_ID}" aws --version
-          
           echo "Testing simulator commands availability..."
           docker exec "${CONTAINER_ID}" which perftest
           docker exec "${CONTAINER_ID}" which inventory

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,6 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/sh
     echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list && \
     apt-get update && apt-get install -y terraform && rm -rf /var/lib/apt/lists/*
 
-# Install AWS CLI
-RUN python${PYTHON_VERSION} -m pip install --no-cache-dir awscli
-
 # Install Python dependencies
 RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
     python${PYTHON_VERSION} -m pip install --no-cache-dir --break-system-packages --ignore-installed -r /tmp/requirements.txt
@@ -148,7 +145,6 @@ RUN echo '#!/bin/bash' > /opt/simulator/bin/simulator-welcome && \
     echo 'echo "  Java: $(java -version 2>&1 | head -n1)"' >> /opt/simulator/bin/simulator-welcome && \
     echo 'echo "  Maven: $(mvn --version 2>&1 | head -n1)"' >> /opt/simulator/bin/simulator-welcome && \
     echo 'echo "  Terraform: $(terraform version 2>&1 | head -n1)"' >> /opt/simulator/bin/simulator-welcome && \
-    echo 'echo "  AWS CLI: $(aws --version 2>&1)"' >> /opt/simulator/bin/simulator-welcome && \
     echo 'echo ""' >> /opt/simulator/bin/simulator-welcome && \
     echo 'echo "Current directory: $(pwd)"' >> /opt/simulator/bin/simulator-welcome && \
     echo 'echo "==========================================="' >> /opt/simulator/bin/simulator-welcome


### PR DESCRIPTION
[The docker build fails with a cryptic error message](https://github.com/hazelcast/hazelcast-simulator/actions/runs/26574821141/job/78291161764#step:13:263-L286):
> ImportError: cannot import name 'register_feature_id' from 'botocore.useragent' (/usr/local/lib/python3.11/dist-packages/botocore/useragent.py)

The root cause is that we install the (implicitly) latest `awscli`:
https://github.com/hazelcast/hazelcast-simulator/blob/868206378aa383848dd16b49f843343240277868/Dockerfile#L52-L53

But then subsequently install outdated dependencies with hardcoded versions which are not compatible:
https://github.com/hazelcast/hazelcast-simulator/blob/868206378aa383848dd16b49f843343240277868/requirements.txt#L3-L4

The Docker image doesn't (appear) to _need_ `awscli` - as such the simplest fix is just to remove it.