### PR TITLE
Add combined latency plot

### DIFF
--- a/src/simulator/perftest_report.py
+++ b/src/simulator/perftest_report.py
@@ -6,12 +6,12 @@ import csv
 import glob
 import shutil
 
+from simulator.perftest_report_common import *
 from simulator.perftest_report_dstat import report_dstat, analyze_dstat
 from simulator.perftest_report_hdr import report_hdr, prepare_hdr, analyze_latency_history
+from simulator.perftest_report_html import HTMLReport
 from simulator.perftest_report_operations import report_operations, prepare_operation, analyze_operations
 from simulator.util import mkdir, exit_with_error
-from simulator.perftest_report_common import *
-from simulator.perftest_report_html import HTMLReport
 
 
 def prepare(config: ReportConfig):
@@ -220,6 +220,9 @@ class PerfTestReportCli:
         parser.add_argument('-ll', '--longLabel',
                             help='Include benchmark name in run label',
                             action='store_true')
+        parser.add_argument('-cl', '--combinedLatency',
+                            help='Produce plot with all latency distributions',
+                            action='store_true')
         parser.add_argument('--width',
                             nargs=1,
                             default=[1600],
@@ -247,6 +250,7 @@ class PerfTestReportCli:
         config.worker_reporting = args.full
         config.compare_last = args.last
         config.long_label = args.longLabel
+        config.combined_latency_plot = args.combinedLatency
         config.preserve_time = args.time
         config.y_start_from_zero = args.zero
         config.svg = args.svg

--- a/src/simulator/perftest_report_common.py
+++ b/src/simulator/perftest_report_common.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
-from datetime import datetime, timezone
-
 import numpy as np
+import os
 import pandas as pd
+from datetime import datetime, timezone
 
 from simulator.log import info
 
@@ -38,6 +37,7 @@ class ReportConfig:
     worker_reporting = True
     compare_last = False
     long_label = False
+    combined_latency_plot = False
     preserve_time = False
     y_start_from_zero = False
     svg = False

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -334,6 +334,8 @@ def __report_hgrm(config: ReportConfig):
     __make_hgrm_latency_by_perc_dist_html(config, hgrm_files)
     # make_hgrm_histogram_plot(items)
     __make_latency_by_perc_dist_plot(config, hgrm_files)
+    if len(hgrm_files) > 1 and config.combined_latency_plot:
+        __make_latency_by_perc_dist_plot(config, sorted(hgrm_files), True)
 
 
 def __find_hgrm_files(config: ReportConfig, run_label):
@@ -358,11 +360,14 @@ def __find_hgrm_files(config: ReportConfig, run_label):
     return result
 
 
-def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
+def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files, combined = False):
+    first = True
     for hgrm_file_name in hgrm_files:
-        plt.figure(figsize=(config.image_width_px / config.image_dpi,
-                            config.image_height_px / config.image_dpi),
-                   dpi=config.image_dpi)
+        if not combined or first:
+            plt.figure(figsize=(config.image_width_px / config.image_dpi,
+                                config.image_height_px / config.image_dpi),
+                       dpi=config.image_dpi)
+        first = False
 
         for run_label, run_path in config.runs.items():
             dir = f"{config.report_dir}/hdr/{run_label}"
@@ -372,7 +377,8 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
                 continue
 
             df = __load_hgrm(hgrm_file)
-            plt.plot(df['1/(1-Percentile)'], df['Value'], label=run_label)
+            prefix = (Path(hgrm_file_name).stem.replace('_', ' ') + " " if combined else "")
+            plt.plot(df['1/(1-Percentile)'], df['Value'], label=prefix + run_label)
 
         plt.xscale('log')
 
@@ -391,10 +397,14 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
 
         plt.ylabel("Latency")
         plt.xlabel("Percentile")
-        plt.legend()
         plt.title(f"Latency distribution")
-        plt.grid()
         plt.gca().yaxis.set_major_formatter(FuncFormatter(format_us_time_ticks))
+
+        if combined and not first:
+            continue
+
+        plt.grid()
+        plt.legend()
 
         hgrm_file_path_no_ext = hgrm_file_name.rstrip(".hgrm")
         path = f"{config.report_dir}/latency/latency_distribution_{hgrm_file_path_no_ext}.png"
@@ -412,6 +422,21 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
         #     info(f"\tGenerating [{path}]")
         #     plotly_fig = tls.mpl_to_plotly(plt.gcf())
         #     plotly_fig.write_html(path)
+
+        plt.close()
+
+    if combined:
+        plt.grid()
+        plt.legend()
+        path = f"{config.report_dir}/latency/latency_distribution_combined.png"
+        mkdir(os.path.dirname(path))
+        info(f"\tGenerating [{path}]")
+        plt.savefig(path)
+
+        if config.svg:
+            path = f"{config.report_dir}/latency/latency_distribution_combined.svg"
+            info(f"\tGenerating [{path}]")
+            plt.savefig(path)
 
         plt.close()
 


### PR DESCRIPTION
Combined latency plot shows all latency distributions from different tests on single plot for easier comparison which is sometimes useful.