### PR TITLE
Add taskset and irqbalance configuration, asyncprofiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,8 +560,12 @@ should be conducted in.
 | `driver`                               | `hazelcast5`                                           | The Hazelcast Driver to use - for 5.0+ testing, this is either `hazelcast5` or `hazelcast-enterprise5` for OS or EE respectively                                                |
 | `version`                              | `maven=5.1`                                            | The Hazelcast version to use - typically provided by maven, i.e. `maven=5.3.0-SNAPSHOT`                                                                                         |
 | `client_args`                          | `-Xms3g -Xmx3g`                                        | The command-line Java parameters passed to all clients in this test suite                                                                                                       |
+| `client_taskset`                       | `0-7`                                                  | If nonempty, sets CPU cores avialable for client Java process using `taskset` command. Note: the same cores will be used for all worker processes if `clients > 1`              |
 | `member_args`                          | `-Xms3g -Xmx3g`                                        | The command-line Java parameters passed to all members in this test suite                                                                                                       |
+| `member_taskset`                       | `0-7`                                                  | If nonempty, set CPU cores avialable for member Java process using `taskset` command                                                                                            |
 | `performance_monitor_interval_seconds` | `1`                                                    | The interval of the Simulator performance monitor                                                                                                                               |
+| `async_profiler_duration_seconds`      | `120`                                                  | Non-empty value enables `asyncprofiler` for members with specified duration                                                                                                     |
+| `async_profiler_delay`                 | `2m`                                                   | Delay after which `asyncprofiler` will be attached. It should include time for warmup and for test initialization. Format is the same as for `sleep` command                    |
 | `verify_enabled`                       | `True`                                                 | Defines whether tests should be verified after completion or not (default true)                                                                                                 |
 | `warmup_seconds`                       | `0`                                                    | The number of seconds from the start of the test to exclude in reporting (only used for report generation)                                                                      |
 | `cooldown_seconds`                     | `0`                                                    | The number of seconds before the end of the test to exclude in reporting (only used for report generation)                                                                      |
@@ -658,7 +662,7 @@ and preload 1 million entries with a value size of exactly 10 KB, we would edit 
 ```yaml
   test:
     - class: com.hazelcast.simulator.tests.map.IntByteMapTest
-      # probabilites and thread count settings
+      # probabilities and thread count settings
       minSize: 10_000
       maxSize: 10_000
       keyCount: 1_000_000
@@ -1521,6 +1525,8 @@ Currently there is no support for dead code elimination.
 
 ## Profiling your Simulator Test
 
+### Java Flight Recorder
+
 To determine, for example, where the time is spent or other resources are being used, you want to profile your
 application.
 The recommended way to profile is using the Java Flight Recorder (JFR) which is only available in the Oracle JVMs. The
@@ -1547,6 +1553,30 @@ JFR_ARGS="-XX:+UnlockCommercialFeatures  \
 If these `JFR_ARGS` are added to the `client_args` and `member_args` properties of the `tests.yaml`, then both client
 and members will be configured with JFR. Once the Simulator test has completed, all artifacts including the JFR files
 are downloaded. The JFR files can be opened using the Java Mission Control command `jmc`.
+
+### Asyncprofiler
+
+[Asyncprofiler](https://github.com/async-profiler/async-profiler) collects more detailed profiles than JFR.
+
+In order to use asyncprofiler you must install it on the machines using the following command:
+
+```shell
+inventory install async_profiler
+```
+
+Simulator supports basic invocation of `asyncprofiler` out-of-the box. 
+It can be enabled by configuring `async_profiler_duration_seconds` and `async_profiler_delay` for your test.
+More advanced configuration is possible by adjusting `worker.sh` script.
+Asyncprofiler will be attached to all members. Note that it causes some small overhead.
+Profile will be written to `profiler.jfr` file and can be analysed by any tool supporting JFR files like Java Mission Control.
+
+It is recommended to add the following settings to `member_args`:
+```
+    -XX:+UnlockDiagnosticVMOptions
+    -XX:+DebugNonSafepoints
+```
+
+Asyncprofiler and JFR can be both enabled at the same time.
 
 ## GC analysis
 
@@ -1575,6 +1605,70 @@ benchmark
 numbers of the tests can be distorted due to partition migrations during the test. Especially with a large number of
 partitions
 and short tests, this can lead to a very big impact on the benchmark numbers.
+
+### Reserving CPUs
+
+When running benchmarks in cloud environments, larger machines can provide better performance stability and more predictable network throughput
+but may have so many CPU that generating sufficient load for stress or throughput test becomes impractical.
+In such case you may consider crating a larger instance with better network, but only assign subset of cores to member Java process using `member_taskset` property.
+Note that this is not a complete equivalent of running on smaller VM with fewer CPUs. Some activity (operating system, IRQS, network) can use additional cores.
+Be also mindful of HyperThreading and decide if you want to use sibling cores more resembling smaller VM but with lower performance or not use sibling cores which should result in better performance under significant load.
+
+You can use the following command to determine which CPUs are HyperThreading siblings:
+```shell
+lscpu -e=CPU,CORE,SOCKET,NODE
+```
+
+Example result on 36 vCPU machine with HyperThreading:
+```
+CPU CORE SOCKET NODE
+  0    0      0    0
+  1    1      0    0
+  2    2      0    0
+  3    3      0    0
+  4    4      0    0
+  5    5      0    0
+  6    6      0    0
+  7    7      0    0
+  8    8      0    0
+  9    9      0    0
+ 10   10      0    0
+ 11   11      0    0
+ 12   12      0    0
+ 13   13      0    0
+ 14   14      0    0
+ 15   15      0    0
+ 16   16      0    0
+ 17   17      0    0
+ 18    0      0    0
+ 19    1      0    0
+ 20    2      0    0
+ 21    3      0    0
+ 22    4      0    0
+ 23    5      0    0
+ 24    6      0    0
+ 25    7      0    0
+ 26    8      0    0
+ 27    9      0    0
+ 28   10      0    0
+ 29   11      0    0
+ 30   12      0    0
+ 31   13      0    0
+ 32   14      0    0
+ 33   15      0    0
+ 34   16      0    0
+ 35   17      0    0
+```
+
+To get configuration resembling 4 CPUs with HT (8 vCPUs) you can use `member_taskset: 9-12,27-30`. If you want to avoid HyperThreading you can use `member_taskset: 0-7`.
+Even more advanced configuration can be achieved by customizing `worker.sh` script.
+
+Additional factor are network IRQs which can use significant CPU fraction under high load. The IRQs are assigned to CPUs by `irqbalance` service without taking into account `taskset` or application CPU load.
+To make the load more equal you can prevent `irqbalance` from using CPUs intended for the member by invoking 
+```shell
+inventory irq_cpus --banned-cpus <taskset>
+```
+for example: `inventory irq_cpus --banned-cpus 9-12,27-30`.
 
 ## Enabling Diagnostics
 

--- a/java/drivers/driver-hazelcast4plus/conf/worker.sh
+++ b/java/drivers/driver-hazelcast4plus/conf/worker.sh
@@ -199,8 +199,10 @@ JVM_ARGS="-Dlog4j2.configurationFile=log4j.xml"
 
 if [ "${WORKER_TYPE}" = "member" ]; then
     JVM_OPTIONS=$member_args
+    TASKSET="${member_taskset:-}"
 else
     JVM_OPTIONS=$client_args
+    TASKSET="${client_taskset:-}"
 fi
 
 # Include the member/client-worker jvm options
@@ -208,7 +210,32 @@ JVM_ARGS="$JVM_OPTIONS $JVM_ARGS"
 
 MAIN=com.hazelcast.simulator.worker.Worker
 
-java -classpath "$CLASSPATH" ${JVM_ARGS} ${MAIN}
+if [[ -n "${TASKSET}" ]]; then
+    WRAPPER="taskset -c ${TASKSET}"
+    # avoid network IRQs on cores for the app
+    if [[ -f /etc/default/irqbalance ]]; then
+        if ! grep -Fxq "IRQBALANCE_BANNED_CPULIST=${TASKSET}" /etc/default/irqbalance; then
+             echo "irqbalance config not found. Check if network interrupts can interfere with application CPUs or use \`inventory irq_cpus --banned-cpus ${TASKSET}\`"
+        fi
+    fi
+fi
+
+${WRAPPER:-} java -classpath "$CLASSPATH" ${JVM_ARGS} ${MAIN} &
+
+if [ "${WORKER_TYPE}" = "member" ] && [[ -n "${async_profiler_duration_seconds:-}" ]]; then
+    log "INFO" "Waiting before starting asyncprofiler for ${async_profiler_delay:-2m}"
+    # we sleep as long as the system hasn't warmed up.
+    # it depends on the test how much warmup is actually needed; if it takes e.g. 5m for the data to be inserted, you need
+    # a warmup of at least 6m.
+    sleep "${async_profiler_delay:-2m}"
+
+    log "INFO" "Starting asyncprofiler for ${async_profiler_duration_seconds}s"
+    asprof collect -d ${async_profiler_duration_seconds} --jfrsync ${JAVA_HOME}/lib/jfr/default.jfc -f profile.jfr Worker
+    log "INFO" "asyncprofiler done with exit_code $?"
+fi
+
+# wait for worker to finish
+wait
 
 #########################################################################
 # Yourkit

--- a/playbooks/irq.yaml
+++ b/playbooks/irq.yaml
@@ -1,0 +1,29 @@
+---
+- name: Configure irqbalance CPU exclusion
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Determine irqbalance configuration file
+      ansible.builtin.set_fact:
+        irqbalance_config: >-
+          {{
+            '/etc/sysconfig/irqbalance'
+            if ansible_os_family == 'RedHat'
+            else '/etc/default/irqbalance'
+          }}
+
+    - name: Configure IRQBALANCE_BANNED_CPULIST
+      ansible.builtin.lineinfile:
+        path: "{{ irqbalance_config }}"
+        regexp: '^#?\s*IRQBALANCE_BANNED_CPULIST='
+        line: 'IRQBALANCE_BANNED_CPULIST="{{ banned_cpus }}"'
+        create: true
+        mode: '0644'
+      notify: Restart irqbalance
+
+  handlers:
+    - name: Restart irqbalance
+      ansible.builtin.systemd:
+        name: irqbalance
+        state: restarted

--- a/src/inventory_cli.py
+++ b/src/inventory_cli.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
+import argparse
 import os
 import sys
-import argparse
 from os import path
 
-from simulator.inventory_terraform import terraform_import, terraform_destroy, terraform_apply
 from simulator.inventory_lab import lab_apply, lab_destroy
-from simulator.util import load_yaml_file, exit_with_error, simulator_home, shell, now_seconds
+from simulator.inventory_terraform import terraform_import, terraform_destroy, terraform_apply
 from simulator.log import info, log_header
 from simulator.ssh import new_key
+from simulator.util import load_yaml_file, exit_with_error, simulator_home, shell, now_seconds
 
 inventory_plan_path = 'inventory_plan.yaml'
 
@@ -182,7 +182,7 @@ class InventoryInstallCli:
                                          description='Install Async Profiler')
         parser.add_argument("--url",
                             help="The url to the async profiler binary",
-                            default="https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz")
+                            default="https://github.com/async-profiler/async-profiler/releases/download/v4.5/async-profiler-4.5-linux-x64.tar.gz")
         parser.add_argument("--hosts",
                             help="The target hosts.",
                             default="all:!mc")
@@ -510,6 +510,32 @@ class InventoryClearLatenciesCli:
 
         log_header("Clearing Latencies: Done")
 
+class InventoryIrqBannedCpus:
+
+    def __init__(self, argv):
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            description='Configures CPUs for IRQs on member nodes'
+        )
+        parser.add_argument("--banned-cpus", help="List of banned cpus in the same format as for taskset command", required=True)
+
+        args = parser.parse_args(argv)
+
+        self.banned_cpus = args.banned_cpus
+
+        cmd = f"ansible-playbook --inventory inventory.yaml -l nodes {simulator_home}/playbooks/irq.yaml"
+
+        # Add variables to the command
+        cmd += f" -e banned_cpus='{self.banned_cpus}'"
+
+        # Execute the command
+        info(f"Running command: {cmd}")
+        exitcode = shell(cmd)
+        if exitcode != 0:
+            exit_with_error(f"Failed to configure CPUs for IRQs, exitcode={exitcode}, command=[{cmd}])")
+
+        log_header("Configuring CPUs for IRQs: Done")
+
 class InventoryCli:
 
     def __init__(self):
@@ -556,6 +582,8 @@ class InventoryCli:
     def clear_latencies(self, argv):
         InventoryClearLatenciesCli(argv)
 
+    def irq_cpus(self, argv):
+        InventoryIrqBannedCpus(argv)
 
 if __name__ == '__main__':
     InventoryCli()

--- a/src/simulator/perftest_report.py
+++ b/src/simulator/perftest_report.py
@@ -6,12 +6,12 @@ import csv
 import glob
 import shutil
 
+from simulator.perftest_report_common import *
 from simulator.perftest_report_dstat import report_dstat, analyze_dstat
 from simulator.perftest_report_hdr import report_hdr, prepare_hdr, analyze_latency_history
+from simulator.perftest_report_html import HTMLReport
 from simulator.perftest_report_operations import report_operations, prepare_operation, analyze_operations
 from simulator.util import mkdir, exit_with_error
-from simulator.perftest_report_common import *
-from simulator.perftest_report_html import HTMLReport
 
 
 def prepare(config: ReportConfig):
@@ -220,6 +220,9 @@ class PerfTestReportCli:
         parser.add_argument('-ll', '--longLabel',
                             help='Include benchmark name in run label',
                             action='store_true')
+        parser.add_argument('-cl', '--combinedLatency',
+                            help='Produce plot with all latency distributions',
+                            action='store_true')
         parser.add_argument('--width',
                             nargs=1,
                             default=[1600],
@@ -247,6 +250,7 @@ class PerfTestReportCli:
         config.worker_reporting = args.full
         config.compare_last = args.last
         config.long_label = args.longLabel
+        config.combined_latency_plot = args.combinedLatency
         config.preserve_time = args.time
         config.y_start_from_zero = args.zero
         config.svg = args.svg

--- a/src/simulator/perftest_report_common.py
+++ b/src/simulator/perftest_report_common.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
-from datetime import datetime, timezone
-
 import numpy as np
+import os
 import pandas as pd
+from datetime import datetime, timezone
 
 from simulator.log import info
 
@@ -38,6 +37,7 @@ class ReportConfig:
     worker_reporting = True
     compare_last = False
     long_label = False
+    combined_latency_plot = False
     preserve_time = False
     y_start_from_zero = False
     svg = False

--- a/src/simulator/perftest_report_hdr.py
+++ b/src/simulator/perftest_report_hdr.py
@@ -334,6 +334,8 @@ def __report_hgrm(config: ReportConfig):
     __make_hgrm_latency_by_perc_dist_html(config, hgrm_files)
     # make_hgrm_histogram_plot(items)
     __make_latency_by_perc_dist_plot(config, hgrm_files)
+    if len(hgrm_files) > 1 and config.combined_latency_plot:
+        __make_latency_by_perc_dist_plot(config, sorted(hgrm_files), True)
 
 
 def __find_hgrm_files(config: ReportConfig, run_label):
@@ -358,11 +360,14 @@ def __find_hgrm_files(config: ReportConfig, run_label):
     return result
 
 
-def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
+def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files, combined = False):
+    first = True
     for hgrm_file_name in hgrm_files:
-        plt.figure(figsize=(config.image_width_px / config.image_dpi,
-                            config.image_height_px / config.image_dpi),
-                   dpi=config.image_dpi)
+        if not combined or first:
+            plt.figure(figsize=(config.image_width_px / config.image_dpi,
+                                config.image_height_px / config.image_dpi),
+                       dpi=config.image_dpi)
+        first = False
 
         for run_label, run_path in config.runs.items():
             dir = f"{config.report_dir}/hdr/{run_label}"
@@ -372,7 +377,8 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
                 continue
 
             df = __load_hgrm(hgrm_file)
-            plt.plot(df['1/(1-Percentile)'], df['Value'], label=run_label)
+            prefix = (Path(hgrm_file_name).stem.replace('_', ' ') + " " if combined else "")
+            plt.plot(df['1/(1-Percentile)'], df['Value'], label=prefix + run_label)
 
         plt.xscale('log')
 
@@ -391,10 +397,14 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
 
         plt.ylabel("Latency")
         plt.xlabel("Percentile")
-        plt.legend()
         plt.title(f"Latency distribution")
-        plt.grid()
         plt.gca().yaxis.set_major_formatter(FuncFormatter(format_us_time_ticks))
+
+        if combined and not first:
+            continue
+
+        plt.grid()
+        plt.legend()
 
         hgrm_file_path_no_ext = hgrm_file_name.rstrip(".hgrm")
         path = f"{config.report_dir}/latency/latency_distribution_{hgrm_file_path_no_ext}.png"
@@ -412,6 +422,21 @@ def __make_latency_by_perc_dist_plot(config: ReportConfig, hgrm_files):
         #     info(f"\tGenerating [{path}]")
         #     plotly_fig = tls.mpl_to_plotly(plt.gcf())
         #     plotly_fig.write_html(path)
+
+        plt.close()
+
+    if combined:
+        plt.grid()
+        plt.legend()
+        path = f"{config.report_dir}/latency/latency_distribution_combined.png"
+        mkdir(os.path.dirname(path))
+        info(f"\tGenerating [{path}]")
+        plt.savefig(path)
+
+        if config.svg:
+            path = f"{config.report_dir}/latency/latency_distribution_combined.svg"
+            info(f"\tGenerating [{path}]")
+            plt.savefig(path)
 
         plt.close()
 


### PR DESCRIPTION
Adds ability to configure `taskset` for Hazelcast processes
Adds ability to configure `irqbalance` blocklist (in particular to match `taskset` for Hazelcast processes)
Adds convenient invocation of `asyncprofiler` for benchmarks and updates asyncprofiler to current stable version (4.5)